### PR TITLE
Use slash to delimit model/explore in filters

### DIFF
--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -329,11 +329,11 @@ def _build_sql_subparser(
     subparser.add_argument(
         "--explores",
         nargs="+",
-        default=["*.*"],
+        default=["*/*"],
         help="Specify the explores spectacles should test. \
-            List of selector strings in 'model_name.explore_name' format. \
+            List of selector strings in 'model_name/explore_name' format. \
             The '*' wildcard selects all models or explores. For instance,\
-            'model_name.*' would select all explores in the 'model_name' model.",
+            'model_name/*' would select all explores in the 'model_name' model.",
     )
     subparser.add_argument(
         "--mode",

--- a/spectacles/validators.py
+++ b/spectacles/validators.py
@@ -85,12 +85,12 @@ class SqlValidator(Validator):
 
     @staticmethod
     def parse_selectors(selectors: List[str]) -> DefaultDict[str, set]:
-        """Parses explore selectors with the format 'model_name.explore_name'.
+        """Parses explore selectors with the format 'model_name/explore_name'.
 
         Args:
-            selectors: List of selector strings in 'model_name.explore_name' format.
+            selectors: List of selector strings in 'model_name/explore_name' format.
                 The '*' wildcard selects all models or explores. For instance,
-                'model_name.*' would select all explores in the 'model_name' model.
+                'model_name/*' would select all explores in the 'model_name' model.
 
         Returns:
             DefaultDict[str, set]: A hierarchy of selected model names (keys) and
@@ -100,12 +100,12 @@ class SqlValidator(Validator):
         selection: DefaultDict = defaultdict(set)
         for selector in selectors:
             try:
-                model, explore = selector.split(".")
+                model, explore = selector.split("/")
             except ValueError:
                 raise SpectaclesException(
                     f"Explore selector '{selector}' is not valid.\n"
-                    "Instead, use the format 'model_name.explore_name'. "
-                    f"Use 'model_name.*' to select all explores in a model."
+                    "Instead, use the format 'model_name/explore_name'. "
+                    f"Use 'model_name/*' to select all explores in a model."
                 )
             else:
                 selection[model].add(explore)
@@ -129,9 +129,9 @@ class SqlValidator(Validator):
         """Creates an object representation of the project's LookML.
 
         Args:
-            selectors: List of selector strings in 'model_name.explore_name' format.
+            selectors: List of selector strings in 'model_name/explore_name' format.
                 The '*' wildcard selects all models or explores. For instance,
-                'model_name.*' would select all explores in the 'model_name' model.
+                'model_name/*' would select all explores in the 'model_name' model.
 
         """
         selection = self.parse_selectors(selectors)

--- a/tests/resources/response_models.json
+++ b/tests/resources/response_models.json
@@ -39,7 +39,7 @@
     ],
     "has_content": false,
     "label": "Test Model Two",
-    "name": "test_model_two",
+    "name": "test_model.two",
     "project_name": "test_project",
     "unlimited_db_connections": false,
     "allowed_db_connection_names": [

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -57,7 +57,7 @@ def project():
     explores_model_two = [Explore("test_explore_two", dimensions)]
     models = [
         Model("test_model_one", "test_project", explores_model_one),
-        Model("test_model_two", "test_project", explores_model_two),
+        Model("test_model.two", "test_project", explores_model_two),
     ]
     project = Project("test_project", models)
     return project
@@ -68,7 +68,7 @@ def project():
 def test_build_project(mock_get_models, mock_get_dimensions, project, validator):
     mock_get_models.return_value = load("response_models.json")
     mock_get_dimensions.return_value = load("response_dimensions.json")
-    validator.build_project(selectors=["*.*"])
+    validator.build_project(selectors=["*/*"])
     assert validator.project == project
 
 


### PR DESCRIPTION
Updated to use slash rather than period because it's possible that model names may contain period characters.

This PR replaces #121

