### PR TITLE
Adding anonymised Segment tracking

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests==2.22.0
 colorama==0.4.1
 PyYAML==5.1.2
 backoff==1.8.0
+analytics-python==1.2.9

--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -319,6 +319,13 @@ def _build_base_subparser() -> argparse.ArgumentParser:
         default="logs",
         help="The directory that Spectacles will write logs to.",
     )
+    base_subparser.add_argument(
+        "--do-no-track",
+        action=EnvVarAction,
+        env_var="SPECTACLES_LOG_DIR",
+        default="logs",
+        help="The directory that Spectacles will write logs to.",
+    )
 
     return base_subparser
 

--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -185,9 +185,10 @@ def main():
 
     set_file_handler(args.log_dir)
 
-    invocation_id = tracking.track_invocation_start(
-        args.base_url, args.command, args.project
-    )
+    if not args.do_not_track:
+        invocation_id = tracking.track_invocation_start(
+            args.base_url, args.command, args.project
+        )
 
     if args.command == "connect":
         run_connect(
@@ -227,9 +228,10 @@ def main():
             args.import_projects,
         )
 
-    tracking.track_invocation_end(
-        args.base_url, args.command, args.project, invocation_id
-    )
+    if not args.do_not_track:
+        tracking.track_invocation_end(
+            args.base_url, args.command, args.project, invocation_id
+        )
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -320,11 +322,10 @@ def _build_base_subparser() -> argparse.ArgumentParser:
         help="The directory that Spectacles will write logs to.",
     )
     base_subparser.add_argument(
-        "--do-no-track",
-        action=EnvVarAction,
-        env_var="SPECTACLES_LOG_DIR",
-        default="logs",
-        help="The directory that Spectacles will write logs to.",
+        "--do-not-track",
+        action=EnvVarStoreTrueAction,
+        env_var="SPECTACLES_DO_NOT_TRACK",
+        help="Disables anonymised event tracking.",
     )
 
     return base_subparser

--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -12,6 +12,7 @@ from spectacles.client import LookerClient
 from spectacles.exceptions import SpectaclesException, GenericValidationError
 from spectacles.logger import GLOBAL_LOGGER as logger, set_file_handler
 import spectacles.printer as printer
+import spectacles.tracking as tracking
 
 
 class ConfigFileAction(argparse.Action):
@@ -184,6 +185,10 @@ def main():
 
     set_file_handler(args.log_dir)
 
+    invocation_id = tracking.track_invocation_start(
+        args.base_url, args.command, args.project
+    )
+
     if args.command == "connect":
         run_connect(
             args.base_url,
@@ -221,6 +226,10 @@ def main():
             args.remote_reset,
             args.import_projects,
         )
+
+    tracking.track_invocation_end(
+        args.base_url, args.command, args.project, invocation_id
+    )
 
 
 def create_parser() -> argparse.ArgumentParser:

--- a/spectacles/tracking.py
+++ b/spectacles/tracking.py
@@ -10,8 +10,9 @@ def anonymise(trait: str) -> str:
     return trait
 
 
