### PR TITLE
Make client methods have one-to-one relationship with API endpoints

### DIFF
--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -132,7 +132,7 @@ class LookerClient:
         response = self.session.patch(url=url, json=body, timeout=TIMEOUT_SEC)
         try:
             response.raise_for_status()
-        except requests.exceptions.HTTPError as error:
+        except requests.exceptions.HTTPError:
             raise LookerApiError(
                 name="unable-to-update-workspace",
                 title="Couldn't update the session's workspace.",
@@ -159,7 +159,7 @@ class LookerClient:
         response = self.session.put(url=url, json=body, timeout=TIMEOUT_SEC)
         try:
             response.raise_for_status()
-        except requests.exceptions.HTTPError as error:
+        except requests.exceptions.HTTPError:
             raise LookerApiError(
                 name="unable-to-checkout-branch",
                 title="Couldn't checkout Git branch.",
@@ -186,7 +186,7 @@ class LookerClient:
         response = self.session.post(url=url, timeout=TIMEOUT_SEC)
         try:
             response.raise_for_status()
-        except requests.exceptions.HTTPError as error:
+        except requests.exceptions.HTTPError:
             raise LookerApiError(
                 name="unable-to-reset-remote",
                 title="Couldn't checkout Git branch.",

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -25,7 +25,7 @@ def manage_dependent_branches(fn: Callable) -> Callable:
             response = fn(self, *args, **kwargs)
 
             for project in local_dependencies:
-                self.client.update_branch(project["name"], project["active_branch"])
+                self.client.checkout_branch(project["name"], project["active_branch"])
                 self.client.delete_branch(project["name"], project["temp_branch"])
 
         else:

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -25,7 +25,7 @@ def manage_dependent_branches(fn: Callable) -> Callable:
             response = fn(self, *args, **kwargs)
 
             for project in local_dependencies:
-                self.client.update_session(project["name"], project["active_branch"])
+                self.client.update_branch(project["name"], project["active_branch"])
                 self.client.delete_branch(project["name"], project["temp_branch"])
 
         else:
@@ -70,7 +70,13 @@ class Runner:
         self.client = LookerClient(
             base_url, client_id, client_secret, port, api_version
         )
-        self.client.update_session(project, branch, remote_reset)
+        if branch == "master":
+            self.client.update_workspace(project, "production")
+        else:
+            self.client.update_workspace(project, "dev")
+            self.client.checkout_branch(project, branch)
+            if remote_reset:
+                self.client.reset_to_remote(project)
 
     @manage_dependent_branches
     @log_duration

--- a/tests/cassettes/init_runner.yaml
+++ b/tests/cassettes/init_runner.yaml
@@ -1,0 +1,470 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/login
+  response:
+    body:
+      string: '{"access_token":"BrBWFhsfXkJbtbZJyqsvGP54nYSJtX5byJ4n4Ngz","token_type":"Bearer","expires_in":3600}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 02 May 2020 21:16:32 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/versions
+  response:
+    body:
+      string: '{"looker_release_version":"7.6.17","current_version":{"version":"3.1","full_version":"3.1.0","status":"current","swagger_url":"https://spectacles.looker.com:19999/api/3.1/swagger.json"},"supported_versions":[{"version":"2.99","full_version":"2.99.0","status":"internal_test","swagger_url":"https://spectacles.looker.com:19999/api/2.99/swagger.json"},{"version":"3.0","full_version":"3.0.0","status":"legacy","swagger_url":"https://spectacles.looker.com:19999/api/3.0/swagger.json"},{"version":"3.1","full_version":"3.1.0","status":"current","swagger_url":"https://spectacles.looker.com:19999/api/3.1/swagger.json"},{"version":"4.0","full_version":"4.0.7.6","status":"experimental","swagger_url":"https://spectacles.looker.com:19999/api/4.0/swagger.json"}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '756'
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 02 May 2020 21:16:32 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 02 May 2020 21:16:32 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - looker.browser=1155; expires=Tue, 02 May 2023 21:16:32 -0000; HttpOnly
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "pytest"}'
+    headers:
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=1155
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
+  response:
+    body:
+      string: '{"name":"pytest","remote":"origin","remote_name":"pytest","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1588340597,"ref":"176721285e47e0adac1b3ff55a26ca0346d5bfc7","remote_ref":"176721285e47e0adac1b3ff55a26ca0346d5bfc7","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '363'
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 02 May 2020 21:16:33 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/login
+  response:
+    body:
+      string: '{"access_token":"TXYG5Hq8nYJBmkTYpB6drddypCT8mPk8t8XW2dwm","token_type":"Bearer","expires_in":3600}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 02 May 2020 21:23:21 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/versions
+  response:
+    body:
+      string: '{"looker_release_version":"7.6.17","current_version":{"version":"3.1","full_version":"3.1.0","status":"current","swagger_url":"https://spectacles.looker.com:19999/api/3.1/swagger.json"},"supported_versions":[{"version":"2.99","full_version":"2.99.0","status":"internal_test","swagger_url":"https://spectacles.looker.com:19999/api/2.99/swagger.json"},{"version":"3.0","full_version":"3.0.0","status":"legacy","swagger_url":"https://spectacles.looker.com:19999/api/3.0/swagger.json"},{"version":"3.1","full_version":"3.1.0","status":"current","swagger_url":"https://spectacles.looker.com:19999/api/3.1/swagger.json"},{"version":"4.0","full_version":"4.0.7.6","status":"experimental","swagger_url":"https://spectacles.looker.com:19999/api/4.0/swagger.json"}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '756'
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 02 May 2020 21:23:21 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 02 May 2020 21:23:22 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - looker.browser=1159; expires=Tue, 02 May 2023 21:23:22 -0000; HttpOnly
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "pytest"}'
+    headers:
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=1159
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
+  response:
+    body:
+      string: '{"name":"pytest","remote":"origin","remote_name":"pytest","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1588340597,"ref":"176721285e47e0adac1b3ff55a26ca0346d5bfc7","remote_ref":"176721285e47e0adac1b3ff55a26ca0346d5bfc7","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '363'
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 02 May 2020 21:23:22 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=1159
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"message":"An error has occurred.","documentation_url":"http://docs.looker.com/"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '82'
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 02 May 2020 21:23:22 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 500
+      message: Internal Server Error
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/login
+  response:
+    body:
+      string: '{"access_token":"Q6C846vwrJT7mbRhMfZzg3sppzvmhvVKkXjbS4ZS","token_type":"Bearer","expires_in":3600}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 02 May 2020 21:24:06 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/versions
+  response:
+    body:
+      string: '{"looker_release_version":"7.6.17","current_version":{"version":"3.1","full_version":"3.1.0","status":"current","swagger_url":"https://spectacles.looker.com:19999/api/3.1/swagger.json"},"supported_versions":[{"version":"2.99","full_version":"2.99.0","status":"internal_test","swagger_url":"https://spectacles.looker.com:19999/api/2.99/swagger.json"},{"version":"3.0","full_version":"3.0.0","status":"legacy","swagger_url":"https://spectacles.looker.com:19999/api/3.0/swagger.json"},{"version":"3.1","full_version":"3.1.0","status":"current","swagger_url":"https://spectacles.looker.com:19999/api/3.1/swagger.json"},{"version":"4.0","full_version":"4.0.7.6","status":"experimental","swagger_url":"https://spectacles.looker.com:19999/api/4.0/swagger.json"}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '756'
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 02 May 2020 21:24:06 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 02 May 2020 21:24:06 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - looker.browser=1160; expires=Tue, 02 May 2023 21:24:06 -0000; HttpOnly
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "pytest"}'
+    headers:
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=1160
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
+  response:
+    body:
+      string: '{"name":"pytest","remote":"origin","remote_name":"pytest","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1588340597,"ref":"176721285e47e0adac1b3ff55a26ca0346d5bfc7","remote_ref":"176721285e47e0adac1b3ff55a26ca0346d5bfc7","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '363'
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 02 May 2020 21:24:07 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=1160
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"message":"An error has occurred.","documentation_url":"http://docs.looker.com/"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '82'
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 02 May 2020 21:24:07 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 500
+      message: Internal Server Error
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=1160
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"message":"An error has occurred.","documentation_url":"http://docs.looker.com/"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '82'
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 02 May 2020 21:24:07 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 500
+      message: Internal Server Error
+version: 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ def looker_client(record_mode) -> Iterable[LookerClient]:
             client_id=os.environ.get("LOOKER_CLIENT_ID", ""),
             client_secret=os.environ.get("LOOKER_CLIENT_SECRET", ""),
         )
