### PR TITLE
Handle access filter error

### DIFF
--- a/spectacles/validators.py
+++ b/spectacles/validators.py
@@ -302,9 +302,12 @@ class SqlValidator(Validator):
             errors = data.get("errors") or [data.get("error")]
             first_error = errors[0]
             message = " ".join(
-                [first_error.get("message", ""), first_error.get("message_details", "")]
-            ).strip()
-            sql = data["sql"]
+                filter(
+                    None,
+                    [first_error.get("message"), first_error.get("message_details")],
+                )
+            )
+            sql = data.get("sql")
             error_loc = first_error.get("sql_error_loc")
             if error_loc:
                 line_number = error_loc.get("line")

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -141,32 +141,15 @@ def test_extract_error_details_error_non_str_message_details(validator, project)
         validator._extract_error_details(query_result)
 
 
-def test_extract_error_details_for_unset_access_filter(validator, project):
-    message = (
-        'Access filter field "foo.bar" on model "baz.qux" '
-        + "is unset for the current user."
-    )
-    sql = None
+def test_extract_error_details_no_message_details(validator, project):
+    message = "An error message."
     query_result = {
         "status": "error",
-        "data": {
-            "errors": [
-                {
-                    "message": message,
-                    "message_details": None,
-                    "params": None,
-                    "edit_url": None,
-                    "error_pos": None,
-                    "fatal": True,
-                    "level": "fatal",
-                    "login_required_oauth_application_id": None,
-                }
-            ]
-        },
+        "data": {"errors": [{"message": message, "message_details": None}]},
     }
     extracted = validator._extract_error_details(query_result)
     assert extracted["message"] == message
-    assert extracted["sql"] == sql
+    assert extracted["sql"] is None
 
 
 def test_extract_error_details_error_loc_wo_line(validator, project):

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -141,12 +141,28 @@ def test_extract_error_details_error_non_str_message_details(validator, project)
         validator._extract_error_details(query_result)
 
 
-def test_extract_error_details_error_loc_wo_msg_details(validator, project):
-    message = "An error message."
-    sql = "SELECT * FROM orders"
+def test_extract_error_details_for_unset_access_filter(validator, project):
+    message = (
+        'Access filter field "foo.bar" on model "baz.qux" '
+        + "is unset for the current user."
+    )
+    sql = None
     query_result = {
         "status": "error",
-        "data": {"errors": [{"message": message}], "sql": sql},
+        "data": {
+            "errors": [
+                {
+                    "message": message,
+                    "message_details": None,
+                    "params": None,
+                    "edit_url": None,
+                    "error_pos": None,
+                    "fatal": True,
+                    "level": "fatal",
+                    "login_required_oauth_application_id": None,
+                }
+            ]
+        },
     }
     extracted = validator._extract_error_details(query_result)
     assert extracted["message"] == message

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -100,7 +100,7 @@ async def test_get_query_results_task_complete(
     assert not await errors
 
 
-def test_extract_error_details_error_dict(validator, project):
+def test_extract_error_details_error_dict(validator):
     message = "An error message."
     message_details = "Shocking details."
     sql = "SELECT * FROM orders"
@@ -116,7 +116,7 @@ def test_extract_error_details_error_dict(validator, project):
     assert extracted["sql"] == sql
 
 
-def test_extract_error_details_error_list(validator, project):
+def test_extract_error_details_error_list(validator):
     message = "An error message."
     query_result = {"status": "error", "data": [message]}
     extracted = validator._extract_error_details(query_result)
@@ -124,13 +124,13 @@ def test_extract_error_details_error_list(validator, project):
     assert extracted["sql"] is None
 
 
-def test_extract_error_details_error_other(validator, project):
+def test_extract_error_details_error_other(validator):
     query_result = {"status": "error", "data": "some string"}
     with pytest.raises(TypeError):
         validator._extract_error_details(query_result)
 
 
-def test_extract_error_details_error_non_str_message_details(validator, project):
+def test_extract_error_details_error_non_str_message_details(validator):
     message = {"message": "An error messsage.", "details": "More details."}
     sql = "SELECT * FROM orders"
     query_result = {
@@ -141,7 +141,7 @@ def test_extract_error_details_error_non_str_message_details(validator, project)
         validator._extract_error_details(query_result)
 
 
-def test_extract_error_details_no_message_details(validator, project):
+def test_extract_error_details_no_message_details(validator):
     message = "An error message."
     query_result = {
         "status": "error",
@@ -152,7 +152,7 @@ def test_extract_error_details_no_message_details(validator, project):
     assert extracted["sql"] is None
 
 
-def test_extract_error_details_error_loc_wo_line(validator, project):
+def test_extract_error_details_error_loc_wo_line(validator):
     message = "An error message."
     sql = "SELECT x FROM orders"
     query_result = {


### PR DESCRIPTION
:man_facepalming: 

This was proposed to be fixed via #117, but an incomplete example in that PR led to an incomplete solution. This time I updated the example to use a snippet taken directly from the error that was logged.

Note that there is also no `sql` key in this error which is now handled as well.