### PR TITLE
Improve error messaging for API errors

### DIFF
--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -72,10 +72,13 @@ class LookerClient:
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as error:
+            details = utils.details_from_http_error(response)
             raise ApiConnectionError(
                 f"Failed to authenticate to {url}\n"
-                f'Attempted authentication with client ID "{client_id}"\n'
-                f'Error raised: "{error}"'
+                f"Attempted authentication with client ID {client_id}\n"
+                f"Looker API error encountered: {error}\n"
+                + "Message received from Looker's API: "
+                f'"{details}"'
             )
 
         access_token = response.json()["access_token"]
@@ -98,9 +101,12 @@ class LookerClient:
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as error:
+            details = utils.details_from_http_error(response)
             raise ApiConnectionError(
                 f"Unable to update session to development workspace.\n"
-                f'Error raised: "{error}"'
+                f"Looker API error encountered: {error}\n"
+                + "Message received from Looker's API: "
+                f'"{details}"'
             )
 
         logger.debug(f"Setting Git branch to {branch}")
@@ -110,8 +116,14 @@ class LookerClient:
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as error:
+            details = utils.details_from_http_error(response)
             raise ApiConnectionError(
-                f'Unable to set git branch to {branch}.\nError raised: "{error}"'
+                f"Unable to checkout Git branch {branch}. "
+                "If you have uncommitted changes on the current branch, "
+                "please commit or revert them, then try again.\n\n"
+                f"Looker API error encountered: {error}\n"
+                + "Message received from Looker's API: "
+                f'"{details}"'
             )
 
         logger.info(f"Checked out branch {branch}")
@@ -129,8 +141,12 @@ class LookerClient:
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as error:
+            details = utils.details_from_http_error(response)
             raise ApiConnectionError(
-                f'Unable to retrieve explores.\nError raised: "{error}"'
+                f"Unable to retrieve explores.\n"
+                f"Looker API error encountered: {error}\n"
+                + "Message received from Looker's API: "
+                f'"{details}"'
             )
 
         return response.json()
@@ -155,9 +171,12 @@ class LookerClient:
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as error:
+            details = utils.details_from_http_error(response)
             raise ApiConnectionError(
                 f'Unable to get dimensions for explore "{explore}".\n'
-                f'Error raised: "{error}"'
+                f"Looker API error encountered: {error}\n"
+                + "Message received from Looker's API: "
+                f'"{details}"'
             )
 
         return response.json()["fields"]["dimensions"]
@@ -267,5 +286,10 @@ class LookerClient:
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as error:
-            raise ApiConnectionError(error)
+            details = utils.details_from_http_error(response)
+            raise ApiConnectionError(
+                f"Looker API error encountered: {error}\n"
+                + "Message received from Looker's API: "
+                f'"{details}"'
+            )
         return response.json()

--- a/spectacles/utils.py
+++ b/spectacles/utils.py
@@ -1,4 +1,5 @@
 from typing import List
+import requests
 
 
 def compose_url(base_url: str, path: List) -> str:
@@ -7,3 +8,15 @@ def compose_url(base_url: str, path: List) -> str:
     parts = [base_url] + path
     url = "/".join(str(part).strip("/") for part in parts)
     return url
+
+
+def details_from_http_error(response: requests.Response) -> str:
+    try:
+        response_json = response.json()
+    # Requests raises a ValueError if the response is invalid JSON
+    except ValueError:
+        details = ""
+    else:
+        details = response_json.get("message")
+    details = details.strip() if details else ""
+    return details


### PR DESCRIPTION
Include the `message` key from the response JSON, if found, in `APIConnectionError` messaging. Add a utility to pull that string out of the response object. Also add suggestion for branch checkout errors to ensure there are no uncommitted changes.