### PR TITLE
Allow model names to contain periods

### DIFF
--- a/spectacles/validators.py
+++ b/spectacles/validators.py
@@ -108,7 +108,7 @@ class SqlValidator(Validator):
         selection: DefaultDict = defaultdict(set)
         for selector in selectors:
             try:
-                model, explore = selector.split(".")
+                model, explore = selector.rsplit(".", 1)
             except ValueError:
                 raise SpectaclesException(
                     f"Explore selector '{selector}' is not valid.\n"

--- a/tests/resources/response_models.json
+++ b/tests/resources/response_models.json
@@ -39,7 +39,7 @@
     ],
     "has_content": false,
     "label": "Test Model Two",
-    "name": "test_model_two",
+    "name": "test_model.two",
     "project_name": "test_project",
     "unlimited_db_connections": false,
     "allowed_db_connection_names": [

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -66,8 +66,9 @@ def project():
     explores_model_two = [Explore("test_explore_two", dimensions)]
     models = [
         Model("test_model_one", "test_project", explores_model_one),
-        Model("test_model_two", "test_project", explores_model_two),
+        Model("test_model.two", "test_project", explores_model_two),
     ]
+
     project = Project("test_project", models)
     return project
 
@@ -79,6 +80,19 @@ def test_build_project(mock_get_models, mock_get_dimensions, project, validator)
     mock_get_dimensions.return_value = load("response_dimensions.json")
     validator.build_project(selectors=["*.*"])
     assert validator.project == project
+
+
+@patch("spectacles.client.LookerClient.get_lookml_dimensions")
+@patch("spectacles.client.LookerClient.get_lookml_models")
+def test_build_project_using_periods_in_name(
+    mock_get_models, mock_get_dimensions, project, validator
+):
+    mock_get_models.return_value = load("response_models.json")
+    mock_get_dimensions.return_value = load("response_dimensions.json")
+
+    for model in project.models:
+        validator.build_project(selectors=[f"{model.name}.*"])
+        assert validator.project.models == [model]
 
 
 @patch("spectacles.client.LookerClient.get_query_task_multi_results")


### PR DESCRIPTION
We are probably outliers here, but our models often have periods in their names which is not handled very well by the model/explore filtering. 

Alternatively, I wonder if we could we use another delimiter than period, such as a slash '/' instead?