### PR TITLE
Refactor data test validator to use Project

### DIFF
--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -658,6 +658,10 @@ def run_assert(
     )
     results = runner.validate_data_tests(explores, exclude)
 
+    for test in sorted(results["tested"], key=lambda x: (x["model"], x["explore"])):
+        message = f"{test['model']}.{test['explore']}"
+        printer.print_validation_result(passed=test["passed"], source=message)
+
     errors = sorted(
         results["errors"],
         key=lambda x: (x["model"], x["explore"], x["metadata"]["test_name"]),

--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -1,14 +1,14 @@
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Optional
 import time
 from dataclasses import dataclass
 import backoff  # type: ignore
 import requests
 from requests.exceptions import Timeout
 import spectacles.utils as utils
+from spectacles.types import JsonDict
 from spectacles.logger import GLOBAL_LOGGER as logger
 from spectacles.exceptions import SpectaclesException, LookerApiError
 
-JsonDict = Dict[str, Any]
 TIMEOUT_SEC = 300
 
 

--- a/spectacles/exceptions.py
+++ b/spectacles/exceptions.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any, Optional
 import requests
 from spectacles.utils import details_from_http_error
+from spectacles.types import JsonDict
 
 
 class SpectaclesException(Exception):
@@ -47,9 +48,7 @@ class LookerApiError(SpectaclesException):
         request: requests.PreparedRequest = response.request
         super().__init__("looker-api-errors/" + name, title, detail)
         self.status = status
-        self.looker_api_response: Optional[Dict[str, Any]] = details_from_http_error(
-            response
-        )
+        self.looker_api_response: Optional[JsonDict] = details_from_http_error(response)
         self.request = {"url": request.url, "method": request.method}
 
 

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -179,7 +179,7 @@ class Runner:
                 "Building LookML project hierarchy for project "
                 f"'{self.project}' @ {self.branch_manager.ref}"
             )
-            sql_validator.build_project(selectors, exclusions)
+            sql_validator.build_project(selectors, exclusions, build_dimensions=True)
             explore_count = sql_validator.project.count_explores()
             print_header(
                 f"Testing {explore_count} "

--- a/spectacles/types.py
+++ b/spectacles/types.py
@@ -1,3 +1,5 @@
+from typing import Dict, Any
 from typing_extensions import Literal
 
 QueryMode = Literal["batch", "hybrid", "single"]
+JsonDict = Dict[str, Any]

--- a/spectacles/validators/content.py
+++ b/spectacles/validators/content.py
@@ -1,9 +1,7 @@
 from typing import List, Optional, Any, Dict
 from spectacles.validators.validator import Validator
 from spectacles.client import LookerClient
-from spectacles.lookml import Project, Model
-from spectacles.exceptions import LookMlNotFound, ContentError
-from spectacles.select import is_selected
+from spectacles.exceptions import ContentError
 from spectacles.lookml import Explore
 from spectacles.logger import GLOBAL_LOGGER as logger
 
@@ -12,8 +10,7 @@ class ContentValidator(Validator):
     def __init__(
         self, client: LookerClient, project: str, exclude_personal: bool = False
     ):
-        super().__init__(client)
-        self.project = Project(project, models=[])
+        super().__init__(client, project)
         personal_folders = self._get_personal_folders() if exclude_personal else []
         self.personal_folders: List[int] = personal_folders
 
@@ -24,54 +21,6 @@ class ContentValidator(Validator):
             if folder["is_personal"] or folder["is_personal_descendant"]:
                 personal_folders.append(folder["id"])
         return personal_folders
-
-    def build_project(
-        self,
-        selectors: Optional[List[str]] = None,
-        exclusions: Optional[List[str]] = None,
-    ) -> None:
-        """Creates an object representation of the project's LookML.
-
-        Args:
-            selectors: List of selector strings in 'model_name/explore_name' format.
-                The '*' wildcard selects all models or explores. For instance,
-                'model_name/*' would select all explores in the 'model_name' model.
-
-        """
-        # Assign default values for selectors and exclusions
-        if selectors is None:
-            selectors = ["*/*"]
-        if exclusions is None:
-            exclusions = []
-
-        all_models = [
-            Model.from_json(model) for model in self.client.get_lookml_models()
-        ]
-        project_models = [
-            model for model in all_models if model.project_name == self.project.name
-        ]
-
-        if not project_models:
-            raise LookMlNotFound(
-                name="project-models-not-found",
-                title="No configured models found for the specified project.",
-                detail=(
-                    f"Go to {self.client.base_url}/projects and confirm "
-                    "a) at least one model exists for the project and "
-                    "b) it has an active configuration."
-                ),
-            )
-
-        for model in project_models:
-            model.explores = [
-                explore
-                for explore in model.explores
-                if is_selected(model.name, explore.name, selectors, exclusions)
-            ]
-
-        self.project.models = [
-            model for model in project_models if len(model.explores) > 0
-        ]
 
     def validate(self) -> Dict[str, Any]:
         result = self.client.content_validation()

--- a/spectacles/validators/data_test.py
+++ b/spectacles/validators/data_test.py
@@ -1,6 +1,5 @@
 from typing import Optional, List, Dict, Any
 from collections import OrderedDict
-from spectacles.client import LookerClient
 from spectacles.validators.validator import Validator
 from spectacles.select import is_selected
 from spectacles.exceptions import SpectaclesException, DataTestError
@@ -16,10 +15,6 @@ class DataTestValidator(Validator):
 
     """
 
-    def __init__(self, client: LookerClient, project: str):
-        super().__init__(client)
-        self.project = project
-
     def validate(
         self,
         selectors: Optional[List[str]] = None,
@@ -31,7 +26,7 @@ class DataTestValidator(Validator):
         if exclusions is None:
             exclusions = []
 
-        all_tests = self.client.all_lookml_tests(self.project)
+        all_tests = self.client.all_lookml_tests(self.project.name)
         selected_tests = []
         test_to_explore = {}
         for test in all_tests:
@@ -63,7 +58,7 @@ class DataTestValidator(Validator):
             test_name = test["name"]
             model_name = test["model_name"]
             results = self.client.run_lookml_test(
-                self.project, model=model_name, test=test_name
+                self.project.name, model=model_name, test=test_name
             )
             test_results.extend(results)
 

--- a/spectacles/validators/sql.py
+++ b/spectacles/validators/sql.py
@@ -2,10 +2,9 @@ from typing import Union, Dict, Any, List, Optional
 import time
 from spectacles.validators.validator import Validator
 from spectacles.client import LookerClient
-from spectacles.lookml import Project, Model, Dimension, Explore
+from spectacles.lookml import Dimension, Explore
 from spectacles.types import QueryMode
-from spectacles.exceptions import SpectaclesException, SqlError, LookMlNotFound
-from spectacles.select import is_selected
+from spectacles.exceptions import SpectaclesException, SqlError
 from spectacles.logger import GLOBAL_LOGGER as logger
 
 
@@ -50,9 +49,7 @@ class SqlValidator(Validator):
     """
 
     def __init__(self, client: LookerClient, project: str, concurrency: int = 10):
-        super().__init__(client)
-
-        self.project = Project(project, models=[])
+        super().__init__(client, project)
         self.query_slots = concurrency
         self._running_queries: List[Query] = []
         # Lookup used to retrieve the LookML object
@@ -72,60 +69,9 @@ class SqlValidator(Validator):
         self,
         selectors: Optional[List[str]] = None,
         exclusions: Optional[List[str]] = None,
+        build_dimensions: bool = True,
     ) -> None:
