### PR TITLE
Allow model/explore selection and exclusion in assert

### DIFF
--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -161,8 +161,10 @@ class Runner:
         return results
 
     @log_duration
-    def validate_data_tests(self) -> Dict[str, Any]:
+    def validate_data_tests(
+        self, selectors: List[str], exclusions: List[str]
+    ) -> Dict[str, Any]:
         with self.branch_manager:
             data_test_validator = DataTestValidator(self.client, self.project)
-            results = data_test_validator.validate()
+            results = data_test_validator.validate(selectors, exclusions)
         return results

--- a/spectacles/select.py
+++ b/spectacles/select.py
@@ -1,0 +1,37 @@
+import re
+from typing import List
+from spectacles.exceptions import SpectaclesException
+
+
+def selector_to_pattern(selector: str) -> str:
+    try:
+        model, explore = selector.split("/")
+        assert model
+        assert explore
+    except (ValueError, AssertionError):
+        raise SpectaclesException(
+            name="invalid-selector-format",
+            title="Specified explore selector is invalid.",
+            detail=(
+                f"'{selector}' is not a valid format. "
+                "Instead, use the format 'model_name/explore_name'. "
+                f"Use 'model_name/*' to select all explores in a model."
+            ),
+        )
+    return f"^{selector.replace('*', '.+?')}$"
+
+
+def is_selected(
+    model: str, explore: str, selectors: List[str], exclusions: List[str]
+) -> bool:
+    if not selectors:
+        raise ValueError("Selectors cannot be an empty list.")
+    test_string = f"{model}/{explore}"
+    in_any_selector = any(
+        re.match(selector_to_pattern(selector), test_string) for selector in selectors
+    )
+    in_no_exclusions = not any(
+        re.match(selector_to_pattern(exclusion), test_string)
+        for exclusion in exclusions
+    )
+    return in_any_selector and in_no_exclusions

--- a/spectacles/validators.py
+++ b/spectacles/validators.py
@@ -79,6 +79,12 @@ class DataTestValidator(Validator):
         selectors: Optional[List[str]] = None,
         exclusions: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
+        # Assign default values for selectors and exclusions
+        if selectors is None:
+            selectors = ["*/*"]
+        if exclusions is None:
+            exclusions = []
+
         tests = self.client.all_lookml_tests(self.project)
 
         # The error objects don't contain the name of the explore

--- a/spectacles/validators.py
+++ b/spectacles/validators.py
@@ -98,6 +98,16 @@ class DataTestValidator(Validator):
                 test_to_explore[test["name"]] = test["explore_name"]
 
         test_count = len(selected_tests)
+        if test_count == 0:
+            raise SpectaclesException(
+                name="no-data-tests-found",
+                title="No data tests found.",
+                detail=(
+                    "If you're using --explores or --exclude, make sure your project "
+                    "has data tests that reference those models or explores."
+                ),
+            )
+
         printer.print_header(
             f"Running {test_count} {'test' if test_count == 1 else 'tests'}"
         )

--- a/spectacles/validators.py
+++ b/spectacles/validators.py
@@ -74,7 +74,11 @@ class DataTestValidator(Validator):
         super().__init__(client)
         self.project = project
 
