### PR TITLE
Return objects from runner methods, not dictionaries

### DIFF
--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -484,7 +484,7 @@ def run_sql(
         api_version,
         remote_reset,
     )
-    errors = runner.validate_sql(explores, mode, concurrency)
+    project = runner.validate_sql(explores, mode, concurrency)
     if errors:
         for error in sorted(errors, key=lambda x: x["path"]):
             printer.print_sql_error(error)

--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -5,7 +5,7 @@ from yaml.parser import ParserError
 import argparse
 import logging
 import os
-from typing import Callable
+from typing import Callable, Iterable, List
 from spectacles import __version__
 from spectacles.runner import Runner
 from spectacles.client import LookerClient
@@ -484,10 +484,23 @@ def run_sql(
         api_version,
         remote_reset,
     )
+
+    def iter_errors(lookml: List) -> Iterable:
+        for item in lookml:
+            if item.errored:
+                yield item
+
     project = runner.validate_sql(explores, mode, concurrency)
-    if errors:
-        for error in sorted(errors, key=lambda x: x["path"]):
-            printer.print_sql_error(error)
+
+    if project.errored:
+        for model in iter_errors(project.models):
+            for explore in iter_errors(model.explores):
+                if explore.error:
+                    printer.print_sql_error(explore.error)
+                else:
+                    for dimension in iter_errors(explore.dimensions):
+                        printer.print_sql_error(dimension.error)
+
         logger.info("")
         raise ValidationError
     else:

--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -452,7 +452,7 @@ def run_assert(
     )
     errors = runner.validate_data_tests()
     if errors:
-        for error in sorted(errors, key=lambda x: x["path"]):
+        for error in sorted(errors, key=lambda x: x.path):
             printer.print_data_test_error(error)
         logger.info("")
         raise ValidationError

--- a/spectacles/printer.py
+++ b/spectacles/printer.py
@@ -3,7 +3,7 @@ import textwrap
 from typing import List
 import colorama  # type: ignore
 from spectacles.logger import GLOBAL_LOGGER as logger, COLORS
-from spectacles.exceptions import SqlError
+from spectacles.exceptions import SqlError, DataTestError
 
 LINE_WIDTH = 80
 COLOR_CODE_LENGTH = len(colorama.Fore.RED) + len(colorama.Style.RESET_ALL)
@@ -37,9 +37,9 @@ def print_header(text: str, line_width: int = LINE_WIDTH) -> None:
     logger.info(f"\n{header}\n")
 
 
-def print_data_test_error(error: dict) -> None:
-    print_header(red(error["path"]), LINE_WIDTH + COLOR_CODE_LENGTH)
-    wrapped = textwrap.fill(error["message"], LINE_WIDTH)
+def print_data_test_error(error: DataTestError) -> None:
+    print_header(red(error.path), LINE_WIDTH + COLOR_CODE_LENGTH)
+    wrapped = textwrap.fill(error.message, LINE_WIDTH)
     logger.info(wrapped)
 
 

--- a/spectacles/printer.py
+++ b/spectacles/printer.py
@@ -3,6 +3,7 @@ import textwrap
 from typing import List
 import colorama  # type: ignore
 from spectacles.logger import GLOBAL_LOGGER as logger, COLORS
+from spectacles.exceptions import SqlError
 
 LINE_WIDTH = 80
 COLOR_CODE_LENGTH = len(colorama.Fore.RED) + len(colorama.Style.RESET_ALL)
@@ -42,15 +43,15 @@ def print_data_test_error(error: dict) -> None:
     logger.info(wrapped)
 
 
-def print_sql_error(error: dict) -> None:
-    print_header(red(error["path"]), LINE_WIDTH + COLOR_CODE_LENGTH)
-    wrapped = textwrap.fill(error["message"], LINE_WIDTH)
+def print_sql_error(error: SqlError) -> None:
+    print_header(red(error.path), LINE_WIDTH + COLOR_CODE_LENGTH)
+    wrapped = textwrap.fill(error.message, LINE_WIDTH)
     logger.info(wrapped)
     # if error["line_number"]:
     #     sql_context = extract_sql_context(error["sql"], error["line_number"])
     #     logger.info("\n" + sql_context)
-    if error["url"]:
-        logger.info("\n" + f"LookML: {error['url']}")
+    if error.url:
+        logger.info("\n" + f"LookML: {error.url}")
 
 
 def print_validation_result(type: str, source: str):

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -44,8 +44,8 @@ class Runner:
     ) -> List[dict]:
         sql_validator = SqlValidator(self.client, self.project, concurrency)
         sql_validator.build_project(selectors)
-        errors = sql_validator.validate(mode)
-        return [vars(error) for error in errors]
+        project = sql_validator.validate(mode)
+        return project
 
     @log_duration
     def validate_data_tests(self):

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -1,8 +1,9 @@
-from typing import List, Dict
+from typing import List
 from spectacles.client import LookerClient
 from spectacles.validators import SqlValidator, DataTestValidator
 from spectacles.utils import log_duration
 from spectacles.lookml import Project
+from spectacles.exceptions import DataTestError
 
 
 class Runner:
@@ -49,7 +50,7 @@ class Runner:
         return project
 
     @log_duration
-    def validate_data_tests(self) -> List[Dict]:
+    def validate_data_tests(self) -> List[DataTestError]:
         data_test_validator = DataTestValidator(self.client, self.project)
         errors = data_test_validator.validate()
-        return [vars(error) for error in errors]
+        return errors

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -1,7 +1,8 @@
-from typing import List
+from typing import List, Dict
 from spectacles.client import LookerClient
 from spectacles.validators import SqlValidator, DataTestValidator
 from spectacles.utils import log_duration
+from spectacles.lookml import Project
 
 
 class Runner:
@@ -41,14 +42,14 @@ class Runner:
     @log_duration
     def validate_sql(
         self, selectors: List[str], mode: str = "batch", concurrency: int = 10
-    ) -> List[dict]:
+    ) -> Project:
         sql_validator = SqlValidator(self.client, self.project, concurrency)
         sql_validator.build_project(selectors)
         project = sql_validator.validate(mode)
         return project
 
     @log_duration
-    def validate_data_tests(self):
+    def validate_data_tests(self) -> List[Dict]:
         data_test_validator = DataTestValidator(self.client, self.project)
         errors = data_test_validator.validate()
         return [vars(error) for error in errors]


### PR DESCRIPTION
Closes #142.

Changes the Runner validation methods to return native objects (e.g. `spectacles.lookml.Project`) instead of lists of dictionaries.

@DylanBaker, the `validate_data_tests` method only returns a list of `DataTestError` currently because assertions are not directly associated with the LookML structure. I'm curious to know if we should still try and slot these into a Model instead of just returning a list of errors. It may be helpful to have the consistency of always returning a Project object.

This would allow us to break out the `build_project` call and run that at `Runner` instantiation instead of individually for each validator.

FYI, I'm going to leave Project serialization for a separate PR.