### PR TITLE
Handle expired queries as errors

### DIFF
--- a/spectacles/validators.py
+++ b/spectacles/validators.py
@@ -319,10 +319,10 @@ class SqlValidator(Validator):
             query_status = query_result["status"]
             logger.debug("Query task %s status is %s", query_task_id, query_status)
 
-            if query_status in ("running", "added", "expired"):
+            if query_status in ("running", "added"):
                 still_running.append(query_task_id)
                 continue
-            elif query_status in ("complete", "error"):
+            elif query_status in ("complete", "error", "expired"):
                 lookml_object = self.query_tasks[query_task_id]
                 lookml_object.queried = True
             else:
@@ -344,6 +344,16 @@ class SqlValidator(Validator):
                     path=lookml_object.name,
                     url=getattr(lookml_object, "url", None),
                     **details,
+                )
+                lookml_object.error = sql_error
+                errors.append(sql_error)
+            elif query_status == "expired":
+                sql_error = SqlError(
+                    path=lookml_object.name,
+                    url=getattr(lookml_object, "url", None),
+                    message="Query expired",
+                    sql="",
+                    line_number=None,
                 )
                 lookml_object.error = sql_error
                 errors.append(sql_error)


### PR DESCRIPTION
On our Looker instance we had an issue with an explore
which took a long time to generate (over an hour actually),
and I had to kill the query. Killing the query makes the
query status 'expired', so this commit marks expired as
errors.