-    def validate(self) -> Dict[str, Any]:
+    def validate(
+        self,
+        selectors: Optional[List[str]] = None,
+        exclusions: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
         tests = self.client.all_lookml_tests(self.project)
 
         # The error objects don't contain the name of the explore

--- a/tests/cassettes/test_data_test_validator/fixture_validator_fail.yaml
+++ b/tests/cassettes/test_data_test_validator/fixture_validator_fail.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=4560
+      - looker.browser=4962
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/lookml_tests
   response:
@@ -17,7 +17,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 13 May 2020 23:41:04 GMT
+      - Tue, 16 Jun 2020 20:27:06 GMT
       Server:
       - nginx
       Vary:
@@ -32,29 +32,113 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=4560
+      - looker.browser=4962
     method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/lookml_tests/run
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/lookml_tests/run?model=eye_exam&test=users_age_should_be_in_expected_range
   response:
     body:
-      string: '[{"model_name":"eye_exam","test_name":"users_age_should_be_in_expected_range","assertions_count":2,"assertions_failed":0,"errors":[],"warnings":[],"success":true,"can":{}},{"model_name":"eye_exam","test_name":"users_name_should_be_in_caps","assertions_count":2,"assertions_failed":0,"errors":[],"warnings":[],"success":true,"can":{}},{"model_name":"eye_exam","test_name":"users__fail_age_should_be_in_expected_range","assertions_count":2,"assertions_failed":2,"errors":[{"code":null,"severity":"error","kind":null,"message":"Assertion
-        \"age_should_be_greater_than_zero\" failed: expression evaluated to \"No\".","field_name":"users__fail.age","file_path":"eye_exam/eye_exam.model.lkml","line_number":40,"model_id":"eye_exam","explore":"users__fail","help_url":null,"params":{"__FILE":"eye_exam/eye_exam.model.lkml","__LINE_NUM":40,"model_id":"eye_exam","explore":"users__fail","field_name":"users__fail.age","level":"error"},"sanitized_message":"Assertion
-        \"(?)\" failed: expression evaluated to \"No\"."},{"code":null,"severity":"error","kind":null,"message":"Assertion
-        \"age_should_be_less_than_130\" failed: expression evaluated to \"No\".","field_name":"users__fail.age","file_path":"eye_exam/eye_exam.model.lkml","line_number":40,"model_id":"eye_exam","explore":"users__fail","help_url":null,"params":{"__FILE":"eye_exam/eye_exam.model.lkml","__LINE_NUM":40,"model_id":"eye_exam","explore":"users__fail","field_name":"users__fail.age","level":"error"},"sanitized_message":"Assertion
-        \"(?)\" failed: expression evaluated to \"No\"."}],"warnings":[],"success":false,"can":{}},{"model_name":"eye_exam","test_name":"users__fail_name_should_be_in_caps","assertions_count":2,"assertions_failed":0,"errors":[],"warnings":[],"success":true,"can":{}}]'
+      string: '[{"model_name":"eye_exam","test_name":"users_age_should_be_in_expected_range","assertions_count":2,"assertions_failed":0,"errors":[],"warnings":[],"success":true,"can":{}}]'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '1747'
+      - '172'
       Content-Type:
       - application/json
       Date:
-      - Wed, 13 May 2020 23:41:05 GMT
+      - Tue, 16 Jun 2020 20:27:06 GMT
       Server:
       - nginx
       Vary:
       - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=4962
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/lookml_tests/run?model=eye_exam&test=users_name_should_be_in_caps
+  response:
+    body:
+      string: '[{"model_name":"eye_exam","test_name":"users_name_should_be_in_caps","assertions_count":2,"assertions_failed":0,"errors":[],"warnings":[],"success":true,"can":{}}]'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '163'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Jun 2020 20:27:06 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=4962
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/lookml_tests/run?model=eye_exam&test=users__fail_age_should_be_in_expected_range
+  response:
+    body:
+      string: '[{"model_name":"eye_exam","test_name":"users__fail_age_should_be_in_expected_range","assertions_count":2,"assertions_failed":2,"errors":[{"code":null,"severity":"error","kind":null,"message":"Assertion
+        \"age_should_be_greater_than_zero\" failed: expression evaluated to \"No\".","field_name":"users__fail.age","file_path":"eye_exam/eye_exam.model.lkml","line_number":40,"model_id":"eye_exam","explore":"users__fail","help_url":null,"params":{"__FILE":"eye_exam/eye_exam.model.lkml","__LINE_NUM":40,"model_id":"eye_exam","explore":"users__fail","field_name":"users__fail.age","level":"error"},"sanitized_message":"Assertion
+        \"(?)\" failed: expression evaluated to \"No\"."},{"code":null,"severity":"error","kind":null,"message":"Assertion
+        \"age_should_be_less_than_130\" failed: expression evaluated to \"No\".","field_name":"users__fail.age","file_path":"eye_exam/eye_exam.model.lkml","line_number":40,"model_id":"eye_exam","explore":"users__fail","help_url":null,"params":{"__FILE":"eye_exam/eye_exam.model.lkml","__LINE_NUM":40,"model_id":"eye_exam","explore":"users__fail","field_name":"users__fail.age","level":"error"},"sanitized_message":"Assertion
+        \"(?)\" failed: expression evaluated to \"No\"."}],"warnings":[],"success":false,"can":{}}]'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1246'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Jun 2020 20:27:07 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=4962
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/lookml_tests/run?model=eye_exam&test=users__fail_name_should_be_in_caps
+  response:
+    body:
+      string: '[{"model_name":"eye_exam","test_name":"users__fail_name_should_be_in_caps","assertions_count":2,"assertions_failed":0,"errors":[],"warnings":[],"success":true,"can":{}}]'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '169'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Jun 2020 20:27:07 GMT
+      Server:
+      - nginx
+      Vary:
       - Accept-Encoding
       X-Content-Type-Options:
       - nosniff