-        """Creates an object representation of the project's LookML.
-
-        Args:
-            selectors: List of selector strings in 'model_name/explore_name' format.
-                The '*' wildcard selects all models or explores. For instance,
-                'model_name/*' would select all explores in the 'model_name' model.
-
-        """
-        # Assign default values for selectors and exclusions
-        if selectors is None:
-            selectors = ["*/*"]
-        if exclusions is None:
-            exclusions = []
-
-        all_models = [
-            Model.from_json(model) for model in self.client.get_lookml_models()
-        ]
-        project_models = [
-            model for model in all_models if model.project_name == self.project.name
-        ]
-
-        if not project_models:
-            raise LookMlNotFound(
-                name="project-models-not-found",
-                title="No configured models found for the specified project.",
-                detail=(
-                    f"Go to {self.client.base_url}/projects and confirm "
-                    "a) at least one model exists for the project and "
-                    "b) it has an active configuration."
-                ),
-            )
-
-        for model in project_models:
-            model.explores = [
-                explore
-                for explore in model.explores
-                if is_selected(model.name, explore.name, selectors, exclusions)
-            ]
-            for explore in model.explores:
-                dimensions_json = self.client.get_lookml_dimensions(
-                    model.name, explore.name
-                )
-                for dimension_json in dimensions_json:
-                    dimension = Dimension.from_json(
-                        dimension_json, model.name, explore.name
-                    )
-                    dimension.url = self.client.base_url + dimension.url
-                    if not dimension.ignore:
-                        explore.add_dimension(dimension)
-
-        self.project.models = [
-            model for model in project_models if len(model.explores) > 0
-        ]
+        super().build_project(selectors, exclusions, build_dimensions)
 
     def validate(self, mode: QueryMode = "batch") -> Dict[str, Any]:
         """Queries selected explores and returns the project tree with errors."""

--- a/spectacles/validators/validator.py
+++ b/spectacles/validators/validator.py
@@ -1,5 +1,9 @@
+from typing import Optional, List
 from abc import ABC, abstractmethod
 from spectacles.client import LookerClient
+from spectacles.lookml import Project, Model, Dimension
+from spectacles.select import is_selected
+from spectacles.exceptions import LookMlNotFound
 
 
 class Validator(ABC):  # pragma: no cover
