### PR TITLE
Fix Flake8 error

### DIFF
--- a/spectacles/validators.py
+++ b/spectacles/validators.py
@@ -248,7 +248,8 @@ class SqlValidator(Validator):
                         logger.debug("Querying one dimension at at time")
                         for dimension in explore.dimensions:
                             task = loop.create_task(
-                                self._query_dimension(session, model, explore, dimension)
+                                self._query_dimension(
+                                    session, model, explore, dimension)
                             )
                             tasks.append(task)
 


### PR DESCRIPTION
Your circle builds are failing since 5cc653c189bee67dcf260c432a73b282be2de2ef

```
spectacles/validators.py:251:89: E501 line too long (89 > 88 characters)
```

This fixes it

https://circleci.com/gh/spectacles-ci/spectacles/301