--- a/tests/cassettes/test_data_test_validator/fixture_validator_fail.yaml
+++ b/tests/cassettes/test_data_test_validator/fixture_validator_fail.yaml
@@ -145,4 +145,32 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=4560
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/lookml_tests
+  response:
+    body:
+      string: '{"message":"Requires authentication.","documentation_url":"http://docs.looker.com/"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '84'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Jun 2020 20:33:37 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 401
+      message: Unauthorized
 version: 1

--- a/tests/cassettes/test_data_test_validator/fixture_validator_init.yaml
+++ b/tests/cassettes/test_data_test_validator/fixture_validator_init.yaml
@@ -1,0 +1,31 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=4973
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/lookml_tests
+  response:
+    body:
+      string: '[{"model_name":"eye_exam","name":"users_age_should_be_in_expected_range","explore_name":"users","query_url_params":"fields=users.age\u0026limit=500\u0026dynamic_fields=%5B%7B%22table_calculation%22%3A%22looker_assert_age_should_be_greater_than_zero%22%2C%22label%22%3A%22Age+Should+Be+Greater+Than+Zero%22%2C%22expression%22%3A%22%24%7Busers.age%7D+%5Cu003e+0+%22%7D%2C%7B%22table_calculation%22%3A%22looker_assert_age_should_be_less_than_130%22%2C%22label%22%3A%22Age+Should+Be+Less+Than+130%22%2C%22expression%22%3A%22%24%7Busers.age%7D+%5Cu003c+130+%22%7D%5D","file":"eye_exam/eye_exam.model.lkml","line":7,"can":{}},{"model_name":"eye_exam","name":"users_name_should_be_in_caps","explore_name":"users","query_url_params":"fields=users.first_name,users.last_name\u0026limit=500\u0026dynamic_fields=%5B%7B%22table_calculation%22%3A%22looker_assert_users_first_name_should_be_in_caps%22%2C%22label%22%3A%22Users+First+Name+Should+Be+In+Caps%22%2C%22expression%22%3A%22%24%7Busers.first_name%7D+%3D+upper%28%24%7Busers.first_name%7D%29+%22%7D%2C%7B%22table_calculation%22%3A%22looker_assert_users_last_name_should_be_in_caps%22%2C%22label%22%3A%22Users+Last+Name+Should+Be+In+Caps%22%2C%22expression%22%3A%22%24%7Busers.last_name%7D+%3D+upper%28%24%7Busers.last_name%7D%29+%22%7D%5D","file":"eye_exam/eye_exam.model.lkml","line":21,"can":{}},{"model_name":"eye_exam","name":"users__fail_age_should_be_in_expected_range","explore_name":"users__fail","query_url_params":"fields=users__fail.age\u0026limit=500\u0026dynamic_fields=%5B%7B%22table_calculation%22%3A%22looker_assert_age_should_be_greater_than_zero%22%2C%22label%22%3A%22Age+Should+Be+Greater+Than+Zero%22%2C%22expression%22%3A%22%24%7Busers__fail.age%7D+%5Cu003e+130+%22%7D%2C%7B%22table_calculation%22%3A%22looker_assert_age_should_be_less_than_130%22%2C%22label%22%3A%22Age+Should+Be+Less+Than+130%22%2C%22expression%22%3A%22%24%7Busers__fail.age%7D+%5Cu003c+0+%22%7D%5D","file":"eye_exam/eye_exam.model.lkml","line":40,"can":{}},{"model_name":"eye_exam","name":"users__fail_name_should_be_in_caps","explore_name":"users__fail","query_url_params":"fields=users__fail.first_name,users__fail.last_name\u0026limit=500\u0026dynamic_fields=%5B%7B%22table_calculation%22%3A%22looker_assert_users__fail_first_name_should_be_in_caps%22%2C%22label%22%3A%22Users+Fail+First+Name+Should+Be+In+Caps%22%2C%22expression%22%3A%22%24%7Busers__fail.first_name%7D+%3D+upper%28%24%7Busers__fail.first_name%7D%29+%22%7D%2C%7B%22table_calculation%22%3A%22looker_assert_users__fail_last_name_should_be_in_caps%22%2C%22label%22%3A%22Users+Fail+Last+Name+Should+Be+In+Caps%22%2C%22expression%22%3A%22%24%7Busers__fail.last_name%7D+%3D+upper%28%24%7Busers__fail.last_name%7D%29+%22%7D%5D","file":"eye_exam/eye_exam.model.lkml","line":54,"can":{}}]'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2784'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Jun 2020 20:52:26 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -295,6 +295,8 @@ def test_main_with_assert_validator(mock_tracking, mock_run_assert, env):
     mock_run_assert.assert_called_once_with(
         "PROJECT_ENV_VAR",  # project
         "BRANCH_ENV_VAR",  # branch
+        ["*/*"],  # explores
+        [],  # exclude
         "BASE_URL_ENV_VAR",  # base_url
         "CLIENT_ID_ENV_VAR",  # client_id
         "CLIENT_SECRET_ENV_VAR",  # client_secret

--- a/tests/test_data_test_validator.py
+++ b/tests/test_data_test_validator.py
@@ -39,5 +39,6 @@ class TestValidateFail:
         jsonschema.validate(results, schema)
 
     def test_no_data_tests_should_raise_error(self, validator):
-        with pytest.raises(SpectaclesException):
+        with pytest.raises(SpectaclesException) as error:
             validator.validate(exclusions=["*/*"])
+            assert error.type == "no-data-tests-found"

--- a/tests/test_data_test_validator.py
+++ b/tests/test_data_test_validator.py
@@ -3,6 +3,7 @@ import pytest
 import vcr
 import jsonschema
 from spectacles.validators import DataTestValidator
+from spectacles.exceptions import SpectaclesException
 
 
 @pytest.fixture(scope="class")
@@ -36,3 +37,7 @@ class TestValidateFail:
     def test_results_should_conform_to_schema(self, schema, validator_fail):
         results = validator_fail[1]
         jsonschema.validate(results, schema)
+
+    def test_no_data_tests_should_raise_error(self, validator):
+        with pytest.raises(SpectaclesException):
+            validator.validate(exclusions=["*/*"])

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,0 +1,55 @@
+import pytest
+from spectacles.select import is_selected, selector_to_pattern
+from spectacles.exceptions import SpectaclesException
+
+
+def test_invalid_format_should_raise_value_error():
+    with pytest.raises(SpectaclesException):
+        selector_to_pattern("model_a.explore_a")
+
+    with pytest.raises(SpectaclesException):
+        selector_to_pattern("model_a/")
+
+    with pytest.raises(SpectaclesException):
+        selector_to_pattern("explore_a")
+
+
+def test_select_wildcard_should_match():
+    assert is_selected("model_a", "explore_a", ["*/*"], [])
+    assert is_selected("model_a", "explore_a", ["model_b/explore_a", "*/*"], [])
+
+
+def test_select_model_wildcard_should_match():
+    assert is_selected("model_a", "explore_a", ["model_a/*"], [])
+
+
+def test_select_explore_wildcard_should_match():
+    assert is_selected("model_a", "explore_a", ["*/explore_a"], [])
+
+
+def test_select_exact_model_and_explore_should_match():
+    assert is_selected("model_a", "explore_a", ["model_a/explore_a"], [])
+
+
+def test_select_wrong_model_should_not_match():
+    assert not is_selected("model_a", "explore_a", ["model_b/explore_a"], [])
+
+
+def test_select_wrong_explore_should_not_match():
+    assert not is_selected("model_a", "explore_a", ["model_a/explore_b"], [])
+
+
+def test_exclude_wildcard_should_not_match():
+    assert not is_selected("model_a", "explore_a", ["*/*"], ["*/*"])
+
+
+def test_exclude_model_wildcard_should_not_match():
+    assert not is_selected("model_a", "explore_a", ["*/*"], ["model_a/*"])
+
+
+def test_exclude_explore_wildcard_should_not_match():
+    assert not is_selected("model_a", "explore_a", ["*/*"], ["*/explore_a"])
+
+
+def test_exclude_exact_model_and_explore_should_not_match():
+    assert not is_selected("model_a", "explore_a", ["*/*"], ["model_a/explore_a"])

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -21,10 +21,12 @@ def test_select_wildcard_should_match():
 
 def test_select_model_wildcard_should_match():
     assert is_selected("model_a", "explore_a", ["model_a/*"], [])
+    assert is_selected("model_a", "explore_b", ["model_a/*"], [])
 
 
 def test_select_explore_wildcard_should_match():
     assert is_selected("model_a", "explore_a", ["*/explore_a"], [])
+    assert is_selected("model_b", "explore_a", ["*/explore_a"], [])
 
 
 def test_select_exact_model_and_explore_should_match():

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -1,5 +1,4 @@
 from typing import Iterable, Tuple, Dict
-from collections import defaultdict
 from unittest.mock import patch, create_autospec
 import pytest
 import jsonschema
@@ -290,29 +289,6 @@ def test_get_running_query_tasks(validator):
     ]
     validator._running_queries = queries
     assert validator.get_running_query_tasks() == ["abc", "def"]
