### PR TITLE
Allow specifying ref to checkout

### DIFF
--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -203,6 +203,7 @@ def main():
             args.mode,
             args.remote_reset,
             args.concurrency,
+            args.ref,
         )
     elif args.command == "assert":
         run_assert(
@@ -214,6 +215,7 @@ def main():
             args.port,
             args.api_version,
             args.remote_reset,
+            args.ref,
         )
 
 
@@ -364,6 +366,14 @@ def _build_sql_subparser(
         help="The branch of your project that spectacles will use to run queries.",
     )
     subparser.add_argument(
+        "--ref",
+        action=EnvVarAction,
+        env_var="LOOKER_GIT_REF",
+        help="A specific Git ref (sha) to reset the branch in Looker to. \
+            WARNING: This will delete any uncommited changes in the user's \
+            workspace.",
+    )
+    subparser.add_argument(
         "--explores",
         nargs="+",
         default=["*/*"],
@@ -432,6 +442,14 @@ def _build_assert_subparser(
         "--branch", action=EnvVarAction, env_var="LOOKER_GIT_BRANCH", required=True
     )
     subparser.add_argument(
+        "--ref",
+        action=EnvVarAction,
+        env_var="LOOKER_GIT_REF",
+        help="A specific Git ref (sha) to reset the branch in Looker to. \
+            WARNING: This will delete any uncommited changes in the user's \
+            workspace.",
+    )
+    subparser.add_argument(
         "--remote-reset",
         action="store_true",
         help="When set to true, the SQL validator will tell Looker to reset the \
@@ -448,7 +466,15 @@ def run_connect(
 
 
 def run_assert(
-    project, branch, base_url, client_id, client_secret, port, api_version, remote_reset
+    project,
+    branch,
+    base_url,
+    client_id,
+    client_secret,
+    port,
+    api_version,
+    remote_reset,
+    ref,
 ) -> None:
     runner = Runner(
         base_url,
@@ -459,6 +485,7 @@ def run_assert(
         port,
         api_version,
         remote_reset,
+        ref,
     )
     errors = runner.validate_data_tests()
     if errors:
@@ -483,6 +510,7 @@ def run_sql(
     mode,
     remote_reset,
     concurrency,
+    ref,
 ) -> None:
     """Runs and validates the SQL for each selected LookML dimension."""
     runner = Runner(
@@ -494,6 +522,7 @@ def run_sql(
         port,
         api_version,
         remote_reset,
+        ref,
     )
 
     def iter_errors(lookml: List) -> Iterable:

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -17,6 +17,8 @@ class Runner:
         client_secret: Looker API client secret.
         port: Desired API port to use for requests.
         api_version: Desired API version to use for requests.
+        remote_reset: Reset state of the branch in Looker to match remote. (reset --hard)
+        ref: The git ref to check out. (This will use a reset --hard in Looker)
 
     Attributes:
         client: Looker API client used for making requests.
@@ -33,12 +35,16 @@ class Runner:
         port: int = 19999,
         api_version: float = 3.1,
         remote_reset: bool = False,
+        ref: str = None,
     ):
         self.project = project
         self.client = LookerClient(
             base_url, client_id, client_secret, port, api_version
         )
-        self.client.update_session(project, branch, remote_reset)
+        self.client.update_session(project, branch)
+        self.client.git_branch(project, branch, ref)
+        if remote_reset:
+            self.client.reset_to_remote(project, branch)
 
     @log_duration
     def validate_sql(


### PR DESCRIPTION
These changes add a `ref` option which may also be set via `LOOKER_GIT_REF` environment variable. When set, ref will be passed to Looker's `git_branch` call to explicitly request the referenced commit be checked out.

~~This resolves an annoyance I've been experiencing while cleaning up some looks where I run `spectacles` which identifies several dimensions with issues. I fix, commit and push the changes but rerunning `spectacles` continues to report them until I go into looker and manually pull the changes into the space. I'd hoped the `--remote-reset` option would resolve this, but it does not. I left that option unchanged as it may be useful in other scenarios.~~  

The `--remote-reset` option does fix this scenario, actually. This `ref` feature is still useful since it can be used to by CI to ensure the state of the repo being tested matches the commit that triggered the build.

While I was in there, I also segregated the calls to be closer to 1:1 with the API. (#96)