### PR TITLE
Fix bug not respecting single or hybrid mode

### DIFF
--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -5,12 +5,12 @@ from yaml.parser import ParserError
 import argparse
 import logging
 import os
-from typing import Callable, Iterable, List, Optional
+from typing import Callable, Iterable, List
 from spectacles import __version__
 from spectacles.runner import Runner
 from spectacles.client import LookerClient
-from spectacles.exceptions import SpectaclesException, ValidationError, SqlError
-from spectacles.logger import GLOBAL_LOGGER as logger, set_file_handler
+from spectacles.exceptions import SpectaclesException, ValidationError
+from spectacles.logger import GLOBAL_LOGGER as logger, set_file_handler, log_sql_error
 import spectacles.printer as printer
 
 
@@ -421,31 +421,6 @@ def _build_assert_subparser(
     )
 
 
-def log_failing_sql(
-    error: SqlError,
-    log_dir: str,
-    model_name: str,
-    explore_name: str,
-    dimension_name: Optional[str] = None,
-):
-
-    file_name = (
-        model_name
-        + "__"
-        + explore_name
-        + ("__" + dimension_name if dimension_name else "")
-        + ".sql"
-    )
-    file_path = Path(log_dir) / "queries" / file_name
-    print(file_path)
-
-    logger.debug(f"Logging failing SQL query for '{error.path}' to '{file_path}'")
-    logger.debug(f"Failing SQL for {error.path}: \n{error.sql}")
-
-    with open(file_path, "w") as file:
-        file.write(error.sql)
-
-
 def run_connect(
     base_url: str, client_id: str, client_secret: str, port: int, api_version: float
 ) -> None:
@@ -513,19 +488,22 @@ def run_sql(
     if project.errored:
         for model in iter_errors(project.models):
             for explore in iter_errors(model.explores):
-                if explore.error:
+                if explore.error and mode == "batch":
                     printer.print_sql_error(explore.error)
-                    log_failing_sql(explore.error, log_dir, model.name, explore.name)
+                    file_path = log_sql_error(
+                        explore.error, log_dir, model.name, explore.name
+                    )
                 else:
                     for dimension in iter_errors(explore.dimensions):
-                        printer.print_sql_error(dimension.error)
-                        log_failing_sql(
+                        file_path = log_sql_error(
                             dimension.error,
                             log_dir,
                             model.name,
                             explore.name,
                             dimension.name,
                         )
+                        printer.print_sql_error(dimension.error)
+                logger.info("\n" + f"Test SQL: {file_path}")
 
         logger.info("")
         raise ValidationError

--- a/spectacles/logger.py
+++ b/spectacles/logger.py
@@ -1,6 +1,8 @@
+from typing import Optional
 from pathlib import Path
 import logging
 import colorama  # type: ignore
+from spectacles.exceptions import SqlError
 
 LOG_FILENAME = "spectacles.log"
 COLORS = {
@@ -52,3 +54,29 @@ class FileFormatter(logging.Formatter):
         message = super().format(record=record)
         formatted = delete_color_codes(message)
         return formatted
+
+
+def log_sql_error(
+    error: SqlError,
+    log_dir: str,
+    model_name: str,
+    explore_name: str,
+    dimension_name: Optional[str] = None,
+) -> Path:
+
+    file_name = (
+        model_name
+        + "__"
+        + explore_name
+        + ("__" + dimension_name if dimension_name else "")
+        + ".sql"
+    )
+    file_path = Path(log_dir) / "queries" / file_name
+
+    logger.debug(f"Logging failing SQL query for '{error.path}' to '{file_path}'")
+    logger.debug(f"Failing SQL for {error.path}: \n{error.sql}")
+
+    with open(file_path, "w") as file:
+        file.write(error.sql)
+
+    return file_path

--- a/spectacles/validators.py
+++ b/spectacles/validators.py
@@ -332,7 +332,7 @@ class SqlValidator(Validator):
         for dimension in explore.dimensions:
             query = self.client.create_query(model_name, explore.name, [dimension.name])
             query = Query(
-                query["id"], lookml_ref=explore, explore_url=query["share_url"]
+                query["id"], lookml_ref=dimension, explore_url=query["share_url"]
             )
             queries.append(query)
         return queries

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,8 @@
 from unittest.mock import patch
 import pytest
 from constants import ENV_VARS
-from pathlib import Path
-from spectacles.cli import main, create_parser, handle_exceptions, log_failing_sql
-from spectacles.exceptions import SpectaclesException, ValidationError, SqlError
+from spectacles.cli import main, create_parser, handle_exceptions
+from spectacles.exceptions import SpectaclesException, ValidationError
 
 
 @pytest.fixture
@@ -182,51 +181,3 @@ def test_bad_config_file_parameter(mock_parse_config, clean_env, parser):
 def test_parse_remote_reset_with_assert(env, parser):
     args = parser.parse_args(["assert", "--remote-reset"])
     assert args.remote_reset
-
-
-def test_logging_failing_explore_sql(tmpdir):
-    error = SqlError(
-        path="example_explore",
-        message="example error message",
-        sql="select example_explore.example_dimension_1 from model",
-        explore_url="https://example.looker.com/x/12345",
-    )
-
-    query_directory = Path(tmpdir / "queries")
-    query_directory.mkdir(exist_ok=True)
-    query_file = Path(query_directory / "explore_model__example_explore.sql")
-
-    log_failing_sql(error, tmpdir, "explore_model", "example_explore")
-    content = open(query_file).read()
-
-    assert Path.exists(query_file)
-    assert content == "select example_explore.example_dimension_1 from model"
-
-
-def test_logging_failing_dimension_sql(tmpdir):
-    error = SqlError(
-        path="example_explore",
-        message="example error message",
-        sql="select example_explore.example_dimension_1 from model",
-        explore_url="https://example.looker.com/x/12345",
-    )
-
-    query_directory = Path(tmpdir / "queries")
-    query_directory.mkdir(exist_ok=True)
-    query_file = (
-        query_directory
-        / "explore_model__example_explore__example_explore.example_dimension_1.sql"
-    )
-
-    log_failing_sql(
-        error,
-        tmpdir,
-        "explore_model",
-        "example_explore",
-        "example_explore.example_dimension_1",
-    )
-
-    content = open(query_file).read()
-
-    assert content == "select example_explore.example_dimension_1 from model"
-    assert Path.exists(query_file)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+from spectacles.logger import log_sql_error
+from spectacles.exceptions import SqlError
+
+
+def test_logging_failing_explore_sql(tmpdir):
+    error = SqlError(
+        path="example_explore",
+        message="example error message",
+        sql="select example_explore.example_dimension_1 from model",
+        explore_url="https://example.looker.com/x/12345",
+    )
+
+    query_directory = Path(tmpdir / "queries")
+    query_directory.mkdir(exist_ok=True)
+    query_file = Path(query_directory / "explore_model__example_explore.sql")
+
+    log_sql_error(error, tmpdir, "explore_model", "example_explore")
+    content = open(query_file).read()
+
+    assert Path.exists(query_file)
+    assert content == "select example_explore.example_dimension_1 from model"
+
+
+def test_logging_failing_dimension_sql(tmpdir):
+    error = SqlError(
+        path="example_explore",
+        message="example error message",
+        sql="select example_explore.example_dimension_1 from model",
+        explore_url="https://example.looker.com/x/12345",
+    )
+
+    query_directory = Path(tmpdir / "queries")
+    query_directory.mkdir(exist_ok=True)
+    query_file = (
+        query_directory
+        / "explore_model__example_explore__example_explore.example_dimension_1.sql"
+    )
+
+    log_sql_error(
+        error,
+        tmpdir,
+        "explore_model",
+        "example_explore",
+        "example_explore.example_dimension_1",
+    )
+
+    content = open(query_file).read()
+
+    assert content == "select example_explore.example_dimension_1 from model"
+    assert Path.exists(query_file)


### PR DESCRIPTION
This PR introduces a few fixes:

- Moves `log_failing_sql` so it sits in `logger.py`, adds a separate test module for log testing, and prepends "Test SQL: " before the filename in the output so it's clear what the path is for.
- Fixes a bug where dimension queries were referencing their explores, not dimensions, effectively breaking single mode.
- Fixes another bug in cli.py where the dimension-level errors were not being printed in hybrid mode.