### PR TITLE
Be less restrictive with Looker version check

### DIFF
--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -106,39 +106,6 @@ class LookerClient:
 
         return response.json()["looker_release_version"]
 
-    def validate_looker_release_version(self, required_version: str) -> bool:
-        """Checks that the current Looker version meets a specified minimum.
-
-        Args:
-            required_version: Minimum instance version number (e.g. 6.22.12)
-
-        Returns:
-            bool: True if the current Looker version >= the required version
-
-        """
-        current_version = self.get_looker_release_version()
-        logger.info(f"Looker instance version is {current_version}")
-
-        def expand_version(version: str):
-            return [int(number) for number in version.split(".")]
-
-        current = expand_version(current_version)
-        required = expand_version(required_version)
-
-        # If version is provided in format 6.20 or 7, extend with .0(s)
-        # e.g. 6.20 would become 6.20.0, 7 would become 7.0.0
-        if len(current) < 3:
-            current.extend([0] * (3 - len(current)))
-
-        for current_num, required_num in zip(current, required):
-            if current_num < required_num:
-                return False
-            elif current_num > required_num:
-                return True
-
-        # Loop exits successfully if current version == required version
-        return True
-
     def update_session(
         self, project: str, branch: str, remote_reset: bool = False
     ) -> None:

--- a/spectacles/validators.py
+++ b/spectacles/validators.py
@@ -76,18 +76,10 @@ class SqlValidator(Validator):
     """
 
     timeout = aiohttp.ClientTimeout(total=300)
-    MIN_LOOKER_VERSION = "6.22.12"
 
     def __init__(self, client: LookerClient, project: str):
         super().__init__(client)
-        meets_required_version = self.client.validate_looker_release_version(
-            required_version=self.MIN_LOOKER_VERSION
-        )
-        if not meets_required_version:
-            raise SpectaclesException(
-                "SQL validation requires version "
-                f"{self.MIN_LOOKER_VERSION} of Looker or higher."
-            )
+
         self.project = Project(project, models=[])
         self.query_tasks: dict = {}
 

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -22,16 +22,7 @@ def load(filename):
 @pytest.fixture
 def client(monkeypatch):
     mock_authenticate = Mock(spec=LookerClient.authenticate)
-    mock_validate_looker_release_version = Mock(
-        spec=LookerClient.validate_looker_release_version
-    )
-    mock_validate_looker_release_version.return_value = True
     monkeypatch.setattr(LookerClient, "authenticate", mock_authenticate)
-    monkeypatch.setattr(
-        LookerClient,
-        "validate_looker_release_version",
-        mock_validate_looker_release_version,
-    )
     return LookerClient(TEST_BASE_URL, TEST_CLIENT_ID, TEST_CLIENT_SECRET)
 
 


### PR DESCRIPTION
If the version detected is less than the defined minimum, issue a warning noting the version being used is not supported rather than refusing to run at all. (maybe it should also warn that it may crash Looker?)

We are running an older version of Looker (6.16.x) and I wanted to see if it simply would not work at all or if we were able to at least gain some utility. To my surprise, it seems to work ok, I have not run into the 500 errors (#73) that led to #81, yet.