### PR TITLE
Support max_concurrency for running Looker queries

### DIFF
--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -175,6 +175,7 @@ def main():
             args.api_version,
             args.mode,
             args.remote_reset,
+            args.max_concurrency,
         )
     elif args.command == "assert":
         run_assert(
@@ -352,6 +353,14 @@ def _build_sql_subparser(
             user's branch to the revision of the branch that is on the remote. \
             WARNING: This will delete any uncommited changes in the user's workspace.",
     )
+    subparser.add_argument(
+        "--max-concurrency",
+        default=0,
+        type=int,
+        help="Specify how many concurrent queries you want to have running \
+            against Looker. If not specified or 0, it will execute as many \
+            queries as you have explores/dimensions.",
+    )
 
 
 def _build_assert_subparser(
@@ -414,6 +423,7 @@ def run_sql(
     api_version,
     mode,
     remote_reset,
+    max_concurrency,
 ) -> None:
     """Runs and validates the SQL for each selected LookML dimension."""
     runner = Runner(
@@ -426,7 +436,7 @@ def run_sql(
         api_version,
         remote_reset,
     )
-    errors = runner.validate_sql(explores, mode)
+    errors = runner.validate_sql(explores, mode, max_concurrency)
     if errors:
         for error in sorted(errors, key=lambda x: x["path"]):
             printer.print_sql_error(error)

--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -175,7 +175,7 @@ def main():
             args.api_version,
             args.mode,
             args.remote_reset,
-            args.max_concurrency,
+            args.query_slots,
         )
     elif args.command == "assert":
         run_assert(
@@ -354,12 +354,11 @@ def _build_sql_subparser(
             WARNING: This will delete any uncommited changes in the user's workspace.",
     )
     subparser.add_argument(
-        "--max-concurrency",
-        default=0,
+        "--query-slots",
+        default=10,
         type=int,
         help="Specify how many concurrent queries you want to have running \
-            against Looker. If not specified or 0, it will execute as many \
-            queries as you have explores/dimensions.",
+            against your data warehouse. The default is 10.",
     )
 
 
@@ -423,7 +422,7 @@ def run_sql(
     api_version,
     mode,
     remote_reset,
-    max_concurrency,
+    query_slots,
 ) -> None:
     """Runs and validates the SQL for each selected LookML dimension."""
     runner = Runner(
@@ -436,7 +435,7 @@ def run_sql(
         api_version,
         remote_reset,
     )
-    errors = runner.validate_sql(explores, mode, max_concurrency)
+    errors = runner.validate_sql(explores, mode, query_slots)
     if errors:
         for error in sorted(errors, key=lambda x: x["path"]):
             printer.print_sql_error(error)

--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -175,7 +175,7 @@ def main():
             args.api_version,
             args.mode,
             args.remote_reset,
-            args.query_slots,
+            args.concurrency,
         )
     elif args.command == "assert":
         run_assert(
@@ -354,7 +354,7 @@ def _build_sql_subparser(
             WARNING: This will delete any uncommited changes in the user's workspace.",
     )
     subparser.add_argument(
-        "--query-slots",
+        "--concurrency",
         default=10,
         type=int,
         help="Specify how many concurrent queries you want to have running \
@@ -422,7 +422,7 @@ def run_sql(
     api_version,
     mode,
     remote_reset,
-    query_slots,
+    concurrency,
 ) -> None:
     """Runs and validates the SQL for each selected LookML dimension."""
     runner = Runner(
@@ -435,7 +435,7 @@ def run_sql(
         api_version,
         remote_reset,
     )
-    errors = runner.validate_sql(explores, mode, query_slots)
+    errors = runner.validate_sql(explores, mode, concurrency)
     if errors:
         for error in sorted(errors, key=lambda x: x["path"]):
             printer.print_sql_error(error)

--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -414,7 +414,9 @@ class LookerClient:
         logger.debug("Query %d is running under query task %s", query_id, query_task_id)
         return query_task_id
 
-    def get_query_task_multi_results(self, query_task_ids: List[str]) -> JsonDict:
+    async def get_query_task_multi_results(
+        self, session: aiohttp.ClientSession, query_task_ids: List[str]
+    ) -> JsonDict:
         """Returns query task results.
 
         If a ClientError or TimeoutError is received, attempts to retry.
@@ -431,16 +433,9 @@ class LookerClient:
             "Attempting to get results for %d query tasks", len(query_task_ids)
         )
         url = utils.compose_url(self.api_url, path=["query_tasks", "multi_results"])
-        response = self.session.get(
+        async with session.get(
             url=url, params={"query_task_ids": ",".join(query_task_ids)}
-        )
-        try:
+        ) as response:
+            result = await response.json()
             response.raise_for_status()
-        except requests.exceptions.HTTPError as error:
-            details = utils.details_from_http_error(response)
-            raise ApiConnectionError(
-                f"Looker API error encountered: {error}\n"
-                + "Message received from Looker's API: "
-                f'"{details}"'
-            )
-        return response.json()
+        return result

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -37,10 +37,12 @@ class Runner:
         )
         self.client.update_session(project, branch, remote_reset)
 
-    def validate_sql(self, selectors: List[str], mode: str = "batch") -> List[dict]:
+    def validate_sql(
+        self, selectors: List[str], mode: str = "batch", max_concurrent: int = 0
+    ) -> List[dict]:
         sql_validator = SqlValidator(self.client, self.project)
         sql_validator.build_project(selectors)
-        errors = sql_validator.validate(mode)
+        errors = sql_validator.validate(mode, max_concurrent)
         return [vars(error) for error in errors]
 
     def validate_data_tests(self):

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -38,11 +38,11 @@ class Runner:
         self.client.update_session(project, branch, remote_reset)
 
     def validate_sql(
-        self, selectors: List[str], mode: str = "batch", max_concurrent: int = 0
+        self, selectors: List[str], mode: str = "batch", query_slots: int = 10
     ) -> List[dict]:
-        sql_validator = SqlValidator(self.client, self.project)
+        sql_validator = SqlValidator(self.client, self.project, query_slots)
         sql_validator.build_project(selectors)
-        errors = sql_validator.validate(mode, max_concurrent)
+        errors = sql_validator.validate(mode)
         return [vars(error) for error in errors]
 
     def validate_data_tests(self):

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -40,9 +40,9 @@ class Runner:
 
     @log_duration
     def validate_sql(
-        self, selectors: List[str], mode: str = "batch", query_slots: int = 10
+        self, selectors: List[str], mode: str = "batch", concurrency: int = 10
     ) -> List[dict]:
-        sql_validator = SqlValidator(self.client, self.project, query_slots)
+        sql_validator = SqlValidator(self.client, self.project, concurrency)
         sql_validator.build_project(selectors)
         errors = sql_validator.validate(mode)
         return [vars(error) for error in errors]

--- a/spectacles/validators.py
+++ b/spectacles/validators.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Sequence, DefaultDict, Set, Tuple
+from typing import List, Sequence, DefaultDict
 import asyncio
 from abc import ABC, abstractmethod
 from collections import defaultdict

--- a/spectacles/validators.py
+++ b/spectacles/validators.py
@@ -80,12 +80,12 @@ class SqlValidator(Validator):
 
     timeout = aiohttp.ClientTimeout(total=300)
 
-    def __init__(self, client: LookerClient, project: str, query_slots: int = 10):
+    def __init__(self, client: LookerClient, project: str, concurrency: int = 10):
         super().__init__(client)
 
         self.project = Project(project, models=[])
         self.query_tasks: dict = {}
-        self.query_slots = asyncio.BoundedSemaphore(query_slots)
+        self.query_slots = asyncio.BoundedSemaphore(concurrency)
         self.running_query_tasks: asyncio.Queue = asyncio.Queue()
 
     @staticmethod

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 import pytest
-from tests.constants import ENV_VARS
+from constants import ENV_VARS
 from spectacles.cli import main, create_parser, handle_exceptions
 from spectacles.exceptions import SpectaclesException, ValidationError
 

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -6,7 +6,6 @@ import asynctest
 from spectacles.lookml import Project, Model, Explore, Dimension
 from spectacles.client import LookerClient
 from spectacles.validators import SqlValidator
-from spectacles.exceptions import SpectaclesException
 
 TEST_BASE_URL = "https://test.looker.com"
 TEST_CLIENT_ID = "test_client_id"


### PR DESCRIPTION
Situation was that once we ran Spectacles on our Looker instance
with 128 explores in our model, it killed the instance in a way that
it stopped responding and eventually crashed. I've diagnosed that it
was merely the number of running queries at a time that caused it.
It scheduled pretty much all 128 queries immediately.

So this adds a flag --max-concurrency which you can use to tweak
and set how much load you want to put on your Looker instance.

I've tried our staging server with 10 and it works nicely and doesn't
crash anything.

Of the things I did:
- made the validate SQL function async and moved the loop code in the parent function
- got rid of creating an asyncio loop as I don’t believe you need it (get_event_loop creates it if one does not exist)
- when you specify max_concurrency the code will only create <max_concurrency> queries as will not queue up more until the previous ones are finished