### PR TITLE
Add 'successes' to result of data test validator

### DIFF
--- a/spectacles/lookml.py
+++ b/spectacles/lookml.py
@@ -1,7 +1,7 @@
 import re
 from typing import Dict, List, Sequence, Optional, Any
 from spectacles.exceptions import ValidationError
-from spectacles.types import QueryMode
+from spectacles.types import QueryMode, JsonDict
 
 
 class LookMlObject:
@@ -85,6 +85,7 @@ class Explore(LookMlObject):
         self.model_name = model_name
         self.dimensions = [] if dimensions is None else dimensions
         self.errors: List[ValidationError] = []
+        self.successes: List[JsonDict] = []
         self._queried: bool = False
 
     def __eq__(self, other):
@@ -296,6 +297,7 @@ class Project(LookMlObject):
         self, validator: str, mode: Optional[QueryMode] = None
     ) -> Dict[str, Any]:
         errors: List[Dict[str, Any]] = []
+        successes: List[Dict[str, Any]] = []
         tested = []
 
         def parse_explore_errors(explore):
@@ -317,6 +319,9 @@ class Project(LookMlObject):
                     "explore": explore.name,
                     "passed": passed,
                 }
+                if explore.successes:
+                    successes.extend([success for success in explore.successes])
+
                 tested.append(test)
 
         passed = min((test["passed"] for test in tested), default=True)
@@ -325,6 +330,7 @@ class Project(LookMlObject):
             "status": "passed" if passed else "failed",
             "tested": tested,
             "errors": errors,
+            "successes": successes,
         }
 
     def __repr__(self):

--- a/spectacles/validators/data_test.py
+++ b/spectacles/validators/data_test.py
@@ -50,7 +50,12 @@ class DataTestValidator(Validator):
             model_name = test["model_name"]
             explore_name = test["explore_name"]
             query_url_params = test["query_url_params"]
-            file_path = test["file"].split("/", 1)[1]
+            
+            try:
+                file_path = test["file"].split("/", 1)[1]
+            except IndexError:
+                raise SpectaclesException(f"Couldn't extract file path from unexpected file '{test['file']}'")
+            
             explore_url = (
                 f"{self.client.base_url}/explore/{model_name}"
                 f"/{explore_name}?{query_url_params}"

--- a/spectacles/validators/data_test.py
+++ b/spectacles/validators/data_test.py
@@ -50,12 +50,16 @@ class DataTestValidator(Validator):
             model_name = test["model_name"]
             explore_name = test["explore_name"]
             query_url_params = test["query_url_params"]
-            
+
             try:
                 file_path = test["file"].split("/", 1)[1]
             except IndexError:
-                raise SpectaclesException(f"Couldn't extract file path from unexpected file '{test['file']}'")
-            
+                raise SpectaclesException(
+                    name="data-test-has-incorrect-file-path-format",
+                    title="A data test does not have the correct file path format.",
+                    detail=f"Couldn't extract file path from unexpected file '{test['file']}'",
+                )
+
             explore_url = (
                 f"{self.client.base_url}/explore/{model_name}"
                 f"/{explore_name}?{query_url_params}"

--- a/tests/resources/validation_schema.json
+++ b/tests/resources/validation_schema.json
@@ -103,6 +103,24 @@
                 }
             },
             "uniqueItems": true
+        },
+        "successes": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "model": {
+                        "type": "string"
+                    },
+                    "explore": {
+                        "type": "string"
+                    },
+                    "metadata": {
+                        "$ref": "#/definitions/data_test_metadata"
+                    }
+                }
+            },
+            "uniqueItems": true
         }
     }
 }

--- a/tests/resources/validation_schema.json
+++ b/tests/resources/validation_schema.json
@@ -173,6 +173,7 @@
             "type": "array",
             "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
                     "model": {
                         "type": "string"

--- a/tests/test_data_test_validator.py
+++ b/tests/test_data_test_validator.py
@@ -39,6 +39,11 @@ class TestValidatePass:
         results = validator_pass[1]
         jsonschema.validate(results, schema)
 
+    def test_results_have_correct_number_of_elements(self, validator_pass):
+        results = validator_pass[1]
+        assert len(results["errors"]) == 0
+        assert len(results["successes"]) == 2
+
 
 class TestValidateFail:
     """Test the eye_exam Looker project on master for an explore without errors."""
@@ -60,6 +65,11 @@ class TestValidateFail:
     def test_results_should_conform_to_schema(self, schema, validator_fail):
         results = validator_fail[1]
         jsonschema.validate(results, schema)
+
+    def test_results_have_correct_number_of_elements(self, validator_fail):
+        results = validator_fail[1]
+        assert len(results["errors"]) == 2
+        assert len(results["successes"]) == 1
 
 
 def test_no_data_tests_should_raise_error(validator):


### PR DESCRIPTION
## Change description

We have had a request from a number of customers to return _all_ data tests, not just passing data tests. This PR achieves this by doing the following:

- Adds a `successes` key to the `Explore` class.
- Adds all passing data tests as JSON to the `successes` key on the explore.
- Formats the results for consumption by the hosted service

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

Closes #397 

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
