### PR TITLE
Adding help messages

### DIFF
--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -202,21 +202,39 @@ def _build_base_subparser() -> argparse.ArgumentParser:
 
     """
     base_subparser = argparse.ArgumentParser(add_help=False)
-    base_subparser.add_argument("--config-file", action=YamlConfigAction)
     base_subparser.add_argument(
-        "--base-url", action=EnvVarAction, env_var="LOOKER_BASE_URL", required=True
+        "--config-file",
+        action=YamlConfigAction,
+        help="The path to an optional YAML config file.",
     )
     base_subparser.add_argument(
-        "--client-id", action=EnvVarAction, env_var="LOOKER_CLIENT_ID", required=True
+        "--base-url",
+        action=EnvVarAction,
+        env_var="LOOKER_BASE_URL",
+        required=True,
+        help="The URL of your Looker instance, e.g. https://company-name.looker.com",
+    )
+    base_subparser.add_argument(
+        "--client-id",
+        action=EnvVarAction,
+        env_var="LOOKER_CLIENT_ID",
+        required=True,
+        help="The client ID of the Looker user that spectacles will authenticate as.",
     )
     base_subparser.add_argument(
         "--client-secret",
         action=EnvVarAction,
         env_var="LOOKER_CLIENT_SECRET",
         required=True,
+        help="The client secret of the Looker user that spectacles will authenticate as.",
     )
     base_subparser.add_argument(
-        "--port", type=int, action=EnvVarAction, env_var="LOOKER_PORT", default=19999
+        "--port",
+        type=int,
+        action=EnvVarAction,
+        env_var="LOOKER_PORT",
+        default=19999,
+        help="The port of your Looker instance’s API. The default is port 19999.",
     )
     base_subparser.add_argument(
         "--api-version",
@@ -224,6 +242,7 @@ def _build_base_subparser() -> argparse.ArgumentParser:
         action=EnvVarAction,
         env_var="LOOKER_API_VERSION",
         default=3.1,
+        help="The version of the Looker API to use. The default is version 3.1.",
     )
     base_subparser.add_argument(
         "-v",
@@ -232,6 +251,7 @@ def _build_base_subparser() -> argparse.ArgumentParser:
         dest="log_level",
         const=logging.DEBUG,
         default=logging.INFO,
+        help="Display debug logging during spectacles execution. Useful for debugging and making bug reports.",
     )
 
     return base_subparser
@@ -279,12 +299,25 @@ def _build_sql_subparser(
     )
 
     subparser.add_argument(
-        "--project", action=EnvVarAction, env_var="LOOKER_PROJECT", required=True
+        "--project",
+        action=EnvVarAction,
+        env_var="LOOKER_PROJECT",
+        required=True,
+        help="The LookML project you want to test.",
     )
     subparser.add_argument(
-        "--branch", action=EnvVarAction, env_var="LOOKER_GIT_BRANCH", required=True
+        "--branch",
+        action=EnvVarAction,
+        env_var="LOOKER_GIT_BRANCH",
+        required=True,
+        help="The branch of your project that spectacles will use to run queries.",
     )
-    subparser.add_argument("--explores", nargs="+", default=["*.*"])
+    subparser.add_argument(
+        "--explores",
+        nargs="+",
+        default=["*.*"],
+        help="Specify the explores spectacles should test.",
+    )
     subparser.add_argument("--batch", action="store_true")
 
 

--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -328,7 +328,6 @@ def _build_sql_subparser(
     )
 
 
-
 def connect(
     base_url: str, client_id: str, client_secret: str, port: int, api_version: float
 ) -> None:

--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -318,7 +318,10 @@ def _build_sql_subparser(
         "--explores",
         nargs="+",
         default=["*.*"],
-        help="Specify the explores spectacles should test.",
+        help="Specify the explores spectacles should test. \
+            List of selector strings in 'model_name.explore_name' format. \
+            The '*' wildcard selects all models or explores. For instance,\
+            'model_name.*' would select all explores in the 'model_name' model.",
     )
     subparser.add_argument("--batch", action="store_true")
 

--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -226,7 +226,8 @@ def _build_base_subparser() -> argparse.ArgumentParser:
         action=EnvVarAction,
         env_var="LOOKER_CLIENT_SECRET",
         required=True,
-        help="The client secret of the Looker user that spectacles will authenticate as.",
+        help="The client secret of the Looker user that spectacles \
+            will authenticate as.",
     )
     base_subparser.add_argument(
         "--port",
@@ -251,7 +252,8 @@ def _build_base_subparser() -> argparse.ArgumentParser:
         dest="log_level",
         const=logging.DEBUG,
         default=logging.INFO,
-        help="Display debug logging during spectacles execution. Useful for debugging and making bug reports.",
+        help="Display debug logging during spectacles execution. \
+            Useful for debugging and making bug reports.",
     )
 
     return base_subparser

--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -324,7 +324,14 @@ def _build_sql_subparser(
             'model_name.*' would select all explores in the 'model_name' model.",
     )
     subparser.add_argument(
-        "--mode", choices=["batch", "single", "hybrid"], default="batch"
+        "--mode",
+        choices=["batch", "single", "hybrid"],
+        default="batch",
+        help="Specify the mode the SQL validator should run.\
+        	In single-dimension mode, the SQL validator will run one query \
+        	per dimension. In batch mode, the SQL validator will create one \
+        	query per explore. In hybrid mode, the SQL validator will run in \
+        	batch mode and then run errored explores in single-dimension mode.",
     )
 
 

--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -328,10 +328,10 @@ def _build_sql_subparser(
         choices=["batch", "single", "hybrid"],
         default="batch",
         help="Specify the mode the SQL validator should run.\
-        	In single-dimension mode, the SQL validator will run one query \
-        	per dimension. In batch mode, the SQL validator will create one \
-        	query per explore. In hybrid mode, the SQL validator will run in \
-        	batch mode and then run errored explores in single-dimension mode.",
+            In single-dimension mode, the SQL validator will run one query \
+            per dimension. In batch mode, the SQL validator will create one \
+            query per explore. In hybrid mode, the SQL validator will run in \
+            batch mode and then run errored explores in single-dimension mode.",
     )
 
 


### PR DESCRIPTION
Closes #59.

This PR adds help messages for both the `sql` and `connect` commands. 

The output looks as follows:

```shell
dylan@Dylans-MacBook-Pro:spectacles-ci/spectacles ‹feature/help-messages*›$ spectacles sql -h
usage: spectacles sql [-h] [--config-file CONFIG_FILE] --base-url BASE_URL
                      --client-id CLIENT_ID --client-secret CLIENT_SECRET
                      [--port PORT] [--api-version API_VERSION] [-v] --project
                      PROJECT --branch BRANCH
                      [--explores EXPLORES [EXPLORES ...]] [--batch]

optional arguments:
  -h, --help            show this help message and exit
  --config-file CONFIG_FILE
                        The path to an optional YAML config file.
  --base-url BASE_URL   The URL of your Looker instance, e.g. https://company-
                        name.looker.com
  --client-id CLIENT_ID
                        The client ID of the Looker user that spectacles will
                        authenticate as.
  --client-secret CLIENT_SECRET
                        The client secret of the Looker user that spectacles
                        will authenticate as.
  --port PORT           The port of your Looker instance’s API. The default is
                        port 19999.
  --api-version API_VERSION
                        The version of the Looker API to use. The default is
                        version 3.1.
  -v, --verbose         Display debug logging during spectacles execution.
                        Useful for debugging and making bug reports.
  --project PROJECT     The LookML project you want to test.
  --branch BRANCH       The branch of your project that spectacles will use to
                        run queries.
  --explores EXPLORES [EXPLORES ...]
                        Specify the explores spectacles should test.
  --batch
```
```
dylan@Dylans-MacBook-Pro:spectacles-ci/spectacles ‹feature/help-messages*›$ spectacles connect -h
usage: spectacles connect [-h] [--config-file CONFIG_FILE] --base-url BASE_URL
                          --client-id CLIENT_ID --client-secret CLIENT_SECRET
                          [--port PORT] [--api-version API_VERSION] [-v]

optional arguments:
  -h, --help            show this help message and exit
  --config-file CONFIG_FILE
                        The path to an optional YAML config file.
  --base-url BASE_URL   The URL of your Looker instance, e.g. https://company-
                        name.looker.com
  --client-id CLIENT_ID
                        The client ID of the Looker user that spectacles will
                        authenticate as.
  --client-secret CLIENT_SECRET
                        The client secret of the Looker user that spectacles
                        will authenticate as.
  --port PORT           The port of your Looker instance’s API. The default is
                        port 19999.
  --api-version API_VERSION
                        The version of the Looker API to use. The default is
                        version 3.1.
  -v, --verbose         Display debug logging during spectacles execution.
                        Useful for debugging and making bug reports.
```