### PR TITLE
Adds Dockerfile to allow independent execution and facilitate CI integrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.7-slim
+
+# set the installation target
+ARG WORKING_DIRECTORY=/data
+
+# parameter-store-exec variables
+ARG USERNAME=runner
+ARG GROUPNAME=runner
+
+# setup initial directories and add runner user as a non-privileged, system account
+# hadolint ignore=DL3013
+RUN mkdir -p ${WORKING_DIRECTORY} \
+  && groupadd --system ${USERNAME} \
+  && useradd --system --gid ${GROUPNAME} --home-dir ${WORKING_DIRECTORY} ${USERNAME} \
+  && chown --recursive ${USERNAME}:${GROUPNAME} ${WORKING_DIRECTORY} \
+  && pip install --no-cache-dir spectacles
+
+# run as the non-privilged, system account
+USER ${USERNAME}
+
+# move to the working directory
+WORKDIR ${WORKING_DIRECTORY}
+
+# check spectacles version
+RUN spectacles --version
+
+# set the default command to run
+ENTRYPOINT [ "spectacles" ]


### PR DESCRIPTION
I've recently come across spectacles and noticed it is not docker-ready to ease CI implementation. In my project, I have prepared a `Dockerfile` that allowed the `spectacles` command to be containerized and super easy to integrate into build pipelines like CircleCI's.

The next step from here would be to integrate this Dockefile into this repository's existing CircleCI pipeline to allow it to be tagged & pushed automatically to dockerhub.com, so spectacles would have its own official dockerhub image available  There's currently no official in dockerhub available, as seen [here](https://hub.docker.com/search?q=spectacles-ci&type=image). I'm not super familiar with publishing to dockerhub, so open to receive advice and feedback on this one :)


### Build

Considering this is not published to dockerhub yet, we'd have to build the image before using it:
```
docker build . -t spectacles
```

### Usage

Considering the command is containerized, its usage would be simple as using `docker run`, here's an example of running the SQL Validator:

```
docker run \
  --rm \
  -v config.yml:/data/config.yml \
  spectacles sql \
      --config-file config.yml \
      --project my_project \
      --concurrency 20 \
      --mode hybrid \
      --verbose \
      --branch my_branch
```

Here's an example of running the Content Validator:

```
docker run \
  --rm \
  -v config.yml:/data/config.yml \
  spectacles content \
      --config-file config.yml \
      --project my_project \
      --verbose \
      --branch my_branch
```

We have been consistently using this approach in our company's production pipelines for some time now, and I thought if this is useful to us, it's probably useful to others out there - the great benefit I've personally seen is that it completely removes the need for any local setup prior to running spectacles, which greatly improves productivity and adoption of the tool.

First PR that I open to this repository, so happy to take on feedback folks :) 