### PR TITLE
Add always false filter to queries to improve speed (particularly on Snowflake)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @spectacles-ci/spectacles-maintainers
+*  @DylanBaker @joshtemple

--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -334,7 +334,13 @@ class LookerClient:
             explore,
             "*" if len(dimensions) > 1 else dimensions[0],
         )
-        body = {"model": model, "view": explore, "fields": dimensions, "limit": 0}
+        body = {
+            "model": model,
+            "view": explore,
+            "fields": dimensions,
+            "limit": 0,
+            "filter_expression": "1=2",
+        }
         url = utils.compose_url(self.api_url, path=["queries"])
         async with session.post(url=url, json=body) as response:
             result = await response.json()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -106,5 +106,6 @@ async def test_create_query(mock_post, client):
             "view": "test_explore_one",
             "fields": ["dimension_one", "dimension_two"],
             "limit": 0,
+            "filter_expression": "1=2",
         },
     )


### PR DESCRIPTION
We run `limit 0` queries in order to test the validity of the SQL Looker generates. On lots of warehouses, that processes no data and is very fast (BigQuery and Redshift, notably).

On Snowflake, it still processes a lot of data and there isn't an `EXPLAIN` functionality we can use right now. The proposed solution is to add a `1=2` filter to all queries, which does stop it from processing data.