### PR TITLE
Reset Client to development mode if required after 60 minute timeout

### DIFF
--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -80,6 +80,7 @@ class LookerClient:
         self.api_version: float = api_version
         self.access_token: Optional[AccessToken] = None
         self.session: requests.Session = requests.Session()
+        self.requires_dev_mode: bool = False
 
         self.authenticate()
 
@@ -132,6 +133,8 @@ class LookerClient:
         if self.access_token and self.access_token.expired:
             logger.debug("Looker API access token has expired, requesting a new one")
             self.authenticate()
+            if self.requires_dev_mode:
+                self.update_workspace("dev")
         return self.session.request(method, url, *args, **kwargs)
 
     def get(self, url, *args, **kwargs) -> requests.Response:

--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -80,7 +80,7 @@ class LookerClient:
         self.api_version: float = api_version
         self.access_token: Optional[AccessToken] = None
         self.session: requests.Session = requests.Session()
-        self.requires_dev_mode: bool = False
+        self.workspace: str = "production"
 
         self.authenticate()
 
@@ -133,7 +133,7 @@ class LookerClient:
         if self.access_token and self.access_token.expired:
             logger.debug("Looker API access token has expired, requesting a new one")
             self.authenticate()
-            if self.requires_dev_mode:
+            if self.workspace == "dev":
                 self.update_workspace("dev")
         return self.session.request(method, url, *args, **kwargs)
 
@@ -232,6 +232,7 @@ class LookerClient:
                 ),
                 response=response,
             )
+        self.workspace = workspace
 
     def get_all_branches(self, project: str) -> List[str]:
         """Returns a list of git branches in the project repository.

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -136,7 +136,6 @@ class LookerBranchManager:
         if self.workspace != workspace:
             self.client.update_workspace(workspace)
             self.workspace = workspace
-        self.client.requires_dev_mode = True if workspace == "dev" else False
 
     def get_project_state(self) -> ProjectState:
         workspace = self.client.get_workspace()

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -136,6 +136,7 @@ class LookerBranchManager:
         if self.workspace != workspace:
             self.client.update_workspace(workspace)
             self.workspace = workspace
+        self.client.requires_dev_mode = True if workspace == "dev" else False
 
     def get_project_state(self) -> ProjectState:
         workspace = self.client.get_workspace()


### PR DESCRIPTION
## Change description

60 minutes after authenticating the client, we need to re-authenticate with the Looker client. When we do so, the workspace gets reset to production, even if we had previously been in development mode. This change fixes that behaviour. If we were in development mode when the token expires, we will reset to development mode after re-authenticating.

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Closes #392 

## Checklists

### Security

- [X] Security impact of change has been considered
- [X] Code follows security best practices and guidelines

### Code review 

- [X] Pull request has a descriptive title and context useful to a reviewer
