### PR TITLE
Include instance looker version in connect msg

### DIFF
--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -79,7 +79,11 @@ class LookerClient:
         access_token = response.json()["access_token"]
         self.session.headers = {"Authorization": f"token {access_token}"}
 
-        logger.info(f"Connected using Looker API {api_version}")
+        looker_version = self.get_looker_release_version()
+        logger.info(
+            f"Connected to Looker version {looker_version} "
+            f"using Looker API {api_version}"
+        )
 
     def get_looker_release_version(self) -> str:
         """Gets the version number of connected Looker instance.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -37,10 +37,14 @@ def test_bad_authenticate_raises_connection_error(mock_post, mock_response):
 
 
 @patch("spectacles.client.requests.Session.post")
-def test_authenticate_sets_session_headers(mock_post):
-    mock_response = Mock(spec=requests.Response)
-    mock_response.json.return_value = {"access_token": "test_access_token"}
-    mock_post.return_value = mock_response
+def test_authenticate_sets_session_headers(mock_post, monkeypatch):
+    mock_looker_version = Mock(spec=LookerClient.get_looker_release_version)
+    mock_looker_version.return_value("1.2.3")
+    monkeypatch.setattr(LookerClient, "get_looker_release_version", mock_looker_version)
+
+    mock_post_response = Mock(spec=requests.Response)
+    mock_post_response.json.return_value = {"access_token": "test_access_token"}
+    mock_post.return_value = mock_post_response
     client = LookerClient(TEST_BASE_URL, TEST_CLIENT_ID, TEST_CLIENT_SECRET)
     assert client.session.headers == {"Authorization": f"token test_access_token"}
 


### PR DESCRIPTION
After the version check was removed it no longer prints the instance version, which I thought was at least as interesting as the API version so I added it to the logged connection string. 