### PR TITLE
Convert asynchronous requests to synchronous

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "requirements.txt" }}
+            - v1-dependencies-{{ checksum "requirements-dev.txt" }}
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
 
@@ -26,13 +26,13 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install -r requirements.txt
+            pip install -r requirements-dev.txt
             pip install .
 
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
+          key: v1-dependencies-{{ checksum "requirements-dev.txt" }}
 
       - run:
           name: mypy

--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ config/
 
 # MacOS
 .DS_Store
+
+# VSCode
+.vscode/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+default_language_version:
+  python: python3.7
+repos:
+  - repo: https://github.com/ambv/black
+    rev: 19.3b0
+    hooks:
+    - id: black
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.8
+    hooks:
+    - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.701
+    hooks:
+    - id: mypy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+-r requirements.txt
+
+black==19.3b0
+mypy==0.701
+pytest==5.2.0
+pytest-cov==2.7.1
+setuptools==41.2.0
+flake8==3.7.8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ pytest==5.2.0
 pytest-cov==2.7.1
 setuptools==41.2.0
 flake8==3.7.8
+pre-commit==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,4 @@
-black==19.3b0
 requests==2.22.0
-mypy==0.701
-asynctest==0.13.0
-pytest==5.2.0
-pytest-cov==2.7.1
-pytest-asyncio==0.10.0
-setuptools==41.2.0
 colorama==0.4.1
 PyYAML==5.1.2
 backoff==1.8.0
-aiohttp==3.6.1
-flake8==3.7.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,3 +20,5 @@ add-ignore = D100,D107,D202
 max-line-length = 88
 builtins = unicode
 tee = True
+select = C,E,F,W,B,B950
+ignore = E203,E501,W503

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ convention = google
 add-ignore = D100,D107,D202
 
 [flake8]
+exclude = .git,__pycache__,docs,build,dist
 max-line-length = 88
 builtins = unicode
 tee = True

--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -328,7 +328,14 @@ class LookerClient:
         }
         url = utils.compose_url(self.api_url, path=["queries"])
         response = self.session.post(url=url, json=body, timeout=TIMEOUT_SEC)
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as error:
+            raise ApiConnectionError(
+                f"Failed to run create query for {model}/{explore}/"
+                f'{"*" if len(dimensions) > 1 else dimensions[0]}\n'
+                f'Error raised: "{error}"'
+            )
         result = response.json()
 
         query_id = result["id"]

--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -1,8 +1,7 @@
 from typing import List, Dict, Any
-import asyncio
 import backoff  # type: ignore
-import aiohttp
 import requests
+from requests.exceptions import Timeout
 import spectacles.utils as utils
 from spectacles.logger import GLOBAL_LOGGER as logger
 from spectacles.exceptions import SpectaclesException, ApiConnectionError
@@ -302,33 +301,15 @@ class LookerClient:
 
         return response.json()["fields"]["dimensions"]
 
-    @backoff.on_exception(
-        backoff.expo, (aiohttp.ClientError, asyncio.TimeoutError), max_tries=2
-    )
-    async def create_query(
-        self,
-        session: aiohttp.ClientSession,
-        model: str,
-        explore: str,
-        dimensions: List[str],
-    ) -> int:
+    @backoff.on_exception(backoff.expo, (Timeout,), max_tries=2)
+    def create_query(self, model: str, explore: str, dimensions: List[str]) -> int:
         """Creates a Looker async query for one or more specified dimensions.
 
         The query created is a SELECT query, selecting all dimensions specified for a
         certain model and explore. Looker builds the query using the `sql` field in the
         LookML for each dimension.
 
-        If a ClientError or TimeoutError is received, attempts to retry.
-
-        Args:
-            session: Existing asychronous HTTP session.
-            model: Name of LookML model to query.
-            explore: Name of LookML explore to query.
-            dimensions: Names of the LookML dimensions in the specified explore to
-                query.
-
-        Returns:
-            int: ID for the created query.
+        If a Timeout exception is received, attempts to retry.
 
         """
         # Using old-style string formatting so that strings are formatted lazily
@@ -346,9 +327,10 @@ class LookerClient:
             "filter_expression": "1=2",
         }
         url = utils.compose_url(self.api_url, path=["queries"])
-        async with session.post(url=url, json=body) as response:
-            result = await response.json()
-            response.raise_for_status()
+        response = self.session.post(url=url, json=body)
+        response.raise_for_status()
+        result = response.json()
+
         query_id = result["id"]
         logger.debug(
             "Query for %s/%s/%s created as query %d",
@@ -359,12 +341,8 @@ class LookerClient:
         )
         return query_id
 
-    @backoff.on_exception(
-        backoff.expo, (aiohttp.ClientError, asyncio.TimeoutError), max_tries=2
-    )
-    async def create_query_task(
-        self, session: aiohttp.ClientSession, query_id: int
-    ) -> str:
+    @backoff.on_exception(backoff.expo, (Timeout,), max_tries=2)
+    def create_query_task(self, query_id: int) -> str:
         """Runs a previously created query asynchronously and returns the query task ID.
 
         If a ClientError or TimeoutError is received, attempts to retry.
@@ -382,18 +360,14 @@ class LookerClient:
         logger.debug("Starting query %d", query_id)
         body = {"query_id": query_id, "result_format": "json_detail"}
         url = utils.compose_url(self.api_url, path=["query_tasks"])
-        async with session.post(
-            url=url, json=body, params={"cache": "false"}
-        ) as response:
-            result = await response.json()
-            response.raise_for_status()
+        response = self.session.post(url=url, json=body, params={"cache": "false"})
+        response.raise_for_status()
+        result = response.json()
         query_task_id = result["id"]
         logger.debug("Query %d is running under query task %s", query_id, query_task_id)
         return query_task_id
 
-    async def get_query_task_multi_results(
-        self, session: aiohttp.ClientSession, query_task_ids: List[str]
-    ) -> JsonDict:
+    def get_query_task_multi_results(self, query_task_ids: List[str]) -> JsonDict:
         """Returns query task results.
 
         If a ClientError or TimeoutError is received, attempts to retry.
@@ -410,17 +384,15 @@ class LookerClient:
             "Attempting to get results for %d query tasks", len(query_task_ids)
         )
         url = utils.compose_url(self.api_url, path=["query_tasks", "multi_results"])
-        async with session.get(
+        response = self.session.get(
             url=url, params={"query_task_ids": ",".join(query_task_ids)}
-        ) as response:
-            result = await response.json()
-            response.raise_for_status()
+        )
+        response.raise_for_status()
+        result = response.json()
         return result
 
-    async def cancel_query_task(
-        self, session: aiohttp.ClientSession, query_task_id: str
-    ):
-        """ Cancels a query task.
+    def cancel_query_task(self, query_task_id: str):
+        """Cancels a query task.
 
         Args:
             query_task_id: ID for the query task to cancel.
@@ -428,8 +400,7 @@ class LookerClient:
         """
         logger.debug(f"Cancelling query task: {query_task_id}")
         url = utils.compose_url(self.api_url, path=["running_queries", query_task_id])
-        async with session.delete(url=url) as response:
-            await response.read()
+        response = self.session.delete(url=url)
 
-            # No raise_for_status() here because Looker API seems to give a 404
-            # if you try to cancel a finished query which can happen as part of cleanup
+        # No raise_for_status() here because Looker API seems to give a 404
+        # if you try to cancel a finished query which can happen as part of cleanup

--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -9,6 +9,7 @@ from spectacles.exceptions import SpectaclesException, ApiConnectionError
 JsonDict = Dict[str, Any]
 TIMEOUT_SEC = 300
 
+
 class LookerClient:
     """Wraps some endpoints of the Looker API, issues requests and handles responses.
 