-        client.update_session(project="eye_exam", branch="master", remote_reset=False)
+        client.update_workspace(project="eye_exam", workspace="production")
         yield client
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from spectacles.client import LookerClient
 from spectacles.exceptions import SqlError
 from spectacles.lookml import Project, Model, Explore, Dimension
 from tests.utils import load_resource
+from spectacles.runner import Runner
 
 
 @pytest.fixture(scope="session")
@@ -28,6 +29,24 @@ def looker_client(record_mode) -> Iterable[LookerClient]:
         )
         client.update_workspace(project="eye_exam", workspace="production")
         yield client
+
+
+@pytest.fixture(scope="session")
+def runner(record_mode) -> Iterable[Runner]:
+    with vcr.use_cassette(
+        "tests/cassettes/init_runner.yaml",
+        filter_post_data_parameters=["client_id", "client_secret"],
+        filter_headers=["Authorization"],
+        record_mode=record_mode,
+    ):
+        runner = Runner(
+            project="eye_exam",
+            branch="pytest",
+            base_url="https://spectacles.looker.com",
+            client_id=os.environ.get("LOOKER_CLIENT_ID", ""),
+            client_secret=os.environ.get("LOOKER_CLIENT_SECRET", ""),
+        )
+        yield runner
 
 
 @pytest.fixture

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -40,7 +40,9 @@ def client_kwargs():
     return dict(
         authenticate={"client_id": "", "client_secret": "", "api_version": 3.1},
         get_looker_release_version={},
-        update_session={"project": "project_name", "branch": "branch_name"},
+        update_workspace={"project": "project_name", "workspace": "dev"},
+        checkout_branch={"project": "project_name", "branch": "branch_name"},
+        reset_to_remote={"project": "project_name"},
         all_lookml_tests={"project": "project_name"},
         run_lookml_test={"project": "project_name"},
         get_lookml_models={},
@@ -63,10 +65,9 @@ def client_kwargs():
 @pytest.mark.vcr(match_on=["uri", "method", "raw_body"])
 def test_branch_management_should_work(looker_client):
     project = "eye_exam"
-    tmp_branch = "tmp-pytest"
-    looker_client.update_session(
-        project="eye_exam", branch="pytest", remote_reset=False
-    )
+    tmp_branch = f"tmp-pytest"
+    looker_client.update_workspace(project=project, workspace="dev")
+    looker_client.checkout_branch(project=project, branch="pytest")
     looker_client.create_branch("eye_exam", tmp_branch)
     try:
         looker_client.update_branch(project, tmp_branch, "master")
@@ -76,7 +77,7 @@ def test_branch_management_should_work(looker_client):
         # Return to the master branch and delete the temp branch
         looker_client.update_branch(project, "master")
         looker_client.delete_branch(project, tmp_branch)
-    looker_client.update_session(project=project, branch="master", remote_reset=False)
+    looker_client.update_workspace(project=project, workspace="production")
 
 
 @pytest.mark.vcr

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,15 @@
+import pytest
+from spectacles.runner import Runner
+from spectacles.exceptions import ApiConnectionError
+
+
+def test_validate_sql_with_import_projects_error(runner):
+    runner.import_projects = True
+    with pytest.raises(ApiConnectionError):
+        runner.validate_sql(["*/*"], [])
+
+
+def test_validate_assert_with_import_projects_error(runner):
+    runner.import_projects = True
+    with pytest.raises(ApiConnectionError):
+        runner.validate_sql()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,14 +1,14 @@
 import pytest
-from spectacles.exceptions import ApiConnectionError
+from spectacles.exceptions import LookerApiError
 
 
 def test_validate_sql_with_import_projects_error(runner):
     runner.import_projects = True
-    with pytest.raises(ApiConnectionError):
+    with pytest.raises(LookerApiError):
         runner.validate_sql(["*/*"], [])
 
 
 def test_validate_assert_with_import_projects_error(runner):
     runner.import_projects = True
-    with pytest.raises(ApiConnectionError):
+    with pytest.raises(LookerApiError):
         runner.validate_sql()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,5 +1,4 @@
 import pytest
-from spectacles.runner import Runner
 from spectacles.exceptions import ApiConnectionError
 
 

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -56,8 +56,8 @@ class TestBuildUnconfiguredProject:
 
     def test_project_with_no_configured_models_should_raise_error(self, validator):
         validator.project.name = "eye_exam_unconfigured"
-        validator.client.update_session(
-            project="eye_exam_unconfigured", branch="master", remote_reset=False
+        validator.client.update_workspace(
+            project="eye_exam_unconfigured", workspace="production"
         )
         with pytest.raises(SpectaclesException):
             validator.build_project()


### PR DESCRIPTION
This PR gets rid of the `update_session` method and creates:
* `checkout_branch`
* `update_workspace`
* `reset_to_remote`

It updates the Runner accordingly.

closes #96 