### PR TITLE
Add batch mode help message

### DIFF
--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -562,9 +562,8 @@ def run_sql(
             )
         if mode == "batch":
             logger.info(
-                f"\nTo determine the exact dimensions responsible for {'this error' if project.number_of_errors == 1 else 'these errors'}, "
-                "you can re-run this explore \n"
-                "in single-dimension mode, with `--mode single`.\n\n"
+                f"\n\nTo determine the exact dimensions responsible for {'this error' if project.number_of_errors == 1 else 'these errors'}, "
+                f"you can re-run Spectacles in single-dimension mode, with `--mode single`.\n\n"
                 "You can also run this original validation with `--mode hybrid` to do this automatically."
             )
 

--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -563,7 +563,7 @@ def run_sql(
         if mode == "batch":
             logger.info(
                 f"\n\nTo determine the exact dimensions responsible for {'this error' if project.number_of_errors == 1 else 'these errors'}, "
-                f"you can re-run Spectacles in single-dimension mode, with `--mode single`.\n\n"
+                f"you can re-run \nSpectacles in single-dimension mode, with `--mode single`.\n\n"
                 "You can also run this original validation with `--mode hybrid` to do this automatically."
             )
 

--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -560,6 +560,14 @@ def run_sql(
                 dimension=error["metadata"].get("dimension"),
                 lookml_url=error["metadata"].get("lookml_url"),
             )
+        if mode == "batch":
+            logger.info(
+                f"\nTo determine the exact dimensions responsible for {'this error' if project.number_of_errors == 1 else 'these errors'}, "
+                "you can re-run this explore \n"
+                "in single-dimension mode, with `--mode single`.\n\n"
+                "You can also run this original validation with `--mode hybrid` to do this automatically."
+            )
+
         logger.info("")
         raise GenericValidationError
     else:

--- a/spectacles/lookml.py
+++ b/spectacles/lookml.py
@@ -131,6 +131,19 @@ class Explore(LookMlObject):
     def add_dimension(self, dimension: Dimension):
         self.dimensions.append(dimension)
 
+    @property
+    def number_of_errors(self):
+        if self.errored:
+            if self.error:
+                errors = 1
+            else:
+                errors = len(
+                    [dimension for dimension in self.dimensions if dimension.errored]
+                )
+            return errors
+        else:
+            return 0
+
 
 class Model(LookMlObject):
     def __init__(self, name: str, project_name: str, explores: List[Explore]):
@@ -193,6 +206,12 @@ class Model(LookMlObject):
             Explore.from_json(d, model_name=name) for d in json_dict["explores"]
         ]
         return cls(name, project, explores)
+
+    @property
+    def number_of_errors(self):
+        return sum(
+            [explore.number_of_errors for explore in self.explores if explore.errored]
+        )
 
 
 class Project(LookMlObject):
@@ -272,3 +291,10 @@ class Project(LookMlObject):
             "tested": tested,
             "errors": errors,
         }
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(name={self.name}, models={self.models})"
+
+    @property
+    def number_of_errors(self):
+        return sum([model.number_of_errors for model in self.models if model.errored])

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -113,3 +113,36 @@ def test_parent_queried_behavior_should_depend_on_its_child(
         assert parent.queried is True
         children.append(b)
         assert parent.queried is True
+
+
+def test_comparison_to_mismatched_type_object_fails(dimension, explore, model, project):
+    assert dimension != 1
+    assert explore != 1
+    assert model != 1
+    assert project != 1
+
+
+def test_explore_number_of_errors_batch_with_errors(dimension, explore, sql_error):
+    explore.dimensions = [dimension]
+    explore.queried = True
+    explore.error = sql_error
+    assert explore.number_of_errors == 1
+
+
+def test_explore_number_of_errors_batch_with_no_errors(dimension, explore, sql_error):
+    explore.dimensions = [dimension]
+    explore.queried = True
+    assert explore.number_of_errors == 0
+
+
+def test_explore_number_of_errors_single_with_errors(dimension, explore, sql_error):
+    dimension.error = sql_error
+    dimension.queried = True
+    explore.dimensions = [dimension, dimension]
+    assert explore.number_of_errors == 2
+
+
+def test_explore_number_of_errors_single_with_no_errors(dimension, explore, sql_error):
+    dimension.queried = True
+    explore.dimensions = [dimension, dimension]
+    assert explore.number_of_errors == 0

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -146,3 +146,81 @@ def test_explore_number_of_errors_single_with_no_errors(dimension, explore, sql_
     dimension.queried = True
     explore.dimensions = [dimension, dimension]
     assert explore.number_of_errors == 0
+
+
+def test_model_number_of_errors_batch_with_errors(dimension, explore, model, sql_error):
+    explore.dimensions = [dimension]
+    explore.queried = True
+    explore.error = sql_error
+    model.explores = [explore, explore]
+    assert model.number_of_errors == 2
+
+
+def test_model_number_of_errors_batch_with_no_errors(
+    dimension, explore, model, sql_error
+):
+    explore.dimensions = [dimension]
+    explore.queried = True
+    model.explores = [explore, explore]
+    assert model.number_of_errors == 0
+
+
+def test_model_number_of_errors_single_with_errors(
+    dimension, explore, model, sql_error
+):
+    dimension.error = sql_error
+    explore.dimensions = [dimension, dimension]
+    explore.queried = True
+    model.explores = [explore, explore]
+    assert model.number_of_errors == 4
+
+
+def test_model_number_of_errors_single_with_no_errors(
+    dimension, explore, model, sql_error
+):
+    explore.dimensions = [dimension, dimension]
+    explore.queried = True
+    model.explores = [explore, explore]
+    assert model.number_of_errors == 0
+
+
+def test_project_number_of_errors_batch_with_errors(
+    dimension, explore, model, project, sql_error
+):
+    explore.dimensions = [dimension]
+    explore.queried = True
+    explore.error = sql_error
+    model.explores = [explore, explore]
+    project.models = [model]
+    assert project.number_of_errors == 2
+
+
+def test_project_number_of_errors_batch_with_no_errors(
+    dimension, explore, model, project, sql_error
+):
+    explore.dimensions = [dimension]
+    explore.queried = True
+    model.explores = [explore, explore]
+    project.models = [model]
+    assert project.number_of_errors == 0
+
+
+def test_project_number_of_errors_single_with_errors(
+    dimension, explore, model, project, sql_error
+):
+    dimension.error = sql_error
+    explore.dimensions = [dimension, dimension]
+    explore.queried = True
+    model.explores = [explore, explore]
+    project.models = [model, model]
+    assert project.number_of_errors == 8
+
+
+def test_project_number_of_errors_single_with_no_errors(
+    dimension, explore, model, project, sql_error
+):
+    explore.dimensions = [dimension, dimension]
+    explore.queried = True
+    model.explores = [explore, explore]
+    project.models = [model, model]
+    assert project.number_of_errors == 0


### PR DESCRIPTION
closes #132 

@joshtemple This PR adds a message at the end of errored batch runs to suggest they run in single or hybrid mode.

In order to figure out the plurals in the error message, I've added `number_of_errors` properties to the LookML objects. This could have been achieved with a count in the CLI, but I figured there is value in having those properties.

[examples below]