### PR TITLE
Change retry to apply to all client requests + for HTTPError

### DIFF
--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -10,6 +10,10 @@ from spectacles.logger import GLOBAL_LOGGER as logger
 from spectacles.exceptions import SpectaclesException, LookerApiError
 
 TIMEOUT_SEC = 300
+BACKOFF_EXCEPTIONS = (
+    Timeout,
+    HTTPError,
+)
 
 
 @dataclass(frozen=True)  # Token is immutable
@@ -128,14 +132,6 @@ class LookerClient:
             f"using Looker API {self.api_version}"
         )
 
-    @backoff.on_exception(
-        backoff.expo,
-        (
-            Timeout,
-            HTTPError,
-        ),
-        max_tries=2,
-    )
     def request(self, method: str, url: str, *args, **kwargs) -> requests.Response:
         if self.access_token and self.access_token.expired:
             logger.debug("Looker API access token has expired, requesting a new one")
@@ -265,6 +261,11 @@ class LookerClient:
 
         return [branch["name"] for branch in response.json()]
 
+    @backoff.on_exception(
+        backoff.expo,
+        BACKOFF_EXCEPTIONS,
+        max_tries=2,
+    )
     def checkout_branch(self, project: str, branch: str) -> None:
         """Checks out a new git branch. Only works in dev workspace.
 
@@ -291,6 +292,11 @@ class LookerClient:
                 response=response,
             )
 
+    @backoff.on_exception(
+        backoff.expo,
+        BACKOFF_EXCEPTIONS,
+        max_tries=2,
+    )
     def reset_to_remote(self, project: str) -> None:
         """Reset a project development branch to the revision of the project that is on the remote.
 
@@ -349,6 +355,11 @@ class LookerClient:
 
         return manifest
 
+    @backoff.on_exception(
+        backoff.expo,
+        BACKOFF_EXCEPTIONS,
+        max_tries=2,
+    )
     def get_active_branch(self, project: str) -> JsonDict:
         """Gets the active branch for the user in the given project.
 
@@ -386,6 +397,11 @@ class LookerClient:
         full_response = self.get_active_branch(project)
         return full_response["name"]
 
+    @backoff.on_exception(
+        backoff.expo,
+        BACKOFF_EXCEPTIONS,
+        max_tries=2,
+    )
     def create_branch(self, project: str, branch: str, ref: Optional[str] = None):
         """Creates a branch in the given project.
 
@@ -427,6 +443,11 @@ class LookerClient:
                 response=response,
             )
 
+    @backoff.on_exception(
+        backoff.expo,
+        BACKOFF_EXCEPTIONS,
+        max_tries=2,
+    )
     def hard_reset_branch(self, project: str, branch: str, ref: str):
         """Hard resets a branch to the ref prodvided.
 
@@ -461,6 +482,11 @@ class LookerClient:
                 response=response,
             )
 
+    @backoff.on_exception(
+        backoff.expo,
+        BACKOFF_EXCEPTIONS,
+        max_tries=2,
+    )
     def delete_branch(self, project: str, branch: str):
         """Deletes a branch in the given project.
 
@@ -637,6 +663,11 @@ class LookerClient:
 
         return response.json()["fields"]["dimensions"]
 
+    @backoff.on_exception(
+        backoff.expo,
+        BACKOFF_EXCEPTIONS,
+        max_tries=2,
+    )
     def create_query(
         self, model: str, explore: str, dimensions: List[str], fields: List = []
     ) -> Dict:
@@ -696,6 +727,11 @@ class LookerClient:
         )
         return result
 
+    @backoff.on_exception(
+        backoff.expo,
+        BACKOFF_EXCEPTIONS,
+        max_tries=2,
+    )
     def create_query_task(self, query_id: int) -> str:
         """Runs a previously created query asynchronously and returns the query task ID.
 

--- a/spectacles/validators/sql.py
+++ b/spectacles/validators/sql.py
@@ -15,7 +15,7 @@ class Query:
 
     def __init__(
         self,
-        query_id: str,
+        query_id: int,
         lookml_ref: Union[Dimension, Explore],
         explore_url: str,
         query_task_id: Optional[str] = None,
@@ -187,11 +187,13 @@ class SqlValidator(Validator):
         """Creates individual queries for each dimension in an explore"""
         queries = []
         for dimension in explore.dimensions:
-            query = self.client.create_query(
+            query_response = self.client.create_query(
                 model_name, explore.name, [dimension.name], fields=["id", "share_url"]
             )
             query = Query(
-                query["id"], lookml_ref=dimension, explore_url=query["share_url"]
+                query_response["id"],
+                lookml_ref=dimension,
+                explore_url=query_response["share_url"],
             )
             queries.append(query)
         return queries


### PR DESCRIPTION
## Change description

We find that the Looker API can semi-regularly provide transient errors. We already had some logic to retry after Timeout errors. This PR extends that retry to _all_ requests and now also retries after HTTPErrors.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

Closes #379 

### Security

- [X] Security impact of change has been considered
- [X] Code follows security best practices and guidelines

### Code review 

- [X] Pull request has a descriptive title and context useful to a reviewer