@@ -12,9 +16,72 @@ class Validator(ABC):  # pragma: no cover
 
     """
 
-    def __init__(self, client: LookerClient):
+    def __init__(self, client: LookerClient, project: str):
         self.client = client
+        self.project = Project(project, models=[])
 
     @abstractmethod
     def validate(self):
         raise NotImplementedError
+
+    def build_project(
+        self,
+        selectors: Optional[List[str]] = None,
+        exclusions: Optional[List[str]] = None,
+        build_dimensions: bool = False,
+    ) -> None:
+        """Creates an object representation of the project's LookML.
+
+        Args:
+            selectors: List of selector strings in 'model_name/explore_name' format.
+                The '*' wildcard selects all models or explores. For instance,
+                'model_name/*' would select all explores in the 'model_name' model.
+
+        """
+        # Assign default values for selectors and exclusions
+        if selectors is None:
+            selectors = ["*/*"]
+        if exclusions is None:
+            exclusions = []
+
+        all_models = [
+            Model.from_json(model) for model in self.client.get_lookml_models()
+        ]
+        project_models = [
+            model for model in all_models if model.project_name == self.project.name
+        ]
+
+        if not project_models:
+            raise LookMlNotFound(
+                name="project-models-not-found",
+                title="No configured models found for the specified project.",
+                detail=(
+                    f"Go to {self.client.base_url}/projects and confirm "
+                    "a) at least one model exists for the project and "
+                    "b) it has an active configuration."
+                ),
+            )
+
+        for model in project_models:
+            model.explores = [
+                explore
+                for explore in model.explores
+                if is_selected(model.name, explore.name, selectors, exclusions)
+            ]
+
+            if build_dimensions:
+                for explore in model.explores:
+                    dimensions_json = self.client.get_lookml_dimensions(
+                        model.name, explore.name
+                    )
+                    for dimension_json in dimensions_json:
+                        dimension = Dimension.from_json(
+                            dimension_json, model.name, explore.name
+                        )
+                        dimension.url = self.client.base_url + dimension.url
+                        if not dimension.ignore:
+                            explore.add_dimension(dimension)
+
+        self.project.models = [
+            model for model in project_models if len(model.explores) > 0
+        ]

--- a/tests/cassettes/test_data_test_validator/fixture_validator_fail.yaml
+++ b/tests/cassettes/test_data_test_validator/fixture_validator_fail.yaml
@@ -3,7 +3,77 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=4962
+      - looker.browser=5179
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/lookml_models
+  response:
+    body:
+      string: '[{"explores":[{"description":null,"label":"Cohort Data Tool","hidden":true,"group_label":"1)
+        eCommerce with Event Data","name":"cohorts","can":{}},{"description":null,"label":"Web
+        Analytics Data Tool","hidden":true,"group_label":"1) eCommerce with Event
+        Data","name":"data_tool","can":{}},{"description":null,"label":"(1) Orders,
+        Items and Users","hidden":false,"group_label":"1) eCommerce with Event Data","name":"order_items","can":{}},{"description":null,"label":"(2)
+        Web Event Data","hidden":false,"group_label":"1) eCommerce with Event Data","name":"events","can":{}},{"description":null,"label":"(3)
+        Web Session Data","hidden":false,"group_label":"1) eCommerce with Event Data","name":"sessions","can":{}},{"description":null,"label":"(4)
+        Affinity Analysis","hidden":false,"group_label":"1) eCommerce with Event Data","name":"affinity","can":{}},{"description":null,"label":"(5)
+        Share of Wallet Analysis","hidden":false,"group_label":"1) eCommerce with
+        Event Data","name":"orders_with_share_of_wallet_application","can":{}},{"description":null,"label":"(6)
+        Customer Journey Mapping","hidden":false,"group_label":"1) eCommerce with
+        Event Data","name":"journey_mapping","can":{}},{"description":null,"label":"(7)
+        Stock Analysis","hidden":false,"group_label":"1) eCommerce with Event Data","name":"inventory_items","can":{}},{"description":null,"label":"(8)
+        Historical Stock Snapshot Analysis","hidden":false,"group_label":"1) eCommerce
+        with Event Data","name":"inventory_snapshot","can":{}},{"description":null,"label":"Order
+        Items (Kittens)","hidden":true,"group_label":"1) eCommerce with Event Data","name":"kitten_order_items","can":{}}],"has_content":true,"label":"1)
+        eCommerce with Event Data","name":"thelook","project_name":"welcome_to_looker","unlimited_db_connections":false,"allowed_db_connection_names":["snowlooker"],"can":{"index":true,"show":true,"create":true,"update":true,"destroy":true}},{"explores":[{"description":null,"label":"Orders","hidden":false,"group_label":"Jaffle
+        Shop","name":"fct_orders","can":{}}],"has_content":true,"label":"Jaffle Shop","name":"jaffle_shop","project_name":"jaffle_shop","unlimited_db_connections":false,"allowed_db_connection_names":["bigquery"],"can":{"index":true,"show":true,"create":true,"update":true,"destroy":true}},{"explores":[],"has_content":false,"label":"Admin","name":"admin","project_name":"jaffle_shop","unlimited_db_connections":false,"allowed_db_connection_names":["bigquery"],"can":{"index":true,"show":true,"create":true,"update":true,"destroy":true}},{"explores":[{"description":null,"label":"Users","hidden":false,"group_label":"Eye
+        Exam","name":"users","can":{}},{"description":null,"label":"Users Fail","hidden":false,"group_label":"Eye
+        Exam","name":"users__fail","can":{}},{"description":null,"label":"Users Fail
+        and Warn","hidden":false,"group_label":"Eye Exam","name":"users__fail_and_warn","can":{}},{"description":null,"label":"Users
+        Warn","hidden":false,"group_label":"Eye Exam","name":"users__warn","can":{}}],"has_content":true,"label":"Eye
+        Exam","name":"eye_exam","project_name":"eye_exam","unlimited_db_connections":false,"allowed_db_connection_names":["snowlooker"],"can":{"index":true,"show":true,"create":true,"update":true,"destroy":true}},{"explores":[{"description":null,"label":"Content
+        Usage","hidden":false,"group_label":"System Activity","name":"content_usage","can":{}},{"description":null,"label":"Dashboard","hidden":false,"group_label":"System
+        Activity","name":"dashboard","can":{}},{"description":null,"label":"Dashboard
+        Performance","hidden":false,"group_label":"System Activity","name":"dashboard_performance","can":{}},{"description":null,"label":"DB
+        Connection","hidden":false,"group_label":"System Activity","name":"db_connection","can":{}},{"description":null,"label":"Event","hidden":false,"group_label":"System
+        Activity","name":"event","can":{}},{"description":null,"label":"Event Attribute","hidden":false,"group_label":"System
+        Activity","name":"event_attribute","can":{}},{"description":null,"label":"Field
+        Usage","hidden":false,"group_label":"System Activity","name":"field_usage","can":{}},{"description":null,"label":"Group","hidden":false,"group_label":"System
+        Activity","name":"group","can":{}},{"description":null,"label":"History","hidden":false,"group_label":"System
+        Activity","name":"history","can":{}},{"description":null,"label":"Look","hidden":false,"group_label":"System
+        Activity","name":"look","can":{}},{"description":null,"label":"Merge Query","hidden":false,"group_label":"System
+        Activity","name":"merge_query","can":{}},{"description":null,"label":"PDT
+        Event Log","hidden":false,"group_label":"System Activity","name":"pdt_event_log","can":{}},{"description":null,"label":"PDT
+        Builds","hidden":false,"group_label":"System Activity","name":"pdt_builds","can":{}},{"description":null,"label":"Result
+        Maker Lookup","hidden":false,"group_label":"System Activity","name":"result_maker_lookup","can":{}},{"description":null,"label":"Scheduled
+        Plan","hidden":false,"group_label":"System Activity","name":"scheduled_plan","can":{}},{"description":null,"label":"Space","hidden":false,"group_label":"System
+        Activity","name":"space","can":{}},{"description":null,"label":"SQL Query","hidden":false,"group_label":"System
+        Activity","name":"sql_query","can":{}},{"description":null,"label":"User","hidden":false,"group_label":"System
+        Activity","name":"user","can":{}},{"description":null,"label":"Role","hidden":false,"group_label":"System
+        Activity","name":"role","can":{}}],"has_content":true,"label":"System Activity","name":"system__activity","project_name":"system__activity","unlimited_db_connections":false,"allowed_db_connection_names":[],"can":{"index":true,"show":true,"create":true,"update":true,"destroy":true}}]'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5740'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2020 03:26:50 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=5179
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/lookml_tests
   response:
@@ -17,7 +87,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 16 Jun 2020 20:27:06 GMT
+      - Tue, 23 Jun 2020 03:26:50 GMT
       Server:
       - nginx
       Vary:
@@ -32,63 +102,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=4962
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/lookml_tests/run?model=eye_exam&test=users_age_should_be_in_expected_range
-  response:
-    body:
-      string: '[{"model_name":"eye_exam","test_name":"users_age_should_be_in_expected_range","assertions_count":2,"assertions_failed":0,"errors":[],"warnings":[],"success":true,"can":{}}]'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 16 Jun 2020 20:27:06 GMT
-      Server:
-      - nginx
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=4962
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/lookml_tests/run?model=eye_exam&test=users_name_should_be_in_caps
-  response:
-    body:
-      string: '[{"model_name":"eye_exam","test_name":"users_name_should_be_in_caps","assertions_count":2,"assertions_failed":0,"errors":[],"warnings":[],"success":true,"can":{}}]'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '163'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 16 Jun 2020 20:27:06 GMT
-      Server:
-      - nginx
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=4962
+      - looker.browser=5179
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/lookml_tests/run?model=eye_exam&test=users__fail_age_should_be_in_expected_range
   response:
@@ -106,7 +120,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 16 Jun 2020 20:27:07 GMT
+      - Tue, 23 Jun 2020 03:26:50 GMT
       Server:
       - nginx
       Vary:
@@ -121,7 +135,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=4962
+      - looker.browser=5179
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/lookml_tests/run?model=eye_exam&test=users__fail_name_should_be_in_caps
   response:
@@ -135,7 +149,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 16 Jun 2020 20:27:07 GMT
+      - Tue, 23 Jun 2020 03:26:50 GMT
       Server:
       - nginx
       Vary:
@@ -145,32 +159,4 @@ interactions:
     status:
       code: 200
       message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=4560
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/lookml_tests
-  response:
-    body:
-      string: '{"message":"Requires authentication.","documentation_url":"http://docs.looker.com/"}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '84'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 16 Jun 2020 20:33:37 GMT
-      Server:
-      - nginx
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 401
-      message: Unauthorized
 version: 1

--- a/tests/cassettes/test_data_test_validator/fixture_validator_init.yaml
+++ b/tests/cassettes/test_data_test_validator/fixture_validator_init.yaml
@@ -3,7 +3,77 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=4973
+      - looker.browser=5179
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/lookml_models
+  response:
+    body:
+      string: '[{"explores":[{"description":null,"label":"Cohort Data Tool","hidden":true,"group_label":"1)
+        eCommerce with Event Data","name":"cohorts","can":{}},{"description":null,"label":"Web
+        Analytics Data Tool","hidden":true,"group_label":"1) eCommerce with Event
+        Data","name":"data_tool","can":{}},{"description":null,"label":"(1) Orders,
+        Items and Users","hidden":false,"group_label":"1) eCommerce with Event Data","name":"order_items","can":{}},{"description":null,"label":"(2)
+        Web Event Data","hidden":false,"group_label":"1) eCommerce with Event Data","name":"events","can":{}},{"description":null,"label":"(3)
+        Web Session Data","hidden":false,"group_label":"1) eCommerce with Event Data","name":"sessions","can":{}},{"description":null,"label":"(4)
+        Affinity Analysis","hidden":false,"group_label":"1) eCommerce with Event Data","name":"affinity","can":{}},{"description":null,"label":"(5)
+        Share of Wallet Analysis","hidden":false,"group_label":"1) eCommerce with
+        Event Data","name":"orders_with_share_of_wallet_application","can":{}},{"description":null,"label":"(6)
+        Customer Journey Mapping","hidden":false,"group_label":"1) eCommerce with
+        Event Data","name":"journey_mapping","can":{}},{"description":null,"label":"(7)
+        Stock Analysis","hidden":false,"group_label":"1) eCommerce with Event Data","name":"inventory_items","can":{}},{"description":null,"label":"(8)
+        Historical Stock Snapshot Analysis","hidden":false,"group_label":"1) eCommerce
+        with Event Data","name":"inventory_snapshot","can":{}},{"description":null,"label":"Order
+        Items (Kittens)","hidden":true,"group_label":"1) eCommerce with Event Data","name":"kitten_order_items","can":{}}],"has_content":true,"label":"1)
+        eCommerce with Event Data","name":"thelook","project_name":"welcome_to_looker","unlimited_db_connections":false,"allowed_db_connection_names":["snowlooker"],"can":{"index":true,"show":true,"create":true,"update":true,"destroy":true}},{"explores":[{"description":null,"label":"Orders","hidden":false,"group_label":"Jaffle
+        Shop","name":"fct_orders","can":{}}],"has_content":true,"label":"Jaffle Shop","name":"jaffle_shop","project_name":"jaffle_shop","unlimited_db_connections":false,"allowed_db_connection_names":["bigquery"],"can":{"index":true,"show":true,"create":true,"update":true,"destroy":true}},{"explores":[],"has_content":false,"label":"Admin","name":"admin","project_name":"jaffle_shop","unlimited_db_connections":false,"allowed_db_connection_names":["bigquery"],"can":{"index":true,"show":true,"create":true,"update":true,"destroy":true}},{"explores":[{"description":null,"label":"Users","hidden":false,"group_label":"Eye
+        Exam","name":"users","can":{}},{"description":null,"label":"Users Fail","hidden":false,"group_label":"Eye
+        Exam","name":"users__fail","can":{}},{"description":null,"label":"Users Fail
+        and Warn","hidden":false,"group_label":"Eye Exam","name":"users__fail_and_warn","can":{}},{"description":null,"label":"Users
+        Warn","hidden":false,"group_label":"Eye Exam","name":"users__warn","can":{}}],"has_content":true,"label":"Eye
+        Exam","name":"eye_exam","project_name":"eye_exam","unlimited_db_connections":false,"allowed_db_connection_names":["snowlooker"],"can":{"index":true,"show":true,"create":true,"update":true,"destroy":true}},{"explores":[{"description":null,"label":"Content
+        Usage","hidden":false,"group_label":"System Activity","name":"content_usage","can":{}},{"description":null,"label":"Dashboard","hidden":false,"group_label":"System
+        Activity","name":"dashboard","can":{}},{"description":null,"label":"Dashboard
+        Performance","hidden":false,"group_label":"System Activity","name":"dashboard_performance","can":{}},{"description":null,"label":"DB
+        Connection","hidden":false,"group_label":"System Activity","name":"db_connection","can":{}},{"description":null,"label":"Event","hidden":false,"group_label":"System
+        Activity","name":"event","can":{}},{"description":null,"label":"Event Attribute","hidden":false,"group_label":"System
+        Activity","name":"event_attribute","can":{}},{"description":null,"label":"Field
+        Usage","hidden":false,"group_label":"System Activity","name":"field_usage","can":{}},{"description":null,"label":"Group","hidden":false,"group_label":"System
+        Activity","name":"group","can":{}},{"description":null,"label":"History","hidden":false,"group_label":"System
+        Activity","name":"history","can":{}},{"description":null,"label":"Look","hidden":false,"group_label":"System
+        Activity","name":"look","can":{}},{"description":null,"label":"Merge Query","hidden":false,"group_label":"System
+        Activity","name":"merge_query","can":{}},{"description":null,"label":"PDT
+        Event Log","hidden":false,"group_label":"System Activity","name":"pdt_event_log","can":{}},{"description":null,"label":"PDT
+        Builds","hidden":false,"group_label":"System Activity","name":"pdt_builds","can":{}},{"description":null,"label":"Result
+        Maker Lookup","hidden":false,"group_label":"System Activity","name":"result_maker_lookup","can":{}},{"description":null,"label":"Scheduled
+        Plan","hidden":false,"group_label":"System Activity","name":"scheduled_plan","can":{}},{"description":null,"label":"Space","hidden":false,"group_label":"System
+        Activity","name":"space","can":{}},{"description":null,"label":"SQL Query","hidden":false,"group_label":"System
+        Activity","name":"sql_query","can":{}},{"description":null,"label":"User","hidden":false,"group_label":"System
+        Activity","name":"user","can":{}},{"description":null,"label":"Role","hidden":false,"group_label":"System
+        Activity","name":"role","can":{}}],"has_content":true,"label":"System Activity","name":"system__activity","project_name":"system__activity","unlimited_db_connections":false,"allowed_db_connection_names":[],"can":{"index":true,"show":true,"create":true,"update":true,"destroy":true}}]'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5740'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2020 03:26:49 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=5179
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/lookml_tests
   response:
@@ -17,7 +87,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 16 Jun 2020 20:52:26 GMT
+      - Tue, 23 Jun 2020 03:26:49 GMT
       Server:
       - nginx
       Vary:

--- a/tests/cassettes/test_data_test_validator/fixture_validator_pass.yaml
+++ b/tests/cassettes/test_data_test_validator/fixture_validator_pass.yaml
@@ -1,0 +1,157 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=5185
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/lookml_models
+  response:
+    body:
+      string: '[{"explores":[{"description":null,"label":"Cohort Data Tool","hidden":true,"group_label":"1)
+        eCommerce with Event Data","name":"cohorts","can":{}},{"description":null,"label":"Web
+        Analytics Data Tool","hidden":true,"group_label":"1) eCommerce with Event
+        Data","name":"data_tool","can":{}},{"description":null,"label":"(1) Orders,
+        Items and Users","hidden":false,"group_label":"1) eCommerce with Event Data","name":"order_items","can":{}},{"description":null,"label":"(2)
+        Web Event Data","hidden":false,"group_label":"1) eCommerce with Event Data","name":"events","can":{}},{"description":null,"label":"(3)
+        Web Session Data","hidden":false,"group_label":"1) eCommerce with Event Data","name":"sessions","can":{}},{"description":null,"label":"(4)
+        Affinity Analysis","hidden":false,"group_label":"1) eCommerce with Event Data","name":"affinity","can":{}},{"description":null,"label":"(5)
+        Share of Wallet Analysis","hidden":false,"group_label":"1) eCommerce with
+        Event Data","name":"orders_with_share_of_wallet_application","can":{}},{"description":null,"label":"(6)
+        Customer Journey Mapping","hidden":false,"group_label":"1) eCommerce with
+        Event Data","name":"journey_mapping","can":{}},{"description":null,"label":"(7)
+        Stock Analysis","hidden":false,"group_label":"1) eCommerce with Event Data","name":"inventory_items","can":{}},{"description":null,"label":"(8)
+        Historical Stock Snapshot Analysis","hidden":false,"group_label":"1) eCommerce
+        with Event Data","name":"inventory_snapshot","can":{}},{"description":null,"label":"Order
+        Items (Kittens)","hidden":true,"group_label":"1) eCommerce with Event Data","name":"kitten_order_items","can":{}}],"has_content":true,"label":"1)
+        eCommerce with Event Data","name":"thelook","project_name":"welcome_to_looker","unlimited_db_connections":false,"allowed_db_connection_names":["snowlooker"],"can":{"index":true,"show":true,"create":true,"update":true,"destroy":true}},{"explores":[{"description":null,"label":"Orders","hidden":false,"group_label":"Jaffle
+        Shop","name":"fct_orders","can":{}}],"has_content":true,"label":"Jaffle Shop","name":"jaffle_shop","project_name":"jaffle_shop","unlimited_db_connections":false,"allowed_db_connection_names":["bigquery"],"can":{"index":true,"show":true,"create":true,"update":true,"destroy":true}},{"explores":[],"has_content":false,"label":"Admin","name":"admin","project_name":"jaffle_shop","unlimited_db_connections":false,"allowed_db_connection_names":["bigquery"],"can":{"index":true,"show":true,"create":true,"update":true,"destroy":true}},{"explores":[{"description":null,"label":"Users","hidden":false,"group_label":"Eye
+        Exam","name":"users","can":{}},{"description":null,"label":"Users Fail","hidden":false,"group_label":"Eye
+        Exam","name":"users__fail","can":{}},{"description":null,"label":"Users Fail
+        and Warn","hidden":false,"group_label":"Eye Exam","name":"users__fail_and_warn","can":{}},{"description":null,"label":"Users
+        Warn","hidden":false,"group_label":"Eye Exam","name":"users__warn","can":{}}],"has_content":true,"label":"Eye
+        Exam","name":"eye_exam","project_name":"eye_exam","unlimited_db_connections":false,"allowed_db_connection_names":["snowlooker"],"can":{"index":true,"show":true,"create":true,"update":true,"destroy":true}},{"explores":[{"description":null,"label":"Content
+        Usage","hidden":false,"group_label":"System Activity","name":"content_usage","can":{}},{"description":null,"label":"Dashboard","hidden":false,"group_label":"System
+        Activity","name":"dashboard","can":{}},{"description":null,"label":"Dashboard
+        Performance","hidden":false,"group_label":"System Activity","name":"dashboard_performance","can":{}},{"description":null,"label":"DB
+        Connection","hidden":false,"group_label":"System Activity","name":"db_connection","can":{}},{"description":null,"label":"Event","hidden":false,"group_label":"System
+        Activity","name":"event","can":{}},{"description":null,"label":"Event Attribute","hidden":false,"group_label":"System
+        Activity","name":"event_attribute","can":{}},{"description":null,"label":"Field
+        Usage","hidden":false,"group_label":"System Activity","name":"field_usage","can":{}},{"description":null,"label":"Group","hidden":false,"group_label":"System
+        Activity","name":"group","can":{}},{"description":null,"label":"History","hidden":false,"group_label":"System
+        Activity","name":"history","can":{}},{"description":null,"label":"Look","hidden":false,"group_label":"System
+        Activity","name":"look","can":{}},{"description":null,"label":"Merge Query","hidden":false,"group_label":"System
+        Activity","name":"merge_query","can":{}},{"description":null,"label":"PDT
+        Event Log","hidden":false,"group_label":"System Activity","name":"pdt_event_log","can":{}},{"description":null,"label":"PDT
+        Builds","hidden":false,"group_label":"System Activity","name":"pdt_builds","can":{}},{"description":null,"label":"Result
+        Maker Lookup","hidden":false,"group_label":"System Activity","name":"result_maker_lookup","can":{}},{"description":null,"label":"Scheduled
+        Plan","hidden":false,"group_label":"System Activity","name":"scheduled_plan","can":{}},{"description":null,"label":"Space","hidden":false,"group_label":"System
+        Activity","name":"space","can":{}},{"description":null,"label":"SQL Query","hidden":false,"group_label":"System
+        Activity","name":"sql_query","can":{}},{"description":null,"label":"User","hidden":false,"group_label":"System
+        Activity","name":"user","can":{}},{"description":null,"label":"Role","hidden":false,"group_label":"System
+        Activity","name":"role","can":{}}],"has_content":true,"label":"System Activity","name":"system__activity","project_name":"system__activity","unlimited_db_connections":false,"allowed_db_connection_names":[],"can":{"index":true,"show":true,"create":true,"update":true,"destroy":true}}]'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5740'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2020 22:18:06 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=5185
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/lookml_tests
+  response:
+    body:
+      string: '[{"model_name":"eye_exam","name":"users_age_should_be_in_expected_range","explore_name":"users","query_url_params":"fields=users.age\u0026limit=500\u0026dynamic_fields=%5B%7B%22table_calculation%22%3A%22looker_assert_age_should_be_greater_than_zero%22%2C%22label%22%3A%22Age+Should+Be+Greater+Than+Zero%22%2C%22expression%22%3A%22%24%7Busers.age%7D+%5Cu003e+0+%22%7D%2C%7B%22table_calculation%22%3A%22looker_assert_age_should_be_less_than_130%22%2C%22label%22%3A%22Age+Should+Be+Less+Than+130%22%2C%22expression%22%3A%22%24%7Busers.age%7D+%5Cu003c+130+%22%7D%5D","file":"eye_exam/eye_exam.model.lkml","line":7,"can":{}},{"model_name":"eye_exam","name":"users_name_should_be_in_caps","explore_name":"users","query_url_params":"fields=users.first_name,users.last_name\u0026limit=500\u0026dynamic_fields=%5B%7B%22table_calculation%22%3A%22looker_assert_users_first_name_should_be_in_caps%22%2C%22label%22%3A%22Users+First+Name+Should+Be+In+Caps%22%2C%22expression%22%3A%22%24%7Busers.first_name%7D+%3D+upper%28%24%7Busers.first_name%7D%29+%22%7D%2C%7B%22table_calculation%22%3A%22looker_assert_users_last_name_should_be_in_caps%22%2C%22label%22%3A%22Users+Last+Name+Should+Be+In+Caps%22%2C%22expression%22%3A%22%24%7Busers.last_name%7D+%3D+upper%28%24%7Busers.last_name%7D%29+%22%7D%5D","file":"eye_exam/eye_exam.model.lkml","line":21,"can":{}},{"model_name":"eye_exam","name":"users__fail_age_should_be_in_expected_range","explore_name":"users__fail","query_url_params":"fields=users__fail.age\u0026limit=500\u0026dynamic_fields=%5B%7B%22table_calculation%22%3A%22looker_assert_age_should_be_greater_than_zero%22%2C%22label%22%3A%22Age+Should+Be+Greater+Than+Zero%22%2C%22expression%22%3A%22%24%7Busers__fail.age%7D+%5Cu003e+130+%22%7D%2C%7B%22table_calculation%22%3A%22looker_assert_age_should_be_less_than_130%22%2C%22label%22%3A%22Age+Should+Be+Less+Than+130%22%2C%22expression%22%3A%22%24%7Busers__fail.age%7D+%5Cu003c+0+%22%7D%5D","file":"eye_exam/eye_exam.model.lkml","line":40,"can":{}},{"model_name":"eye_exam","name":"users__fail_name_should_be_in_caps","explore_name":"users__fail","query_url_params":"fields=users__fail.first_name,users__fail.last_name\u0026limit=500\u0026dynamic_fields=%5B%7B%22table_calculation%22%3A%22looker_assert_users__fail_first_name_should_be_in_caps%22%2C%22label%22%3A%22Users+Fail+First+Name+Should+Be+In+Caps%22%2C%22expression%22%3A%22%24%7Busers__fail.first_name%7D+%3D+upper%28%24%7Busers__fail.first_name%7D%29+%22%7D%2C%7B%22table_calculation%22%3A%22looker_assert_users__fail_last_name_should_be_in_caps%22%2C%22label%22%3A%22Users+Fail+Last+Name+Should+Be+In+Caps%22%2C%22expression%22%3A%22%24%7Busers__fail.last_name%7D+%3D+upper%28%24%7Busers__fail.last_name%7D%29+%22%7D%5D","file":"eye_exam/eye_exam.model.lkml","line":54,"can":{}}]'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2784'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2020 22:18:06 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=5185
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/lookml_tests/run?model=eye_exam&test=users_age_should_be_in_expected_range
+  response:
+    body:
+      string: '[{"model_name":"eye_exam","test_name":"users_age_should_be_in_expected_range","assertions_count":2,"assertions_failed":0,"errors":[],"warnings":[],"success":true,"can":{}}]'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2020 22:18:07 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=5185
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/lookml_tests/run?model=eye_exam&test=users_name_should_be_in_caps
+  response:
+    body:
+      string: '[{"model_name":"eye_exam","test_name":"users_name_should_be_in_caps","assertions_count":2,"assertions_failed":0,"errors":[],"warnings":[],"success":true,"can":{}}]'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '163'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jun 2020 22:18:08 GMT
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_data_test_validator.py
+++ b/tests/test_data_test_validator.py
@@ -18,6 +18,28 @@ def validator(looker_client, record_mode) -> Iterable[DataTestValidator]:
         yield validator
 
 
+class TestValidatePass:
+    """Test the eye_exam Looker project on master for an explore without errors."""
+
+    @pytest.fixture(scope="class")
+    def validator_pass(
+        self, record_mode, validator
+    ) -> Iterable[Tuple[DataTestValidator, Dict]]:
+        with vcr.use_cassette(
+            "tests/cassettes/test_data_test_validator/fixture_validator_pass.yaml",
+            match_on=["uri", "method", "raw_body", "query"],
+            filter_headers=["Authorization"],
+            record_mode=record_mode,
+        ):
+            validator.build_project(selectors=["eye_exam/users"])
+            results = validator.validate()
+            yield validator, results
+
+    def test_results_should_conform_to_schema(self, schema, validator_pass):
+        results = validator_pass[1]
+        jsonschema.validate(results, schema)
+
+
 class TestValidateFail:
     """Test the eye_exam Looker project on master for an explore without errors."""
 

--- a/tests/test_data_test_validator.py
+++ b/tests/test_data_test_validator.py
@@ -27,10 +27,11 @@ class TestValidateFail:
     ) -> Iterable[Tuple[DataTestValidator, Dict]]:
         with vcr.use_cassette(
             "tests/cassettes/test_data_test_validator/fixture_validator_fail.yaml",
-            match_on=["uri", "method", "raw_body"],
+            match_on=["uri", "method", "raw_body", "query"],
             filter_headers=["Authorization"],
             record_mode=record_mode,
         ):
+            validator.build_project(selectors=["eye_exam/users__fail"])
             results = validator.validate()
             yield validator, results
 
@@ -38,7 +39,8 @@ class TestValidateFail:
         results = validator_fail[1]
         jsonschema.validate(results, schema)
 
-    def test_no_data_tests_should_raise_error(self, validator):
-        with pytest.raises(SpectaclesException) as error:
-            validator.validate(exclusions=["*/*"])
-            assert error.type == "no-data-tests-found"
+
+def test_no_data_tests_should_raise_error(validator):
+    with pytest.raises(SpectaclesException):
+        validator.build_project(exclusions=["*/*"])
+        validator.validate()

--- a/tests/test_lookml.py
+++ b/tests/test_lookml.py
@@ -197,6 +197,23 @@ def test_model_number_of_errors_single_with_no_errors(
     assert model.number_of_errors == 0
 
 
+def test_model_cannot_assign_errored_without_explorse(model):
+    model.explores = []
+    with pytest.raises(AttributeError):
+        model.errored = True
+
+
+def test_model_get_errored_explores_returns_the_correct_explore(
+    model, explore, sql_error
+):
+    explore.queried = True
+    pass_explore = deepcopy(explore)
+    fail_explore = deepcopy(explore)
+    fail_explore.errors = [sql_error]
+    model.explores = [pass_explore, fail_explore]
+    assert list(model.get_errored_explores()) == [fail_explore]
+
+
 def test_project_number_of_errors_batch_with_errors(
     dimension, explore, model, project, sql_error
 ):

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -115,3 +115,8 @@ def test_data_test_error_prints_with_relevant_info(sql_error, caplog):
     assert test_name in caplog.text
     assert message in caplog.text
     assert lookml_url in caplog.text
+
+
+def test_print_validation_result_should_work():
+    printer.print_validation_result(passed=True, source="model.explore")
+    printer.print_validation_result(passed=False, source="model.explore")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,25 +1,5 @@
 from spectacles.runner import Runner
-
-
-def build_validation(validator):
-    return {
-        "validator": validator,
-        "status": "failed",
-        "tested": [
-            dict(model="ecommerce", explore="orders", passed=True),
-            dict(model="ecommerce", explore="sessions", passed=True),
-            dict(model="ecommerce", explore="users", passed=False),
-        ],
-        "errors": [
-            dict(
-                model="ecommerce",
-                explore="users",
-                test=None,
-                message="An error occurred",
-                metadata={},
-            )
-        ],
-    }
+from tests.utils import build_validation
 
 
 def test_incremental_same_results_should_not_have_errors():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,9 +1,43 @@
+from typing import Dict, Any
 from pathlib import Path
 import json
 
 
-def load_resource(filename):
+def load_resource(filename) -> Dict[str, Any]:
     """Helper method to load a JSON file from tests/resources and parse it."""
     path = Path(__file__).parent / "resources" / filename
     with path.open() as file:
         return json.load(file)
+
+
+def build_validation(validator) -> Dict[str, Any]:
+    """Builds and returns a fake validator response object."""
+    if validator == "sql":
+        metadata = {"sql": "SELECT user_id FROM users"}
+    elif validator == "content":
+        metadata = {
+            "field_name": "view_a.dimension_a",
+            "content_type": "dashboard",
+            "space": "Shared",
+        }
+    elif validator == "assert":
+        metadata = {"test_name": "test_should_pass"}
+    else:
+        metadata = {}
+    return {
+        "validator": validator,
+        "status": "failed",
+        "tested": [
+            dict(model="ecommerce", explore="orders", passed=True),
+            dict(model="ecommerce", explore="sessions", passed=True),
+            dict(model="ecommerce", explore="users", passed=False),
+        ],
+        "errors": [
+            dict(
+                model="ecommerce",
+                explore="users",
+                message="An error occurred",
+                metadata=metadata,
+            )
+        ],
+    }

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,9 +1,10 @@
 from typing import Dict, Any
 from pathlib import Path
 import json
+from spectacles.types import JsonDict
 
 
-def load_resource(filename) -> Dict[str, Any]:
+def load_resource(filename) -> JsonDict:
     """Helper method to load a JSON file from tests/resources and parse it."""
     path = Path(__file__).parent / "resources" / filename
     with path.open() as file:


### PR DESCRIPTION
Closes #238 

Accomplishes a few things:

- Moves the `build_project` method to the base validator
- Moves logging out of the data test validator and into the `Runner` or CLI module
- Applies selection using the standardized `is_selected` function (similar to the Content and SQL validators)