-def track_invocation_start(base_url: str, command: str, project: str) -> str:
-    invocation_id = str(uuid.uuid4())
+def track_invocation_start(
+    base_url: str, command: str, project: str, invocation_id: str = str(uuid.uuid4())
+) -> str:
     url_hash = anonymise(base_url.rstrip("/"))
     project_hash = anonymise(project)
     analytics.track(

--- a/spectacles/tracking.py
+++ b/spectacles/tracking.py
@@ -1,0 +1,42 @@
+import analytics
+import hashlib
+import uuid
+
+analytics.write_key = "QnqzXWlqkmgDSm7X2qFDrxx3LGCW7Rba"
+
+
+def anonymise(trait: str) -> str:
+    trait = hashlib.md5(trait.encode()).hexdigest()
+    return trait
+
+
+def track_invocation_start(base_url: str, command: str, project: str) -> str:
+    invocation_id = str(uuid.uuid4())
+    url_hash = anonymise(base_url.rstrip("/"))
+    project_hash = anonymise(project)
+    analytics.track(
+        user_id=url_hash,
+        event="invocation",
+        properties={
+            "label": "start",
+            "command": command,
+            "project": project_hash,
+            "invocation_id": invocation_id,
+        },
+    )
+    return invocation_id
+
+
+def track_invocation_end(base_url: str, command: str, project: str, invocation_id: str):
+    url_hash = anonymise(base_url.rstrip("/"))
+    project_hash = anonymise(project)
+    analytics.track(
+        user_id=url_hash,
+        event="invocation",
+        properties={
+            "label": "end",
+            "command": command,
+            "project": project_hash,
+            "invocation_id": invocation_id,
+        },
+    )

--- a/spectacles/tracking.py
+++ b/spectacles/tracking.py
@@ -1,4 +1,4 @@
-import analytics
+import analytics  # type: ignore
 import hashlib
 import uuid
 

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -1,0 +1,80 @@
+from spectacles import tracking
+from unittest.mock import patch
+
+
+def test_anonymise_url():
+    hashed_url = tracking.anonymise("https://organisation.looker.com")
+    assert hashed_url == "67d1b18410d23b5765caa3320b703154"
+
+
+def test_anonymise_project():
+    hashed_url = tracking.anonymise("test_project")
+    assert hashed_url == "6e72a69d5c5cca8f0400338441c022e4"
+
+
+@patch("analytics.track")
+def test_track_invocation_start_sql(mock_track):
+    invocation_id = tracking.track_invocation_start(
+        "https://organisation.looker.com", "sql", "test_project", "123456"
+    )
+    mock_track.assert_called_once_with(
+        user_id="67d1b18410d23b5765caa3320b703154",
+        event="invocation",
+        properties={
+            "label": "start",
+            "command": "sql",
+            "project": "6e72a69d5c5cca8f0400338441c022e4",
+            "invocation_id": "123456",
+        },
+    )
+
+
+@patch("analytics.track")
+def test_track_invocation_start_assert(mock_track):
+    invocation_id = tracking.track_invocation_start(
+        "https://organisation.looker.com", "assert", "test_project", "123456"
+    )
+    mock_track.assert_called_once_with(
+        user_id="67d1b18410d23b5765caa3320b703154",
+        event="invocation",
+        properties={
+            "label": "start",
+            "command": "assert",
+            "project": "6e72a69d5c5cca8f0400338441c022e4",
+            "invocation_id": "123456",
+        },
+    )
+
+
+@patch("analytics.track")
+def test_track_invocation_end_sql(mock_track):
+    invocation_id = tracking.track_invocation_end(
+        "https://organisation.looker.com", "sql", "test_project", "123456"
+    )
+    mock_track.assert_called_once_with(
+        user_id="67d1b18410d23b5765caa3320b703154",
+        event="invocation",
+        properties={
+            "label": "end",
+            "command": "sql",
+            "project": "6e72a69d5c5cca8f0400338441c022e4",
+            "invocation_id": "123456",
+        },
+    )
+
+
+@patch("analytics.track")
+def test_track_invocation_end_assert(mock_track):
+    invocation_id = tracking.track_invocation_end(
+        "https://organisation.looker.com", "assert", "test_project", "123456"
+    )
+    mock_track.assert_called_once_with(
+        user_id="67d1b18410d23b5765caa3320b703154",
+        event="invocation",
+        properties={
+            "label": "end",
+            "command": "assert",
+            "project": "6e72a69d5c5cca8f0400338441c022e4",
+            "invocation_id": "123456",
+        },
+    )

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -50,7 +50,7 @@ def test_track_invocation_start_assert(mock_track):
 
 @patch("analytics.track")
 def test_track_invocation_end_sql(mock_track):
-    invocation_id = tracking.track_invocation_end(
+    tracking.track_invocation_end(
         "https://organisation.looker.com", "sql", "test_project", "123456"
     )
     mock_track.assert_called_once_with(
@@ -63,12 +63,11 @@ def test_track_invocation_end_sql(mock_track):
             "invocation_id": "123456",
         },
     )
-    assert invocation_id == "123456"
 
 
 @patch("analytics.track")
 def test_track_invocation_end_assert(mock_track):
-    invocation_id = tracking.track_invocation_end(
+    tracking.track_invocation_end(
         "https://organisation.looker.com", "assert", "test_project", "123456"
     )
     mock_track.assert_called_once_with(
@@ -81,4 +80,3 @@ def test_track_invocation_end_assert(mock_track):
             "invocation_id": "123456",
         },
     )
-    assert invocation_id == "123456"

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -27,6 +27,7 @@ def test_track_invocation_start_sql(mock_track):
             "invocation_id": "123456",
         },
     )
+    assert invocation_id == "123456"
 
 
 @patch("analytics.track")
@@ -44,6 +45,7 @@ def test_track_invocation_start_assert(mock_track):
             "invocation_id": "123456",
         },
     )
+    assert invocation_id == "123456"
 
 
 @patch("analytics.track")
@@ -61,6 +63,7 @@ def test_track_invocation_end_sql(mock_track):
             "invocation_id": "123456",
         },
     )
+    assert invocation_id == "123456"
 
 
 @patch("analytics.track")
@@ -78,3 +81,4 @@ def test_track_invocation_end_assert(mock_track):
             "invocation_id": "123456",
         },
     )
+    assert invocation_id == "123456"


### PR DESCRIPTION
Wanted to create a draft of what tracking might look like. 

I settled on Segment because:
* GA and Heap don't seem to work well with exclusively server-side events
* Snowplow doesn't have a hosted free tier 
* Segment has pretty good free tier for startups with minimal funding

Ultimately, I think I'd like to use Snowplow, but this should be an easy way to get us going. 

I wanted to get eyes on a possible implementation before adding testing/etc. 

@joshtemple @Hawk94 You should have both received an invite to Segment.