### PR TITLE
Add data testing validator

### DIFF
--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -156,7 +156,7 @@ def main():
             handler.setLevel(args.log_level)
 
     if args.command == "connect":
-        connect(
+        run_connect(
             args.base_url,
             args.client_id,
             args.client_secret,
@@ -164,7 +164,7 @@ def main():
             args.api_version,
         )
     elif args.command == "sql":
-        sql(
+        run_sql(
             args.project,
             args.branch,
             args.explores,
@@ -174,6 +174,16 @@ def main():
             args.port,
             args.api_version,
             args.batch,
+        )
+    elif args.command == "assert":
+        run_assert(
+            args.project,
+            args.branch,
+            args.base_url,
+            args.client_id,
+            args.client_secret,
+            args.port,
+            args.api_version,
         )
 
 
@@ -191,6 +201,7 @@ def create_parser() -> argparse.ArgumentParser:
     base_subparser = _build_base_subparser()
     _build_connect_subparser(subparser_action, base_subparser)
     _build_sql_subparser(subparser_action, base_subparser)
+    _build_assert_subparser(subparser_action, base_subparser)
     return parser
 
 
@@ -288,7 +299,33 @@ def _build_sql_subparser(
     subparser.add_argument("--batch", action="store_true")
 
 
-def connect(
+def _build_assert_subparser(
+    subparser_action: argparse._SubParsersAction,
+    base_subparser: argparse.ArgumentParser,
+) -> None:
+    """Returns the subparser for the subcommand `assert`.
+
+    Args:
+        subparser_action: Description of parameter `subparser_action`.
+        base_subparser: Description of parameter `base_subparser`.
+
+    Returns:
+        type: Description of returned object.
+
+    """
+    subparser = subparser_action.add_parser(
+        "assert", parents=[base_subparser], help="Run Looker data tests."
+    )
+
+    subparser.add_argument(
+        "--project", action=EnvVarAction, env_var="LOOKER_PROJECT", required=True
+    )
+    subparser.add_argument(
+        "--branch", action=EnvVarAction, env_var="LOOKER_GIT_BRANCH", required=True
+    )
+
+
+def run_connect(
     base_url: str, client_id: str, client_secret: str, port: int, api_version: float
 ) -> None:
     """Tests the connection and credentials for the Looker API.
@@ -304,7 +341,23 @@ def connect(
     LookerClient(base_url, client_id, client_secret, port, api_version)
 
 
-def sql(
+def run_assert(
+    project, branch, base_url, client_id, client_secret, port, api_version
+) -> None:
+    runner = Runner(
+        base_url, project, branch, client_id, client_secret, port, api_version
+    )
+    errors = runner.validate_data_tests()
+    if errors:
+        for error in sorted(errors, key=lambda x: x["path"]):
+            printer.print_data_test_error(error)
+        logger.info("")
+        raise ValidationError
+    else:
+        logger.info("")
+
+
+def run_sql(
     project,
     branch,
     explores,

--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -34,7 +34,7 @@ class LookerClient:
         port: int = 19999,
         api_version: float = 3.1,
     ):
-        supported_api_versions = [3.0, 3.1]
+        supported_api_versions = [3.1]
         if api_version not in supported_api_versions:
             raise SpectaclesException(
                 f"API version {api_version} is not supported. "

--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -123,6 +123,23 @@ class LookerClient:
 
         logger.info(f"Checked out branch {branch}")
 
+    def all_lookml_tests(self, project: str):
+        logger.debug(f"Getting LookML tests for project {project}")
+        url = utils.compose_url(
+            self.api_url, path=["projects", project, "lookml_tests"]
+        )
+        response = self.session.get(url=url)
+
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as error:
+            raise ApiConnectionError(
+                f"Failed to retrieve data tests for project {project}\n"
+                f'Error raised: "{error}"'
+            )
+
+        return response.json()
+
     def run_lookml_test(self, project: str, model: str = None) -> List[JsonDict]:
         """Runs all LookML/data tests for a given project and model (optional)
 

--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -123,7 +123,16 @@ class LookerClient:
 
         logger.info(f"Checked out branch {branch}")
 
-    def all_lookml_tests(self, project: str):
+    def all_lookml_tests(self, project: str) -> List[JsonDict]:
+        """Gets all LookML/data tests for a given project.
+
+        Args:
+            project: Name of the Looker project to use
+
+        Returns:
+            List[JsonDict]: JSON response containing all LookML/data tests
+
+        """
         logger.debug(f"Getting LookML tests for project {project}")
         url = utils.compose_url(
             self.api_url, path=["projects", project, "lookml_tests"]

--- a/spectacles/exceptions.py
+++ b/spectacles/exceptions.py
@@ -28,3 +28,13 @@ class SqlError(ValidationError):
 
     def __repr__(self):
         return self.message
+
+
+class DataTestError(ValidationError):
+    def __init__(self, path: str, message: str):
+        super().__init__(message)
+        self.path = path
+        self.message = message
+
+    def __repr__(self):
+        return self.message

--- a/spectacles/printer.py
+++ b/spectacles/printer.py
@@ -36,6 +36,12 @@ def print_header(text: str, line_width: int = LINE_WIDTH) -> None:
     logger.info(f"\n{header}\n")
 
 
+def print_data_test_error(error: dict) -> None:
+    print_header(red(error["path"]), LINE_WIDTH + COLOR_CODE_LENGTH)
+    wrapped = textwrap.fill(error["message"], LINE_WIDTH)
+    logger.info(wrapped)
+
+
 def print_sql_error(error: dict) -> None:
     print_header(red(error["path"]), LINE_WIDTH + COLOR_CODE_LENGTH)
     wrapped = textwrap.fill(error["message"], LINE_WIDTH)

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -1,6 +1,6 @@
 from typing import List
 from spectacles.client import LookerClient
-from spectacles.validators import SqlValidator
+from spectacles.validators import SqlValidator, DataTestValidator
 
 
 class Runner:
@@ -40,4 +40,9 @@ class Runner:
         sql_validator = SqlValidator(self.client, self.project)
         sql_validator.build_project(selectors)
         errors = sql_validator.validate(batch)
+        return [vars(error) for error in errors]
+
+    def validate_data_tests(self):
+        data_test_validator = DataTestValidator(self.client, self.project)
+        errors = data_test_validator.validate()
         return [vars(error) for error in errors]

--- a/spectacles/validators.py
+++ b/spectacles/validators.py
@@ -35,6 +35,11 @@ class DataTestValidator(Validator):
         self.project = project
 
     def validate(self) -> List[DataTestError]:
+        tests = self.client.all_lookml_tests(self.project)
+        test_count = len(tests)
+        printer.print_header(
+            f"Running {test_count} {'test' if test_count == 1 else 'tests'}"
+        )
         errors = []
         test_results = self.client.run_lookml_test(self.project)
         for result in test_results:
@@ -184,7 +189,7 @@ class SqlValidator(Validator):
         """
         explore_count = self._count_explores()
         printer.print_header(
-            f"Begin testing {explore_count} "
+            f"Testing {explore_count} "
             f"{'explore' if explore_count == 1 else 'explores'} "
             f"[{'batch' if batch else 'single-dimension'} mode]"
         )

--- a/spectacles/validators.py
+++ b/spectacles/validators.py
@@ -30,6 +30,14 @@ class Validator(ABC):  # pragma: no cover
 
 
 class DataTestValidator(Validator):
+    """Runs LookML/data tests for a given project.
+
+    Args:
+        client: Looker API client.
+        project: Name of the LookML project to validate.
+
+    """
+
     def __init__(self, client: LookerClient, project: str):
         super().__init__(client)
         self.project = project
@@ -62,8 +70,8 @@ class SqlValidator(Validator):
         project: Name of the LookML project to validate.
 
     Attributes:
-        timeout: aiohttp object to limit duration of running requests.
         project: LookML project object representation.
+        query_tasks: Mapping of query task IDs to LookML objects
 
     """
 


### PR DESCRIPTION
Adds a new validator with command `spectacles assert` to support running LookML/data tests via the API.

The following outstanding items need to be completed before this is ready for review:
- [ ] Looker pushes a fix to include more metadata (explore, line number, etc.)
- [ ] Looker pushes a fix to include the name of the assertion in the API response
- [ ] Flesh out error message with above metadata
- [ ] Provide pass/fail at the explore level for all explores affected by data tests
- [ ] Write unit tests

Closes #62.