### PR TITLE
Ignore 'warning' errors and report all errors

### DIFF
--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -534,17 +534,21 @@ def run_sql(
         for model in iter_errors(project.models):
             for explore in iter_errors(model.explores):
                 if explore.errors and mode == "batch":
+                    file_path = log_sql_error(
+                        explore.errors, log_dir, model.name, explore.name
+                    )
                     for error in explore.errors:
                         printer.print_sql_error(error)
-                        file_path = log_sql_error(
-                            error, log_dir, model.name, explore.name
-                        )
                 else:
                     for dimension in iter_errors(explore.dimensions):
+                        file_path = log_sql_error(
+                            dimension.errors,
+                            log_dir,
+                            model.name,
+                            explore.name,
+                            dimension.name,
+                        )
                         for error in dimension.errors:
-                            file_path = log_sql_error(
-                                error, log_dir, model.name, explore.name, dimension.name
-                            )
                             printer.print_sql_error(error)
                 logger.info("\n" + f"Test SQL: {file_path}")
 

--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -533,21 +533,19 @@ def run_sql(
     if project.errored:
         for model in iter_errors(project.models):
             for explore in iter_errors(model.explores):
-                if explore.error and mode == "batch":
-                    printer.print_sql_error(explore.error)
-                    file_path = log_sql_error(
-                        explore.error, log_dir, model.name, explore.name
-                    )
+                if explore.errors and mode == "batch":
+                    for error in explore.errors:
+                        printer.print_sql_error(error)
+                        file_path = log_sql_error(
+                            error, log_dir, model.name, explore.name
+                        )
                 else:
                     for dimension in iter_errors(explore.dimensions):
-                        file_path = log_sql_error(
-                            dimension.error,
-                            log_dir,
-                            model.name,
-                            explore.name,
-                            dimension.name,
-                        )
-                        printer.print_sql_error(dimension.error)
+                        for error in dimension.errors:
+                            file_path = log_sql_error(
+                                error, log_dir, model.name, explore.name, dimension.name
+                            )
+                            printer.print_sql_error(error)
                 logger.info("\n" + f"Test SQL: {file_path}")
 
         logger.info("")

--- a/spectacles/logger.py
+++ b/spectacles/logger.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 from pathlib import Path
 import logging
 import colorama  # type: ignore
@@ -57,7 +57,7 @@ class FileFormatter(logging.Formatter):
 
 
 def log_sql_error(
-    error: SqlError,
+    errors: List[SqlError],
     log_dir: str,
     model_name: str,
     explore_name: str,
@@ -72,6 +72,8 @@ def log_sql_error(
         + ".sql"
     )
     file_path = Path(log_dir) / "queries" / file_name
+
+    error = errors[0]
 
     logger.debug(f"Logging failing SQL query for '{error.path}' to '{file_path}'")
     logger.debug(f"Failing SQL for {error.path}: \n{error.sql}")

--- a/spectacles/lookml.py
+++ b/spectacles/lookml.py
@@ -15,7 +15,7 @@ class Dimension(LookMlObject):
         self.sql = sql
         self.url = url
         self.queried: bool = False
-        self.error: Optional[SqlError] = None
+        self.errors: Optional[List[SqlError]] = None
         if re.search(r"spectacles\s*:\s*ignore", sql, re.IGNORECASE):
             self.ignore = True
         else:
@@ -40,7 +40,7 @@ class Dimension(LookMlObject):
 
     @property
     def errored(self):
-        return bool(self.error) if self.queried else None
+        return bool(self.errors) if self.queried else None
 
     @errored.setter
     def errored(self, value):
@@ -64,7 +64,7 @@ class Explore(LookMlObject):
         self.name = name
         self.dimensions = [] if dimensions is None else dimensions
         self.queried: bool = False
-        self.error: Optional[SqlError] = None
+        self.errors: Optional[List[SqlError]] = None
 
     def __eq__(self, other):
         if not isinstance(other, Explore):
@@ -75,7 +75,7 @@ class Explore(LookMlObject):
     @property
     def errored(self):
         if self.queried:
-            return bool(self.error) or any(
+            return bool(self.errors) or any(
                 dimension.errored for dimension in self.dimensions
             )
         else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -181,3 +181,37 @@ def test_bad_config_file_parameter(mock_parse_config, clean_env, parser):
 def test_parse_remote_reset_with_assert(env, parser):
     args = parser.parse_args(["assert", "--remote-reset"])
     assert args.remote_reset
+
+
+@patch("spectacles.cli.run_sql")
+def test_main_with_sql_command(run_sql, env, monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        ["spectacles", "sql", "--project", "project_name", "--branch", "branch_name"],
+    )
+    main()
+    run_sql.assert_called_once()
+
+
+@patch("spectacles.cli.run_assert")
+def test_main_with_assert_command(run_assert, env, monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "spectacles",
+            "assert",
+            "--project",
+            "project_name",
+            "--branch",
+            "branch_name",
+        ],
+    )
+    main()
+    run_assert.assert_called_once()
+
+
+@patch("spectacles.cli.run_connect")
+def test_main_with_connect_command(run_connect, env, monkeypatch):
+    monkeypatch.setattr("sys.argv", ["spectacles", "connect"])
+    main()
+    run_connect.assert_called_once()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -15,7 +15,7 @@ def test_logging_failing_explore_sql(tmpdir):
     query_directory.mkdir(exist_ok=True)
     query_file = Path(query_directory / "explore_model__example_explore.sql")
 
-    log_sql_error(error, tmpdir, "explore_model", "example_explore")
+    log_sql_error([error], tmpdir, "explore_model", "example_explore")
     content = open(query_file).read()
 
     assert Path.exists(query_file)
@@ -38,7 +38,7 @@ def test_logging_failing_dimension_sql(tmpdir):
     )
 
     log_sql_error(
-        error,
+        [error],
         tmpdir,
         "explore_model",
         "example_explore",

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -106,7 +106,7 @@ def test_dimensions_with_different_sql_can_be_equal():
 
 def test_dimension_should_not_be_errored_if_not_queried(dimension, sql_error):
     assert dimension.errored is None
-    dimension.error = sql_error
+    dimension.errors = [sql_error]
     assert dimension.errored is None
     dimension.queried = True
     assert dimension.errored is True

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -272,16 +272,38 @@ def test_extract_error_details_error_dict(validator):
         },
     }
     extracted = validator._extract_error_details(query_result)
-    assert extracted["message"] == f"{message} {message_details}"
-    assert extracted["sql"] == sql
+    assert extracted[0]["message"] == f"{message} {message_details}"
+    assert extracted[0]["sql"] == sql
+
+
+def test_extract_error_details_error_dict_multiple(validator):
+    message = "An error message."
+    message_details = "Shocking details."
+    sql = "SELECT * FROM orders"
+    query_result = {
+        "status": "error",
+        "data": {
+            "errors": [
+                {"message": message, "message_details": message_details},
+                {"message": message, "message_details": message_details},
+            ],
+            "sql": sql,
+        },
+    }
+    extracted = validator._extract_error_details(query_result)
+    assert len(extracted) == 2
+    assert extracted[0]["message"] == f"{message} {message_details}"
+    assert extracted[0]["sql"] == sql
+    assert extracted[1]["message"] == f"{message} {message_details}"
+    assert extracted[1]["sql"] == sql
 
 
 def test_extract_error_details_error_list(validator):
     message = "An error message."
     query_result = {"status": "error", "data": [message]}
     extracted = validator._extract_error_details(query_result)
-    assert extracted["message"] == message
-    assert extracted["sql"] is None
+    assert extracted[0]["message"] == message
+    assert extracted[0]["sql"] is None
 
 
 def test_extract_error_details_error_other(validator):
@@ -308,8 +330,8 @@ def test_extract_error_details_no_message_details(validator):
         "data": {"errors": [{"message": message, "message_details": None}]},
     }
     extracted = validator._extract_error_details(query_result)