@@ -234,7 +235,9 @@ class LookerClient:
             self.api_url, path=["projects", project, "lookml_tests", "run"]
         )
         if model is not None:
-            response = self.session.get(url=url, params={"model": model}, timeout=TIMEOUT_SEC)
+            response = self.session.get(
+                url=url, params={"model": model}, timeout=TIMEOUT_SEC
+            )
         else:
             response = self.session.get(url=url, timeout=TIMEOUT_SEC)
 
@@ -367,7 +370,9 @@ class LookerClient:
         logger.debug("Starting query %d", query_id)
         body = {"query_id": query_id, "result_format": "json_detail"}
         url = utils.compose_url(self.api_url, path=["query_tasks"])
-        response = self.session.post(url=url, json=body, params={"cache": "false"}, timeout=TIMEOUT_SEC)
+        response = self.session.post(
+            url=url, json=body, params={"cache": "false"}, timeout=TIMEOUT_SEC
+        )
         response.raise_for_status()
         result = response.json()
         query_task_id = result["id"]
@@ -392,7 +397,9 @@ class LookerClient:
         )
         url = utils.compose_url(self.api_url, path=["query_tasks", "multi_results"])
         response = self.session.get(
-            url=url, params={"query_task_ids": ",".join(query_task_ids)}, timeout=TIMEOUT_SEC
+            url=url,
+            params={"query_task_ids": ",".join(query_task_ids)},
+            timeout=TIMEOUT_SEC,
         )
         response.raise_for_status()
         result = response.json()

--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -7,7 +7,7 @@ from spectacles.logger import GLOBAL_LOGGER as logger
 from spectacles.exceptions import SpectaclesException, ApiConnectionError
 
 JsonDict = Dict[str, Any]
-
+TIMEOUT_SEC = 300
 
 class LookerClient:
     """Wraps some endpoints of the Looker API, issues requests and handles responses.
@@ -62,7 +62,7 @@ class LookerClient:
 
         url = utils.compose_url(self.api_url, path=["login"])
         body = {"client_id": client_id, "client_secret": client_secret}
-        response = self.session.post(url=url, data=body)
+        response = self.session.post(url=url, data=body, timeout=TIMEOUT_SEC)
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as error:
@@ -95,7 +95,7 @@ class LookerClient:
 
         url = utils.compose_url(self.api_url, path=["versions"])
 
-        response = self.session.get(url=url)
+        response = self.session.get(url=url, timeout=TIMEOUT_SEC)
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as error:
@@ -123,7 +123,7 @@ class LookerClient:
             logger.debug("Updating session to use production workspace")
             url = utils.compose_url(self.api_url, path=["session"])
             body = {"workspace_id": "production"}
-            response = self.session.patch(url=url, json=body)
+            response = self.session.patch(url=url, json=body, timeout=TIMEOUT_SEC)
             try:
                 response.raise_for_status()
             except requests.exceptions.HTTPError as error:
@@ -139,7 +139,7 @@ class LookerClient:
             logger.debug("Updating session to use development workspace")
             url = utils.compose_url(self.api_url, path=["session"])
             body = {"workspace_id": "dev"}
-            response = self.session.patch(url=url, json=body)
+            response = self.session.patch(url=url, json=body, timeout=TIMEOUT_SEC)
             try:
                 response.raise_for_status()
             except requests.exceptions.HTTPError as error:
@@ -156,7 +156,7 @@ class LookerClient:
                 self.api_url, path=["projects", project, "git_branch"]
             )
             body = {"name": branch}
-            response = self.session.put(url=url, json=body)
+            response = self.session.put(url=url, json=body, timeout=TIMEOUT_SEC)
             try:
                 response.raise_for_status()
             except requests.exceptions.HTTPError as error:
@@ -175,7 +175,7 @@ class LookerClient:
                 url = utils.compose_url(
                     self.api_url, path=["projects", project, "reset_to_remote"]
                 )
-                response = self.session.post(url=url)
+                response = self.session.post(url=url, timeout=TIMEOUT_SEC)
                 try:
                     response.raise_for_status()
                 except requests.exceptions.HTTPError as error:
@@ -203,7 +203,7 @@ class LookerClient:
         url = utils.compose_url(
             self.api_url, path=["projects", project, "lookml_tests"]
         )
-        response = self.session.get(url=url)
+        response = self.session.get(url=url, timeout=TIMEOUT_SEC)
 
         try:
             response.raise_for_status()
@@ -234,9 +234,9 @@ class LookerClient:
             self.api_url, path=["projects", project, "lookml_tests", "run"]
         )
         if model is not None:
-            response = self.session.get(url=url, params={"model": model})
+            response = self.session.get(url=url, params={"model": model}, timeout=TIMEOUT_SEC)
         else:
-            response = self.session.get(url=url)
+            response = self.session.get(url=url, timeout=TIMEOUT_SEC)
 
         try:
             response.raise_for_status()
@@ -257,7 +257,7 @@ class LookerClient:
         """
         logger.debug(f"Getting all models and explores from {self.base_url}")
         url = utils.compose_url(self.api_url, path=["lookml_models"])
-        response = self.session.get(url=url)
+        response = self.session.get(url=url, timeout=TIMEOUT_SEC)
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as error:
@@ -287,7 +287,7 @@ class LookerClient:
         url = utils.compose_url(
             self.api_url, path=["lookml_models", model, "explores", explore]
         )
-        response = self.session.get(url=url)
+        response = self.session.get(url=url, timeout=TIMEOUT_SEC)
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as error:
@@ -327,7 +327,7 @@ class LookerClient:
             "filter_expression": "1=2",
         }
         url = utils.compose_url(self.api_url, path=["queries"])
-        response = self.session.post(url=url, json=body)
+        response = self.session.post(url=url, json=body, timeout=TIMEOUT_SEC)
         response.raise_for_status()
         result = response.json()
 
@@ -360,7 +360,7 @@ class LookerClient:
         logger.debug("Starting query %d", query_id)
         body = {"query_id": query_id, "result_format": "json_detail"}
         url = utils.compose_url(self.api_url, path=["query_tasks"])
-        response = self.session.post(url=url, json=body, params={"cache": "false"})
+        response = self.session.post(url=url, json=body, params={"cache": "false"}, timeout=TIMEOUT_SEC)
         response.raise_for_status()
         result = response.json()
         query_task_id = result["id"]
@@ -385,7 +385,7 @@ class LookerClient:
         )
         url = utils.compose_url(self.api_url, path=["query_tasks", "multi_results"])
         response = self.session.get(
-            url=url, params={"query_task_ids": ",".join(query_task_ids)}
+            url=url, params={"query_task_ids": ",".join(query_task_ids)}, timeout=TIMEOUT_SEC
         )
         response.raise_for_status()
         result = response.json()
@@ -400,7 +400,7 @@ class LookerClient:
         """
         logger.debug(f"Cancelling query task: {query_task_id}")
         url = utils.compose_url(self.api_url, path=["running_queries", query_task_id])
-        self.session.delete(url=url)
+        self.session.delete(url=url, timeout=TIMEOUT_SEC)
 
         # No raise_for_status() here because Looker API seems to give a 404
         # if you try to cancel a finished query which can happen as part of cleanup

--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -400,7 +400,7 @@ class LookerClient:
         """
         logger.debug(f"Cancelling query task: {query_task_id}")
         url = utils.compose_url(self.api_url, path=["running_queries", query_task_id])
