### PR TITLE
Handle more error variations

### DIFF
--- a/spectacles/validators.py
+++ b/spectacles/validators.py
@@ -277,12 +277,9 @@ class SqlValidator(Validator):
         if isinstance(data, dict):
             errors = data.get("errors") or [data.get("error")]
             first_error = errors[0]
-            message = first_error.get("message_details") or first_error["message"]
-            if not isinstance(message, str):
-                raise TypeError(
-                    "Unexpected message type. Expected a str, "
-                    f"received type {type(message)}: {message}"
-                )
+            message = " ".join(
+                [first_error.get("message", ""), first_error.get("message_details", "")]
+            ).strip()
             sql = data["sql"]
             error_loc = first_error.get("sql_error_loc")
             if error_loc:

--- a/spectacles/validators.py
+++ b/spectacles/validators.py
@@ -277,7 +277,7 @@ class SqlValidator(Validator):
         if isinstance(data, dict):
             errors = data.get("errors") or [data.get("error")]
             first_error = errors[0]
-            message = first_error["message_details"]
+            message = first_error.get("message_details") or first_error["message"]
             if not isinstance(message, str):
                 raise TypeError(
                     "Unexpected message type. Expected a str, "

--- a/spectacles/validators.py
+++ b/spectacles/validators.py
@@ -284,8 +284,9 @@ class SqlValidator(Validator):
                     f"received type {type(message)}: {message}"
                 )
             sql = data["sql"]
-            if first_error.get("sql_error_loc"):
-                line_number = first_error["sql_error_loc"].get("line")
+            error_loc = first_error.get("sql_error_loc")
+            if error_loc:
+                line_number = error_loc.get("line")
             else:
                 line_number = None
         elif isinstance(data, list):

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -101,15 +101,19 @@ def test_get_query_results_task_error_dict(
     lookml_object = project.models[0].explores[0]
     validator.query_tasks = {"query_task_a": lookml_object}
     mock_message = "An error message."
+    mock_details = "Shocking details."
     mock_sql = "SELECT * FROM orders"
     mock_response = {
         "status": "error",
-        "data": {"errors": [{"message_details": mock_message}], "sql": mock_sql},
+        "data": {
+            "errors": [{"message": mock_message, "message_details": mock_details}],
+            "sql": mock_sql,
+        },
     }
     mock_get_query_task_multi_results.return_value = {"query_task_a": mock_response}
     still_running, errors = validator._get_query_results(["query_task_a"])
     assert errors[0].path == lookml_object.name
-    assert errors[0].message == mock_message
+    assert errors[0].message == f"{mock_message} {mock_details}"
     assert errors[0].sql == mock_sql
     assert not still_running
 

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -177,3 +177,26 @@ def test_get_query_results_task_error_loc_wo_msg_details(
     assert errors[0].message == mock_message
     assert errors[0].sql == mock_sql
     assert not still_running
+
+
+@patch("spectacles.client.LookerClient.get_query_task_multi_results")
+def test_get_query_results_task_error_loc_wo_line(
+    mock_get_query_task_multi_results, validator, project
+):
+    lookml_object = project.models[0].explores[0]
+    validator.query_tasks = {"query_task_a": lookml_object}
+    mock_message = "An error message."
+    mock_sql = "SELECT x FROM orders"
+    mock_response = {
+        "status": "error",
+        "data": {
+            "errors": [{"message": mock_message, "sql_error_loc": {"character": 8}}],
+            "sql": mock_sql,
+        },
+    }
+    mock_get_query_task_multi_results.return_value = {"query_task_a": mock_response}
+    still_running, errors = validator._get_query_results(["query_task_a"])
+    assert errors[0].path == lookml_object.name
+    assert errors[0].message == mock_message
+    assert errors[0].sql == mock_sql
+    assert not still_running


### PR DESCRIPTION
### Handle error w/o line number

We ran into an error with one explore which yielded a `sql_error_loc`, but did not contain a line reference:

```python

"errors": [
    {
        "message": "The PostgreSQL database encountered an error while running this query.",
        "message_details": "ERROR: column <scrubbed> does not exist\n  Position: 3178",
        "params": 'SELECT <scrubbed>',
        "edit_url": None,
        "error_pos": None,
        "level": "error",
        "sql_error_loc": {"character": 3178},
    }
],
```
### Handle errors without message_details

We encountered an error in one of our explores which only yielded a message:

```python
"errors": [
    {
        "message": 'Access filter field "scrubbed" on model "scrubbed" is unset for the current user.',
        "message_details": None,
        "params": None,
        "edit_url": None,
        "error_pos": None,
        "fatal": True,
        "level": "fatal",
        "login_required_oauth_application_id": None,
    }
],
```