-    assert extracted["message"] == message
-    assert extracted["sql"] is None
+    assert extracted[0]["message"] == message
+    assert extracted[0]["sql"] is None
 
 
 def test_extract_error_details_error_loc_wo_line(validator):
@@ -323,5 +345,5 @@ def test_extract_error_details_error_loc_wo_line(validator):
         },
     }
     extracted = validator._extract_error_details(query_result)
-    assert extracted["message"] == message
-    assert extracted["sql"] == sql
+    assert extracted[0]["message"] == message
+    assert extracted[0]["sql"] == sql

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -390,6 +390,14 @@ def test_extract_error_details_no_message_details(validator):
     assert extracted[0]["sql"] is None
 
 
+def test_extract_error_details_string(validator):
+    message = "An error message."
+    query_result = {"status": "error", "data": {"error": message}}
+    extracted = validator._extract_error_details(query_result)
+    assert extracted[0]["message"] == message
+    assert extracted[0]["sql"] is None
+
+
 def test_extract_error_details_error_loc_wo_line(validator):
     message = "An error message."
     sql = "SELECT x FROM orders"


### PR DESCRIPTION
This is heavily based on #159. That PR was based on the codebase before we removed the async functionality and it was going to be easier to do again rather than re-factor. 

This PR achieves two things:
* Allows Spectacles to report multiple errors for a given dimension or explore
* Ignores the `"Note: This query contains derived tables with conditional SQL for Development Mode. Query results in Production Mode might be different."` error that is actually warning.

The most meaningful change in this PR is that instead of the LookML objects having an `error` attribute, it is now an `errors` attribute.

Closes #140, #164  

#### To do:
- [x] More testing