### PR TITLE
[Hotfix] Fixed missing argument error in run_sql method

### DIFF
--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -501,7 +501,7 @@ def run_sql(
             if item.errored:
                 yield item
 
-    project = runner.validate_sql(explores, mode, concurrency)
+    project = runner.validate_sql(explores, exclude, mode, concurrency)
 
     if project.errored:
         for model in iter_errors(project.models):


### PR DESCRIPTION
I somehow missed out an argument when resolving conflicts on #172. It doesn't appear to have been caught by the tests. I'm going to review the testing in that area of the CLI, but wanted to merge in the fix more urgently.