-
-
-def test_parse_selectors_should_handle_duplicates():
-    expected = defaultdict(set, model_one=set(["explore_one"]))
-    assert (
-        SqlValidator.parse_selectors(["model_one/explore_one", "model_one/explore_one"])
-        == expected
-    )
-
-
-def test_parse_selectors_should_handle_same_explore_in_different_model():
-    expected = defaultdict(
-        set, model_one=set(["explore_one"]), model_two=set(["explore_one"])
-    )
-    assert (
-        SqlValidator.parse_selectors(["model_one/explore_one", "model_two/explore_one"])
-        == expected
-    )
-
-
-def test_parse_selectors_with_invalid_format_should_raise_error():
-    with pytest.raises(SpectaclesException):
-        SqlValidator.parse_selectors(["model_one.explore_one", "model_two:explore_one"])
 
 
 @patch("spectacles.validators.LookerClient.cancel_query_task")

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -44,10 +44,6 @@ class TestBuildProject:
         validator.build_project(selectors=["eye_exam/users", "eye_exam/users"])
         assert len(validator.project.models) == 1
 
-    def test_invalid_model_selector_should_raise_error(self, validator):
-        with pytest.raises(SpectaclesException):
-            validator.build_project(selectors=["dummy/*"])
-
 
 @pytest.mark.vcr(match_on=["uri", "method", "raw_body"])
 class TestBuildUnconfiguredProject:


### PR DESCRIPTION
Closes #227, closes #165. Refactors the selection logic to use regex, making it much more concise and readable. Move the `--explores` and `--exclude` arguments to the validator subparser.

The architecture of this change means it's much more difficult to validate the selectors and exclusions passed in (for example, raising an error on `model_a/explore_c` to communicate that `explore_c` doesn't exist). This isn't ideal, because it's nice to catch when people have typos in their args, for example.