### PR TITLE
Add LookML url to assert outputs

### DIFF
--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -559,6 +559,7 @@ def run_assert(
                 error["explore"],
                 error["metadata"]["test_name"],
                 error["message"],
+                error["metadata"]["lookml_url"],
             )
         logger.info("")
         raise GenericValidationError

--- a/spectacles/exceptions.py
+++ b/spectacles/exceptions.py
@@ -114,8 +114,10 @@ class SqlError(ValidationError):
 
 
 class DataTestError(ValidationError):
-    def __init__(self, model: str, explore: str, message: str, test_name: str):
-        metadata = {"test_name": test_name}
+    def __init__(
+        self, model: str, explore: str, message: str, test_name: str, lookml_url: str
+    ):
+        metadata = {"test_name": test_name, "lookml_url": lookml_url}
         super().__init__(
             model=model, explore=explore, test=None, message=message, metadata=metadata
         )

--- a/spectacles/printer.py
+++ b/spectacles/printer.py
@@ -37,12 +37,13 @@ def print_header(text: str, line_width: int = LINE_WIDTH) -> None:
 
 
 def print_data_test_error(
-    model: str, explore: str, test_name: str, message: str
+    model: str, explore: str, test_name: str, message: str, lookml_url: str
 ) -> None:
     path = f"{model}/{explore}/{test_name}"
     print_header(red(path), LINE_WIDTH + COLOR_CODE_LENGTH)
     wrapped = textwrap.fill(message, LINE_WIDTH)
     logger.info(wrapped)
+    logger.info("\n" + f"LookML: {lookml_url}")
 
 
 def print_sql_error(

--- a/spectacles/validators.py
+++ b/spectacles/validators.py
@@ -99,12 +99,18 @@ class DataTestValidator(Validator):
             tested.append(test)
             if not result["success"]:
                 for error in result["errors"]:
+                    project, file_path = error["file_path"].split("/", 1)
+                    lookml_url = (
+                        f"{self.client.base_url}/projects/{self.project}"
+                        f"/files/{file_path}?line={error['line_number']}"
+                    )
                     errors.append(
                         DataTestError(
                             model=error["model_id"],
                             explore=error["explore"],
                             message=error["message"],
                             test_name=result["test_name"],
+                            lookml_url=lookml_url,
                         ).__dict__
                     )
 


### PR DESCRIPTION
We can generate a URL to the failing data test from what's returned in the API response. I need to test in more detail how this will handle folders before merging.