-        response = self.session.delete(url=url)
+        self.session.delete(url=url)
 
         # No raise_for_status() here because Looker API seems to give a 404
         # if you try to cancel a finished query which can happen as part of cleanup

--- a/spectacles/exceptions.py
+++ b/spectacles/exceptions.py
@@ -26,6 +26,12 @@ class SqlError(ValidationError):
         self.line_number = line_number
         self.url = url
 
+    def __eq__(self, other):
+        if not isinstance(other, SqlError):
+            return NotImplemented
+        
+        return self.__dict__ == other.__dict__
+
     def __repr__(self):
         return self.message
 

--- a/spectacles/exceptions.py
+++ b/spectacles/exceptions.py
@@ -29,7 +29,7 @@ class SqlError(ValidationError):
     def __eq__(self, other):
         if not isinstance(other, SqlError):
             return NotImplemented
-        
+
         return self.__dict__ == other.__dict__
 
     def __repr__(self):

--- a/spectacles/lookml.py
+++ b/spectacles/lookml.py
@@ -9,7 +9,7 @@ class LookMlObject:
 
 
 class Dimension(LookMlObject):
-    def __init__(self, name: str, type: str, sql: str, url: Optional[str]):
+    def __init__(self, name: str, type: str, sql: str, url: Optional[str] = None):
         self.name = name
         self.type = type
         self.sql = sql

--- a/spectacles/validators.py
+++ b/spectacles/validators.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, List, Dict, NamedTuple, Sequence, DefaultDict, Union, Optional
+from typing import Any, List, Dict, Sequence, DefaultDict, Union, Optional
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from spectacles.client import LookerClient
@@ -24,7 +24,7 @@ class Query:
 
 
 class QueryResult:
-    """Stores ID, query status, and error details for a completed or errored query task"""
+    """Stores ID, query status, and error details for a completed query task"""
 
     def __init__(
         self, query_task_id: str, status: str, error: Optional[Dict[str, Any]] = None
@@ -305,7 +305,7 @@ class SqlValidator(Validator):
             self.client.cancel_query_task(query_task_id)
 
     def _fill_query_slots(self, queries: List[Query]) -> Dict[str, Query]:
-        """Creates query tasks until all slots are being used or all queries are running"""
+        """Creates query tasks until all slots are used or all queries are running"""
         query_tasks: Dict[str, Query] = {}
         while queries and self.query_slots > 0:
             logger.debug(

--- a/spectacles/validators.py
+++ b/spectacles/validators.py
@@ -243,6 +243,7 @@ class SqlValidator(Validator):
         return errors
 
     def _create_and_run(self, mode: str = "batch") -> List[SqlError]:
+        """Runs a single validation using a specified mode"""
         queries = self._create_queries(mode)
         try:
             errors = self._run_queries(queries)
@@ -378,6 +379,7 @@ class SqlValidator(Validator):
 
     @staticmethod
     def _extract_error_details(query_result: Dict) -> Dict:
+        """Extracts the relevant error fields from a Looker API response"""
         data = query_result["data"]
         if isinstance(data, dict):
             errors = data.get("errors") or [data.get("error")]

--- a/spectacles/validators.py
+++ b/spectacles/validators.py
@@ -1,14 +1,37 @@
-from typing import List, Sequence, DefaultDict
-import asyncio
+import time
+from typing import Any, List, Dict, NamedTuple, Sequence, DefaultDict, Union, Optional
 from abc import ABC, abstractmethod
 from collections import defaultdict
-import aiohttp
 from spectacles.client import LookerClient
 from spectacles.lookml import Project, Model, Explore, Dimension
 from spectacles.logger import GLOBAL_LOGGER as logger
 from spectacles.exceptions import SqlError, DataTestError, SpectaclesException
 import spectacles.printer as printer
-import signal
+
+
+class Query:
+    """Stores IDs and a reference to the LookML object being queried"""
+
+    def __init__(
+        self,
+        query_id: str,
+        lookml_ref: Union[Dimension, Explore],
+        query_task_id: Optional[str] = None,
+    ):
+        self.query_id = query_id
+        self.lookml_ref = lookml_ref
+        self.query_task_id = query_task_id
+
+
+class QueryResult:
+    """Stores ID, query status, and error details for a completed or errored query task"""
+
+    def __init__(
+        self, query_task_id: str, status: str, error: Optional[Dict[str, Any]] = None
+    ):
+        self.query_task_id = query_task_id
+        self.status = status
+        self.error = error
 
 
 class Validator(ABC):  # pragma: no cover
@@ -79,15 +102,11 @@ class SqlValidator(Validator):
 
     """
 
-    timeout = aiohttp.ClientTimeout(total=300)
-
     def __init__(self, client: LookerClient, project: str, concurrency: int = 10):
         super().__init__(client)
 
         self.project = Project(project, models=[])
-        self.query_tasks: dict = {}
-        self.query_slots = asyncio.BoundedSemaphore(concurrency)
-        self.running_query_tasks: asyncio.Queue = asyncio.Queue()
+        self.query_slots = concurrency
 
     @staticmethod
     def parse_selectors(selectors: List[str]) -> DefaultDict[str, set]:
@@ -209,17 +228,9 @@ class SqlValidator(Validator):
             f"[{mode} mode]"
         )
 
-        loop = asyncio.get_event_loop()
-
-        signals = (signal.SIGHUP, signal.SIGTERM, signal.SIGINT)
-        for s in signals:
-            loop.add_signal_handler(
-                s, lambda s=s: asyncio.create_task(self.shutdown(s, loop))
-            )
-
-        errors = list(loop.run_until_complete(self._query(mode)))
+        errors = self._create_and_run(mode)
         if mode == "hybrid" and self.project.errored:
-            errors = list(loop.run_until_complete(self._query(mode)))
+            errors = self._create_and_run(mode)
 
         for model in sorted(self.project.models, key=lambda x: x.name):
             for explore in sorted(model.explores, key=lambda x: x.name):
@@ -231,72 +242,142 @@ class SqlValidator(Validator):
 
         return errors
 
-    async def shutdown(self, signal, loop):
-        logger.info("\n\n" + "Please wait, asking Looker to cancel any running queries")
-        logger.debug("Cleaning up async tasks.")
-        tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
-        for task in tasks:
-            task.cancel()
-        await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
-        # Nothing executes beyond this point because of CancelledErrors
-
-    async def _query(self, mode: str = "batch") -> List[SqlError]:
-        session = aiohttp.ClientSession(
-            headers=self.client.session.headers, timeout=self.timeout
-        )
-
-        query_tasks = []
-        for model in self.project.models:
-            for explore in model.explores:
-                if mode == "batch" or (mode == "hybrid" and not explore.queried):
-                    task = asyncio.create_task(
-                        self._query_explore(session, model, explore)
-                    )
-                    query_tasks.append(task)
-                elif mode == "single" or (mode == "hybrid" and explore.errored):
-                    for dimension in explore.dimensions:
-                        task = asyncio.create_task(
-                            self._query_dimension(session, model, explore, dimension)
-                        )
-                        query_tasks.append(task)
-
-        queries = asyncio.gather(*query_tasks)
-        query_results = asyncio.create_task(
-            self._check_for_results(session, query_tasks)
-        )
+    def _create_and_run(self, mode: str = "batch") -> List[SqlError]:
+        queries = self._create_queries(mode)
         try:
-            results = await asyncio.gather(queries, query_results)
-        except asyncio.CancelledError:
-            query_task_ids = []
-            while not self.running_query_tasks.empty():
-                query_task_ids.append(await self.running_query_tasks.get())
-            cancel_query_tasks = []
-            for query_task_id in query_task_ids:
-                task = asyncio.create_task(
-                    self.client.cancel_query_task(session, query_task_id)
-                )
-                cancel_query_tasks.append(task)
-
-            await asyncio.gather(*cancel_query_tasks)
-
-            message = "Spectacles was manually interrupted. "
-            if query_task_ids:
+            errors = self._run_queries(queries)
+        except KeyboardInterrupt:
+            logger.info(
+                "\n\n" + "Please wait, asking Looker to cancel any running queries"
+            )
+            query_tasks = [
+                query.query_task_id for query in queries if query.query_task_id
+            ]
+            self._cancel_queries(query_tasks)
+            message = "SQL validation was interrupted. "
+            if query_tasks:
                 message += (
-                    "Spectacles attempted to cancel "
-                    f"{len(query_task_ids)} running "
-                    f"{'query' if len(query_task_ids) == 1 else 'queries'}."
+                    f"Attempted to cancel {len(query_tasks)} running "
+                    f"{'query' if len(query_tasks) == 1 else 'queries'}."
                 )
             else:
                 message += "No queries were running at the time."
             raise SpectaclesException(message)
-        else:
-            errors = results[1]  # Ignore the results from creating the queries
-            return errors
-        finally:
-            await session.close()
+        return errors
+
+    def _create_explore_query(self, explore: Explore, model_name: str) -> Query:
+        """Creates a single query with all dimensions of an explore"""
+        dimensions = [dimension.name for dimension in explore.dimensions]
+        query_id = self.client.create_query(model_name, explore.name, dimensions)
+        return Query(query_id, lookml_ref=explore)
+
+    def _create_dimension_queries(
+        self, explore: Explore, model_name: str
+    ) -> List[Query]:
+        """Creates individual queries for each dimension in an explore"""
+        queries = []
+        for dimension in explore.dimensions:
+            query_id = self.client.create_query(
+                model_name, explore.name, [dimension.name]
+            )
+            query = Query(query_id, lookml_ref=dimension)
+            queries.append(query)
+        return queries
+
+    def _create_queries(self, mode: str) -> List[Query]:
+        """Creates a list of queries to be executed for validation"""
+        queries: List[Query] = []
+        for model in self.project.models:
+            for explore in model.explores:
+                if mode == "batch" or (mode == "hybrid" and not explore.queried):
+                    query = self._create_explore_query(explore, model.name)
+                    queries.append(query)
+                elif mode == "single" or (mode == "hybrid" and explore.errored):
+                    explore_queries = self._create_dimension_queries(
+                        explore, model.name
+                    )
+                    queries.extend(explore_queries)
+        return queries
+
+    def _cancel_queries(self, query_task_ids: List[str]) -> None:
+        """Asks the Looker API to cancel specified queries"""
+        for query_task_id in query_task_ids:
+            self.client.cancel_query_task(query_task_id)
+
+    def _fill_query_slots(self, queries: List[Query]) -> Dict[str, Query]:
+        """Creates query tasks until all slots are being used or all queries are running"""
+        query_tasks: Dict[str, Query] = {}
+        while queries and self.query_slots > 0:
+            logger.debug(
+                f"{self.query_slots} available query slots, creating query task"
+            )
+            query = queries.pop(0)
+            query_task_id = self.client.create_query_task(query.query_id)
+            self.query_slots -= 1
+            query.query_task_id = query_task_id
+            query_tasks[query_task_id] = query
+        return query_tasks
+
+    def _get_completed_query_tasks(self, query_task_ids) -> List[QueryResult]:
+        """Returns ID, status, and error message for completed and errored tasks"""
+        query_results = []
+        results = self.client.get_query_task_multi_results(query_task_ids)
+        for query_task_id, result in results.items():
+            status = result["status"]
+            logger.debug(f"Query task {query_task_id} status is: {status}")
+            if status in ("complete", "error"):
+                self.query_slots += 1
+                query_result = QueryResult(query_task_id, status)
+                if status == "error":
+                    try:
+                        query_result.error = self._extract_error_details(result)
+                    except (KeyError, TypeError, IndexError) as error:
+                        raise SpectaclesException(
+                            "Encountered an unexpected API query result format, "
+                            "unable to extract error details. "
+                            f"The query result was: {result}"
+                        ) from error
+                query_results.append(query_result)
+            elif status in ("running", "added", "expired"):
+                continue
+            else:
+                raise SpectaclesException(
+                    f'Unexpected query result status "{status}" '
+                    "returned by the Looker API"
+                )
+        return query_results
+
+    def _run_queries(self, queries: List[Query]) -> List[SqlError]:
+        """Creates and runs queries with a maximum concurrency defined by query slots"""
+        QUERY_TASK_LIMIT = 250
+        query_by_task_id: Dict[
+            str, Query
+        ] = {}  # Lookup used to retrieve the LookML object
+        errors: List[SqlError] = []
+
+        while queries:
+            logger.debug(f"Starting a new loop, {len(queries)} queries queued")
+            query_tasks = self._fill_query_slots(queries)
+            query_by_task_id.update(query_tasks)
+            query_task_ids = list(query_by_task_id.keys())[:QUERY_TASK_LIMIT]
+            logger.debug(f"Checking results for {len(query_task_ids)} query tasks")
+            for query_result in self._get_completed_query_tasks(query_task_ids):
+                query = query_by_task_id.pop(query_result.query_task_id)
+                lookml_object = query.lookml_ref
+                lookml_object.queried = True
+                if query_result.status == "error" and query_result.error:
+                    sql_error = SqlError(
+                        path=lookml_object.name,
+                        url=getattr(lookml_object, "url", None),
+                        **query_result.error,
+                    )
+                    lookml_object.error = sql_error
+                    errors.append(sql_error)
+            time.sleep(0.5)
+        return errors
 
     @staticmethod
-    def _extract_error_details(query_result: dict) -> dict:
+    def _extract_error_details(query_result: Dict) -> Dict:
         data = query_result["data"]
         if isinstance(data, dict):
             errors = data.get("errors") or [data.get("error")]
@@ -326,151 +407,8 @@ class SqlValidator(Validator):
 
         return {"message": message, "sql": sql, "line_number": line_number}
 
-    async def _run_query(
-        self,
-        session: aiohttp.ClientSession,
-        model: str,
-        explore: str,
-        dimensions: List[str],
-    ) -> str:
-        query_id = await self.client.create_query(session, model, explore, dimensions)
-        await self.query_slots.acquire()  # Wait for available slots before launching
-        query_task_id = await self.client.create_query_task(session, query_id)
-        await self.running_query_tasks.put(query_task_id)
-        return query_task_id
-
-    async def _get_query_results(
-        self, session: aiohttp.ClientSession
-    ) -> List[SqlError]:
-        logger.debug("%d queries running", self.running_query_tasks.qsize())
-        try:
-            # Empty the queue (up to 250) to get all running query tasks
-            query_task_ids: List[str] = []
-            while not self.running_query_tasks.empty() and len(query_task_ids) <= 250:
-                query_task_ids.append(await self.running_query_tasks.get())
-
-            logger.debug("Getting results for %d query tasks", len(query_task_ids))
-            results = await self.client.get_query_task_multi_results(
-                session, query_task_ids
-            )
-            pending_task_ids = []
-            errors = []
-
-            for query_task_id, query_result in results.items():
-                query_status = query_result["status"]
-                logger.debug("Query task %s status is %s", query_task_id, query_status)
-                if query_status in ("running", "added", "expired"):
-                    pending_task_ids.append(query_task_id)
-                    # Put the running query tasks back in the queue
-                    await self.running_query_tasks.put(query_task_id)
-                    query_task_ids.remove(query_task_id)
-                    continue
-                elif query_status in ("complete", "error"):
-                    query_task_ids.remove(query_task_id)
-                    # We can release a query slot for each completed query
-                    self.query_slots.release()
-                    lookml_object = self.query_tasks[query_task_id]
-                    lookml_object.queried = True
-
-                    if query_status == "error":
-                        try:
-                            details = self._extract_error_details(query_result)
-                        except (KeyError, TypeError, IndexError) as error:
-                            raise SpectaclesException(
-                                "Encountered an unexpected API query result format, "
-                                "unable to extract error details. "
-                                f"The query result was: {query_result}"
-                            ) from error
-                        sql_error = SqlError(
-                            path=lookml_object.name,
-                            url=getattr(lookml_object, "url", None),
-                            **details,
-                        )
-                        lookml_object.error = sql_error
-                        errors.append(sql_error)
-                else:
-                    raise SpectaclesException(
-                        f'Unexpected query result status "{query_status}" '
-                        "returned by the Looker API"
-                    )
-        except asyncio.CancelledError:
-            logger.debug(
-                "Cancelled result fetching, putting "
-                f"{self.running_query_tasks.qsize()} query task IDs back in the queue"
-            )
-            for query_task_id in query_task_ids:
-                await self.running_query_tasks.put(query_task_id)
-            logger.debug("Restored query task IDs to queue")
-            raise
-
-        return errors
-
-    async def _check_for_results(
-        self, session: aiohttp.ClientSession, query_tasks: List[asyncio.Task]
-    ):
-        results = []
-        while (
-            any(not task.done() for task in query_tasks)
-            or not self.running_query_tasks.empty()
-        ):
-            if not self.running_query_tasks.empty():
-                result = await self._get_query_results(session)
-                results.extend(result)
-            await asyncio.sleep(0.5)
-
-        return results
-
-    async def _query_explore(
-        self, session: aiohttp.ClientSession, model: Model, explore: Explore
-    ) -> str:
-        """Creates and executes a query with a single explore.
-
-        Args:
-            model: Object representation of LookML model.
-            explore: Object representation of LookML explore.
-
-        Returns:
-            str: Query task ID for the running query.
-
-        """
-        dimensions = [dimension.name for dimension in explore.dimensions]
-        query_task_id = await self._run_query(
-            session, model.name, explore.name, dimensions
-        )
-        self.query_tasks[query_task_id] = explore
-        return query_task_id
-
-    async def _query_dimension(
-        self,
-        session: aiohttp.ClientSession,
-        model: Model,
-        explore: Explore,
-        dimension: Dimension,
-    ) -> str:
-        """Creates and executes a query with a single dimension.
-
-        Args:
-            model: Object representation of LookML model.
-            explore: Object representation of LookML explore.
-            dimension: Object representation of LookML dimension.
-
-        Returns:
-            str: Query task ID for the running query.
-
-        """
-        query_task_id = await self._run_query(
-            session, model.name, explore.name, [dimension.name]
-        )
-        self.query_tasks[query_task_id] = dimension
-        return query_task_id
-
     def _count_explores(self) -> int:
-        """Counts the explores in the LookML project hierarchy.
-
-        Returns:
-            int: The number of explores in the LookML project.
-
-        """
+        """Counts the explores in the LookML project hierarchy."""
         explore_count = 0
         for model in self.project.models:
             explore_count += len(model.explores)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,50 +10,50 @@ TEST_BASE_URL = "https://test.looker.com"
 TEST_CLIENT_ID = "test_client_id"
 TEST_CLIENT_SECRET = "test_client_secret"
 
+
 def get_client_method_names() -> List[str]:
     """Extracts method names from LookerClient to test for bad responses"""
-    client_members: List[Tuple[str, Callable]] = inspect.getmembers(LookerClient, predicate=inspect.isroutine)
-    client_methods: List[str] = [member[0] for member in client_members if not member[0].startswith('__')]
-    for skip_method in ('authenticate', 'cancel_query_task'):
+    client_members: List[Tuple[str, Callable]] = inspect.getmembers(
+        LookerClient, predicate=inspect.isroutine
+    )
+    client_methods: List[str] = [
+        member[0] for member in client_members if not member[0].startswith("__")
+    ]
+    for skip_method in ("authenticate", "cancel_query_task"):
         client_methods.remove(skip_method)
     return client_methods
+
 
 @pytest.fixture
 def client_kwargs():
     return dict(
         authenticate={
-            'client_id': TEST_CLIENT_ID,
-            'client_secret': TEST_CLIENT_SECRET,
-            'api_version': 3.1
+            "client_id": TEST_CLIENT_ID,
+            "client_secret": TEST_CLIENT_SECRET,
+            "api_version": 3.1,
         },
         get_looker_release_version={},
-        update_session={
-            'project': 'project_name',
-            'branch': 'branch_name',
-        },
-        all_lookml_tests={'project': 'project_name'},
-        run_lookml_test={'project': 'project_name'},
+        update_session={"project": "project_name", "branch": "branch_name"},
+        all_lookml_tests={"project": "project_name"},
+        run_lookml_test={"project": "project_name"},
         get_lookml_models={},
-        get_lookml_dimensions={
-            'model': 'model_name',
-            'explore': 'explore_name'
-        },
+        get_lookml_dimensions={"model": "model_name", "explore": "explore_name"},
         create_query={
-            'model': 'model_name',
-            'explore': 'explore_name',
-            'dimensions': ['dimension_a', 'dimension_b']
+            "model": "model_name",
+            "explore": "explore_name",
+            "dimensions": ["dimension_a", "dimension_b"],
         },
-        create_query_task={'query_id': 13041},
-        get_query_task_multi_results={
-            'query_task_ids': ['ajsdkgj', 'askkwk']
-        }
+        create_query_task={"query_id": 13041},
+        get_query_task_multi_results={"query_task_ids": ["ajsdkgj", "askkwk"]},
     )
+
 
 @pytest.fixture
 def client(monkeypatch):
     mock_authenticate = Mock(spec=LookerClient.authenticate)
     monkeypatch.setattr(LookerClient, "authenticate", mock_authenticate)
     return LookerClient(TEST_BASE_URL, TEST_CLIENT_ID, TEST_CLIENT_SECRET)
+
 
 @pytest.fixture
 def mock_404_response():
@@ -64,14 +64,11 @@ def mock_404_response():
     )
     return mock
 
-@patch('spectacles.client.requests.Session.request')
-@pytest.mark.parametrize('method_name', get_client_method_names())
+
+@patch("spectacles.client.requests.Session.request")
+@pytest.mark.parametrize("method_name", get_client_method_names())
 def test_bad_request_raises_connection_error(
-    mock_request,
-    method_name,
-    client,
-    client_kwargs,
-    mock_404_response
+    mock_request, method_name, client, client_kwargs, mock_404_response
 ):
     """Tests each method of LookerClient for how it handles a 404 response"""
     mock_request.return_value = mock_404_response
@@ -79,14 +76,15 @@ def test_bad_request_raises_connection_error(
     with pytest.raises((ApiConnectionError, requests.exceptions.HTTPError)):
         client_method(**client_kwargs[method_name])
 
-@patch('spectacles.client.LookerClient.authenticate')
+
+@patch("spectacles.client.LookerClient.authenticate")
 def test_unsupported_api_version_raises_error(mock_authenticate):
     with pytest.raises(SpectaclesException):
         LookerClient(
             base_url=TEST_BASE_URL,
             client_id=TEST_CLIENT_ID,
             client_secret=TEST_CLIENT_SECRET,
-            api_version=3.0
+            api_version=3.0,
         )
 
 
@@ -103,25 +101,22 @@ def test_authenticate_sets_session_headers(mock_post, monkeypatch):
     assert client.session.headers == {"Authorization": f"token test_access_token"}
 
 
-@patch('spectacles.client.requests.Session.get')
+@patch("spectacles.client.requests.Session.get")
 def test_get_looker_release_version(mock_get, client):
-    mock_get.return_value.json.return_value = {
-        'looker_release_version':
-        '6.24.12'
-    }
+    mock_get.return_value.json.return_value = {"looker_release_version": "6.24.12"}
     version = client.get_looker_release_version()
-    assert version == '6.24.12'
+    assert version == "6.24.12"
 
 
-@patch('spectacles.client.requests.Session.get')
+@patch("spectacles.client.requests.Session.get")
 def test_get_looker_release_version(mock_get, client):
     mock_get.return_value.json.return_value = {
-        'looker_release_version': '6.24.12',
-        'current_version': '6.24.12',
-        'supported_version': ['6.24.10', '6.24.10']
+        "looker_release_version": "6.24.12",
+        "current_version": "6.24.12",
+        "supported_version": ["6.24.10", "6.24.10"],
     }
     version = client.get_looker_release_version()
-    assert version == '6.24.12'
+    assert version == "6.24.12"
 
 
 @patch("spectacles.client.requests.Session.post")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -108,17 +108,6 @@ def test_get_looker_release_version(mock_get, client):
     assert version == "6.24.12"
 
 
-@patch("spectacles.client.requests.Session.get")
-def test_get_looker_release_version(mock_get, client):
-    mock_get.return_value.json.return_value = {
-        "looker_release_version": "6.24.12",
-        "current_version": "6.24.12",
-        "supported_version": ["6.24.10", "6.24.10"],
-    }
-    version = client.get_looker_release_version()
-    assert version == "6.24.12"
-
-
 @patch("spectacles.client.requests.Session.post")
 def test_create_query(mock_post, client):
     QUERY_ID = 124950204921

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -17,7 +17,7 @@ def client(monkeypatch):
 
 
 @pytest.fixture
-def mock_response():
+def mock_404_response():
     mock = Mock(spec=requests.Response)
     mock.status_code = 404
     mock.raise_for_status.side_effect = requests.exceptions.HTTPError(
@@ -27,11 +27,11 @@ def mock_response():
 
 
 @patch("spectacles.client.requests.Session.post")
-def test_bad_authenticate_raises_connection_error(mock_post, mock_response):
-    mock_post.return_value = mock_response
+def test_bad_authenticate_raises_connection_error(mock_post, mock_404_response):
+    mock_post.return_value = mock_404_response
     with pytest.raises(ApiConnectionError):
         LookerClient(TEST_BASE_URL, TEST_CLIENT_ID, TEST_CLIENT_SECRET)
-    mock_response.raise_for_status.assert_called_once()
+    mock_404_response.raise_for_status.assert_called_once()
 
 
 @patch("spectacles.client.requests.Session.post")
@@ -49,41 +49,41 @@ def test_authenticate_sets_session_headers(mock_post, monkeypatch):
 
 @patch("spectacles.client.requests.Session.patch")
 def test_bad_update_session_patch_raises_connection_error(
-    mock_patch, client, mock_response
+    mock_patch, client, mock_404_response
 ):
-    mock_patch.return_value = mock_response
+    mock_patch.return_value = mock_404_response
     with pytest.raises(ApiConnectionError):
         client.update_session(project="test_project", branch="test_branch")
-    mock_response.raise_for_status.assert_called_once()
+    mock_404_response.raise_for_status.assert_called_once()
 
 
 @patch("spectacles.client.requests.Session.patch")
 @patch("spectacles.client.requests.Session.put")
 def test_bad_update_session_put_raises_connection_error(
-    mock_put, mock_patch, client, mock_response
+    mock_put, mock_patch, client, mock_404_response
 ):
-    mock_put.return_value = mock_response
+    mock_put.return_value = mock_404_response
     with pytest.raises(ApiConnectionError):
         client.update_session(project="test_project", branch="test_branch")
-    mock_response.raise_for_status.assert_called_once()
+    mock_404_response.raise_for_status.assert_called_once()
 
 
 @patch("spectacles.client.requests.Session.get")
-def test_bad_get_lookml_models_raises_connection_error(mock_get, client, mock_response):
-    mock_get.return_value = mock_response
+def test_bad_get_lookml_models_raises_connection_error(mock_get, client, mock_404_response):
+    mock_get.return_value = mock_404_response
     with pytest.raises(ApiConnectionError):
         client.get_lookml_models()
-    mock_response.raise_for_status.assert_called_once()
+    mock_404_response.raise_for_status.assert_called_once()
 
 
 @patch("spectacles.client.requests.Session.get")
 def test_bad_get_lookml_dimensions_raises_connection_error(
-    mock_get, client, mock_response
+    mock_get, client, mock_404_response
 ):
-    mock_get.return_value = mock_response
+    mock_get.return_value = mock_404_response
     with pytest.raises(ApiConnectionError):
         client.get_lookml_dimensions(model="test_model", explore="test_explore")
-    mock_response.raise_for_status.assert_called_once()
+    mock_404_response.raise_for_status.assert_called_once()
 
 
 @patch("spectacles.client.requests.Session.post")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,8 +1,6 @@
 from unittest.mock import Mock, patch
 import pytest
 import requests
-import asynctest
-import aiohttp
 from spectacles.client import LookerClient
 from spectacles.exceptions import ApiConnectionError
 
@@ -93,9 +91,7 @@ def test_create_query(mock_post, client):
     QUERY_ID = 124950204921
     mock_post.return_value.json.return_value = {"id": QUERY_ID}
     query_id = client.create_query(
-        "test_model",
-        "test_explore_one",
-        ["dimension_one", "dimension_two"],
+        "test_model", "test_explore_one", ["dimension_one", "dimension_two"]
     )
     assert query_id == QUERY_ID
     mock_post.assert_called_once_with(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -129,17 +129,11 @@ def test_create_query(mock_post, client):
     )
 
 
-@pytest.mark.asyncio
-@asynctest.patch("aiohttp.ClientSession.post")
-async def test_create_query_lacking_dimensions(mock_post, client):
+@patch("spectacles.client.requests.Session.post")
+def test_create_query_lacking_dimensions(mock_post, client):
     QUERY_ID = 124950204921
-    mock_post.return_value.__aenter__.return_value.json = asynctest.CoroutineMock(
-        return_value={"id": QUERY_ID}
-    )
-    async with aiohttp.ClientSession() as session:
-        query_id = await client.create_query(
-            session, "test_model", "test_explore_one", []
-        )
+    mock_post.return_value.json.return_value = {"id": QUERY_ID}
+    query_id = client.create_query("test_model", "test_explore_one", [])
     assert query_id == QUERY_ID
     mock_post.assert_called_once_with(
         url="https://test.looker.com:19999/api/3.1/queries",
@@ -150,4 +144,5 @@ async def test_create_query_lacking_dimensions(mock_post, client):
             "limit": 0,
             "filter_expression": "1=2",
         },
+        timeout=300,
     )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -88,20 +88,15 @@ def test_bad_get_lookml_dimensions_raises_connection_error(
     mock_response.raise_for_status.assert_called_once()
 
 
-@pytest.mark.asyncio
-@asynctest.patch("aiohttp.ClientSession.post")
-async def test_create_query(mock_post, client):
+@patch("spectacles.client.requests.Session.post")
+def test_create_query(mock_post, client):
     QUERY_ID = 124950204921
-    mock_post.return_value.__aenter__.return_value.json = asynctest.CoroutineMock(
-        return_value={"id": QUERY_ID}
+    mock_post.return_value.json.return_value = {"id": QUERY_ID}
+    query_id = client.create_query(
+        "test_model",
+        "test_explore_one",
+        ["dimension_one", "dimension_two"],
     )
-    async with aiohttp.ClientSession() as session:
-        query_id = await client.create_query(
-            session,
-            "test_model",
-            "test_explore_one",
-            ["dimension_one", "dimension_two"],
-        )
     assert query_id == QUERY_ID
     mock_post.assert_called_once_with(
         url="https://test.looker.com:19999/api/3.1/queries",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,20 +1,59 @@
+from typing import List, Callable, Tuple
 from unittest.mock import Mock, patch
 import pytest
 import requests
+import inspect
 from spectacles.client import LookerClient
-from spectacles.exceptions import ApiConnectionError
+from spectacles.exceptions import SpectaclesException, ApiConnectionError
 
 TEST_BASE_URL = "https://test.looker.com"
 TEST_CLIENT_ID = "test_client_id"
 TEST_CLIENT_SECRET = "test_client_secret"
 
+def get_client_method_names() -> List[str]:
+    """Extracts method names from LookerClient to test for bad responses"""
+    client_members: List[Tuple[str, Callable]] = inspect.getmembers(LookerClient, predicate=inspect.isroutine)
+    client_methods: List[str] = [member[0] for member in client_members if not member[0].startswith('__')]
+    for skip_method in ('authenticate', 'cancel_query_task'):
+        client_methods.remove(skip_method)
+    return client_methods
+
+@pytest.fixture
+def client_kwargs():
+    return dict(
+        authenticate={
+            'client_id': TEST_CLIENT_ID,
+            'client_secret': TEST_CLIENT_SECRET,
+            'api_version': 3.1
+        },
+        get_looker_release_version={},
+        update_session={
+            'project': 'project_name',
+            'branch': 'branch_name',
+        },
+        all_lookml_tests={'project': 'project_name'},
+        run_lookml_test={'project': 'project_name'},
+        get_lookml_models={},
+        get_lookml_dimensions={
+            'model': 'model_name',
+            'explore': 'explore_name'
+        },
+        create_query={
+            'model': 'model_name',
+            'explore': 'explore_name',
+            'dimensions': ['dimension_a', 'dimension_b']
+        },
+        create_query_task={'query_id': 13041},
+        get_query_task_multi_results={
+            'query_task_ids': ['ajsdkgj', 'askkwk']
+        }
+    )
 
 @pytest.fixture
 def client(monkeypatch):
     mock_authenticate = Mock(spec=LookerClient.authenticate)
     monkeypatch.setattr(LookerClient, "authenticate", mock_authenticate)
     return LookerClient(TEST_BASE_URL, TEST_CLIENT_ID, TEST_CLIENT_SECRET)
-
 
 @pytest.fixture
 def mock_404_response():
@@ -25,13 +64,30 @@ def mock_404_response():
     )
     return mock
 
+@patch('spectacles.client.requests.Session.request')
+@pytest.mark.parametrize('method_name', get_client_method_names())
+def test_bad_request_raises_connection_error(
+    mock_request,
+    method_name,
+    client,
+    client_kwargs,
+    mock_404_response
+):
+    """Tests each method of LookerClient for how it handles a 404 response"""
+    mock_request.return_value = mock_404_response
+    client_method = getattr(client, method_name)
+    with pytest.raises((ApiConnectionError, requests.exceptions.HTTPError)):
+        client_method(**client_kwargs[method_name])
 
-@patch("spectacles.client.requests.Session.post")
-def test_bad_authenticate_raises_connection_error(mock_post, mock_404_response):
-    mock_post.return_value = mock_404_response
-    with pytest.raises(ApiConnectionError):
-        LookerClient(TEST_BASE_URL, TEST_CLIENT_ID, TEST_CLIENT_SECRET)
-    mock_404_response.raise_for_status.assert_called_once()
+@patch('spectacles.client.LookerClient.authenticate')
+def test_unsupported_api_version_raises_error(mock_authenticate):
+    with pytest.raises(SpectaclesException):
+        LookerClient(
+            base_url=TEST_BASE_URL,
+            client_id=TEST_CLIENT_ID,
+            client_secret=TEST_CLIENT_SECRET,
+            api_version=3.0
+        )
 
 
 @patch("spectacles.client.requests.Session.post")
@@ -47,43 +103,25 @@ def test_authenticate_sets_session_headers(mock_post, monkeypatch):
     assert client.session.headers == {"Authorization": f"token test_access_token"}
 
 
-@patch("spectacles.client.requests.Session.patch")
-def test_bad_update_session_patch_raises_connection_error(
-    mock_patch, client, mock_404_response
-):
-    mock_patch.return_value = mock_404_response
-    with pytest.raises(ApiConnectionError):
-        client.update_session(project="test_project", branch="test_branch")
-    mock_404_response.raise_for_status.assert_called_once()
+@patch('spectacles.client.requests.Session.get')
+def test_get_looker_release_version(mock_get, client):
+    mock_get.return_value.json.return_value = {
+        'looker_release_version':
+        '6.24.12'
+    }
+    version = client.get_looker_release_version()
+    assert version == '6.24.12'
 
 
-@patch("spectacles.client.requests.Session.patch")
-@patch("spectacles.client.requests.Session.put")
-def test_bad_update_session_put_raises_connection_error(
-    mock_put, mock_patch, client, mock_404_response
-):
-    mock_put.return_value = mock_404_response
-    with pytest.raises(ApiConnectionError):
-        client.update_session(project="test_project", branch="test_branch")
-    mock_404_response.raise_for_status.assert_called_once()
-
-
-@patch("spectacles.client.requests.Session.get")
-def test_bad_get_lookml_models_raises_connection_error(mock_get, client, mock_404_response):
-    mock_get.return_value = mock_404_response
-    with pytest.raises(ApiConnectionError):
-        client.get_lookml_models()
-    mock_404_response.raise_for_status.assert_called_once()
-
-
-@patch("spectacles.client.requests.Session.get")
-def test_bad_get_lookml_dimensions_raises_connection_error(
-    mock_get, client, mock_404_response
-):
-    mock_get.return_value = mock_404_response
-    with pytest.raises(ApiConnectionError):
-        client.get_lookml_dimensions(model="test_model", explore="test_explore")
-    mock_404_response.raise_for_status.assert_called_once()
+@patch('spectacles.client.requests.Session.get')
+def test_get_looker_release_version(mock_get, client):
+    mock_get.return_value.json.return_value = {
+        'looker_release_version': '6.24.12',
+        'current_version': '6.24.12',
+        'supported_version': ['6.24.10', '6.24.10']
+    }
+    version = client.get_looker_release_version()
+    assert version == '6.24.12'
 
 
 @patch("spectacles.client.requests.Session.post")
@@ -96,6 +134,7 @@ def test_create_query(mock_post, client):
     assert query_id == QUERY_ID
     mock_post.assert_called_once_with(
         url="https://test.looker.com:19999/api/3.1/queries",
+        timeout=300,
         json={
             "model": "test_model",
             "view": "test_explore_one",

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -72,34 +72,6 @@ def test_build_project(mock_get_models, mock_get_dimensions, project, validator)
     assert validator.project == project
 
 
-@pytest.mark.asyncio
-@asynctest.patch("spectacles.client.LookerClient.get_query_task_multi_results")
-async def test_get_query_results_task_running(
-    mock_get_query_task_multi_results, validator
-):
-    await validator.query_slots.acquire()
-    await validator.running_query_tasks.put("query_task_a")
-    mock_response = {"status": "running"}
-    mock_get_query_task_multi_results.return_value = {"query_task_a": mock_response}
-    errors = validator._get_query_results(["query_task_a"])
-    assert not await errors
-
-
-@pytest.mark.asyncio
-@asynctest.patch("spectacles.client.LookerClient.get_query_task_multi_results")
-async def test_get_query_results_task_complete(
-    mock_get_query_task_multi_results, validator, project
-):
-    await validator.query_slots.acquire()
-    await validator.running_query_tasks.put("query_task_a")
-    lookml_object = project.models[0].explores[0]
-    validator.query_tasks = {"query_task_a": lookml_object}
-    mock_response = {"status": "complete"}
-    mock_get_query_task_multi_results.return_value = {"query_task_a": mock_response}
-    errors = validator._get_query_results(["query_task_a"])
-    assert not await errors
-
-
 def test_extract_error_details_error_dict(validator):
     message = "An error message."
     message_details = "Shocking details."

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -71,6 +71,7 @@ def test_build_project(mock_get_models, mock_get_dimensions, project, validator)
     validator.build_project(selectors=["*/*"])
     assert validator.project == project
 
+
 # If get_query_results returns an error for a mapped query task ID,
 # The corresponding explore should be set to errored and
 # The SqlError instance should be present and validated
@@ -78,30 +79,21 @@ def test_build_project(mock_get_models, mock_get_dimensions, project, validator)
 # TODO: Refactor error responses into fixtures
 # TODO: Should query IDs be ints instead of strings?
 
+
 def test_error_is_set_on_project(project, validator):
-    query_task_id = 'akdk13kkidi2mkv029rld'
-    message = 'An error has occurred'
-    sql = 'SELECT DISTINCT 1 FROM table_name'
-    error_details = {
-        "message": message,
-        "sql": sql,
-    }
+    query_task_id = "akdk13kkidi2mkv029rld"
+    message = "An error has occurred"
+    sql = "SELECT DISTINCT 1 FROM table_name"
+    error_details = {"message": message, "sql": sql}
     validator.project = project
     explore = project.models[0].explores[0]
-    query = Query(
-        query_id='10319',
-        lookml_ref=explore,
-        query_task_id=query_task_id
-    )
+    query = Query(query_id="10319", lookml_ref=explore, query_task_id=query_task_id)
     validator._running_queries.append(query)
-    query_result = QueryResult(query_task_id, status='error', error=error_details)
+    query_result = QueryResult(query_task_id, status="error", error=error_details)
     validator._query_by_task_id[query_task_id] = query
     returned_sql_error = validator._handle_query_result(query_result)
     expected_sql_error = SqlError(
-        path='test_explore_one',
-        url=None,
-        message=message,
-        sql=sql
+        path="test_explore_one", url=None, message=message, sql=sql
     )
     assert returned_sql_error == expected_sql_error
     assert returned_sql_error == explore.error

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -112,9 +112,7 @@ def test_error_is_set_on_project(project, validator):
 def test_cancel_queries(mock_client_cancel, validator):
     """
     Cancelling queries should result in the same number of client calls as
-    query tasks IDs passed in, with the corresponding query task IDs called
-
-    TODO: Use the correct mock method for testing how many times called for each
+    query tasks IDs passed in, with the corresponding query task IDs called.
 
     """
     query_task_ids = ['A', 'B', 'C']

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -120,7 +120,7 @@ def test_cancel_queries(mock_client_cancel, validator):
     query_task_ids = ['A', 'B', 'C']
     validator._cancel_queries(query_task_ids)
     for task_id in query_task_ids:
-        mock_client_cancel.assert_called_with(task_id)
+        mock_client_cancel.assert_any_call(task_id)
 
 
 def test_handle_running_query(validator):

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -2,7 +2,6 @@ from pathlib import Path
 import json
 from unittest.mock import patch, Mock
 import pytest
-import asynctest
 from spectacles.lookml import Project, Model, Explore, Dimension
 from spectacles.client import LookerClient
 from spectacles.validators import SqlValidator

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -108,27 +108,27 @@ def test_error_is_set_on_project(project, validator):
     assert all(dimension.queried for dimension in explore.dimensions)
 
 
-@patch('spectacles.validators.LookerClient.cancel_query_task')
+@patch("spectacles.validators.LookerClient.cancel_query_task")
 def test_cancel_queries(mock_client_cancel, validator):
     """
     Cancelling queries should result in the same number of client calls as
     query tasks IDs passed in, with the corresponding query task IDs called.
 
     """
-    query_task_ids = ['A', 'B', 'C']
+    query_task_ids = ["A", "B", "C"]
     validator._cancel_queries(query_task_ids)
     for task_id in query_task_ids:
         mock_client_cancel.assert_any_call(task_id)
 
 
 def test_handle_running_query(validator):
-    query_task_id = 'sakgwj392jfkajgjcks'
+    query_task_id = "sakgwj392jfkajgjcks"
     query = Query(
-        query_id='19428',
-        lookml_ref=Dimension('dimension_one', 'string', '${TABLE}.dimension_one'),
-        query_task_id=query_task_id
+        query_id="19428",
+        lookml_ref=Dimension("dimension_one", "string", "${TABLE}.dimension_one"),
+        query_task_id=query_task_id,
     )
-    query_result = QueryResult(query_task_id=query_task_id, status='running')
+    query_result = QueryResult(query_task_id=query_task_id, status="running")
     validator._running_queries = [query]
     validator._query_by_task_id[query_task_id] = query
     returned_sql_error = validator._handle_query_result(query_result)
@@ -144,6 +144,7 @@ def test_count_explores(validator, project):
     explore = validator.project.models[0].explores[0]
     validator.project.models[0].explores.extend([explore, explore])
     assert validator._count_explores() == 4
+
 
 def test_extract_error_details_error_dict(validator):
     message = "An error message."


### PR DESCRIPTION
This is a refactor to move to a synchronous approach for API requests. Based on limited testing, this does not increase the runtime of SQL validation but significantly decreases the complexity of the code for ease of maintenance and contribution.