### PR TITLE
Add remote reset flag

### DIFF
--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -174,6 +174,7 @@ def main():
             args.port,
             args.api_version,
             args.mode,
+            args.remote_reset,
         )
 
 
@@ -333,6 +334,13 @@ def _build_sql_subparser(
             query per explore. In hybrid mode, the SQL validator will run in \
             batch mode and then run errored explores in single-dimension mode.",
     )
+    subparser.add_argument(
+        "--remote-reset",
+        action="store_true",
+        help="When set to true, the SQL validator will tell Looker to reset the \
+            user's branch to the revision of the branch that is on the remote. \
+            This will delete any uncommited changes in the user's workspace.",
+    )
 
 
 def connect(
@@ -352,10 +360,18 @@ def sql(
     port,
     api_version,
     mode,
+    remote_reset,
 ) -> None:
     """Runs and validates the SQL for each selected LookML dimension."""
     runner = Runner(
-        base_url, project, branch, client_id, client_secret, port, api_version
+        base_url,
+        project,
+        branch,
+        client_id,
+        client_secret,
+        port,
+        api_version,
+        remote_reset,
     )
     errors = runner.validate_sql(explores, mode)
     if errors:

--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -339,7 +339,7 @@ def _build_sql_subparser(
         action="store_true",
         help="When set to true, the SQL validator will tell Looker to reset the \
             user's branch to the revision of the branch that is on the remote. \
-            This will delete any uncommited changes in the user's workspace.",
+            WARNING: This will delete any uncommited changes in the user's workspace.",
     )
 
 

--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -139,7 +139,9 @@ class LookerClient:
         # Loop exits successfully if current version == required version
         return True
 
-    def update_session(self, project: str, branch: str) -> None:
+    def update_session(
+        self, project: str, branch: str, remote_reset: bool = False
+    ) -> None:
         """Switches to a development mode session and checks out the desired branch.
 
         Args:
@@ -197,6 +199,23 @@ class LookerClient:
                     + "Message received from Looker's API: "
                     f'"{details}"'
                 )
+
+            if remote_reset:
+                logger.debug(f"Resetting branch {branch} to remote.")
+                url = utils.compose_url(
+                    self.api_url, path=["projects", project, "reset_to_remote"]
+                )
+                response = self.session.post(url=url)
+                try:
+                    response.raise_for_status()
+                except requests.exceptions.HTTPError as error:
+                    details = utils.details_from_http_error(response)
+                    raise ApiConnectionError(
+                        f"Unable to reset branch to remote.\n"
+                        f"Looker API error encountered: {error}\n"
+                        + "Message received from Looker's API: "
+                        f'"{details}"'
+                    )
 
             logger.info(f"Checked out branch {branch}")
 

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -29,12 +29,13 @@ class Runner:
         client_secret: str,
         port: int = 19999,
         api_version: float = 3.1,
+        remote_reset: bool = False,
     ):
         self.project = project
         self.client = LookerClient(
             base_url, client_id, client_secret, port, api_version
         )
-        self.client.update_session(project, branch)
+        self.client.update_session(project, branch, remote_reset)
 
     def validate_sql(self, selectors: List[str], mode: str = "batch") -> List[dict]:
         sql_validator = SqlValidator(self.client, self.project)


### PR DESCRIPTION
Closes #89 

@joshtemple Wanted to test out one implementation of this. As discussed, happy to go another route if preferred.

Adds a flag `--remote-reset` to the SQL validator which tells spectacles to reset the branch to the remote version after checking it out. 