### PR TITLE
Add tile type and title to content validation errors

### DIFF
--- a/spectacles/exceptions.py
+++ b/spectacles/exceptions.py
@@ -156,7 +156,7 @@ class ContentError(ValidationError):
             "space": space,
             "url": url,
         }
-        if tile_type:
+        if tile_type and tile_title:
             metadata["tile_type"] = tile_type
             metadata["tile_title"] = tile_title
         super().__init__(

--- a/spectacles/exceptions.py
+++ b/spectacles/exceptions.py
@@ -146,6 +146,8 @@ class ContentError(ValidationError):
         title: str,
         space: str,
         url: str,
+        tile_type: Optional[str] = None,
+        tile_title: Optional[str] = None,
     ):
         metadata = {
             "field_name": field_name,
@@ -154,6 +156,9 @@ class ContentError(ValidationError):
             "space": space,
             "url": url,
         }
+        if tile_type:
+            metadata["tile_type"] = tile_type
+            metadata["tile_title"] = tile_title
         super().__init__(
             model=model, explore=explore, message=message, metadata=metadata
         )

--- a/spectacles/validators/content.py
+++ b/spectacles/validators/content.py
@@ -46,7 +46,6 @@ class ContentValidator(Validator):
             else:
                 self._handle_content_result(content, content_type)
 
-        print(self.project.get_results(validator="content"))
         return self.project.get_results(validator="content")
 
     @staticmethod

--- a/spectacles/validators/content.py
+++ b/spectacles/validators/content.py
@@ -46,6 +46,7 @@ class ContentValidator(Validator):
             else:
                 self._handle_content_result(content, content_type)
 
+        print(self.project.get_results(validator="content"))
         return self.project.get_results(validator="content")
 
     @staticmethod
@@ -56,6 +57,17 @@ class ContentValidator(Validator):
             return "look"
         else:
             raise KeyError("Content type not found. Valid keys are 'look', 'dashboard'")
+
+    @staticmethod
+    def _get_tile_type(content: Dict[str, Any]) -> str:
+        if content["dashboard_element"]:
+            return "dashboard_element"
+        elif content["dashboard_filter"]:
+            return "dashboard_filter"
+        else:
+            raise KeyError(
+                "Tile type not found. Valid keys are 'dashboard_element', 'dashboard_filter'"
+            )
 
     def _handle_content_result(self, content: Dict, content_type: str) -> None:
         for error in content["errors"]:
@@ -78,6 +90,16 @@ class ContentValidator(Validator):
                 title=content[content_type]["title"],
                 space=content[content_type]["space"]["name"],
                 url=f"{self.client.base_url}/{content_type}s/{content_id}",
+                tile_type=(
+                    self._get_tile_type(content)
+                    if content_type == "dashboard"
+                    else None
+                ),
+                tile_title=(
+                    content[self._get_tile_type(content)]["title"]
+                    if content_type == "dashboard"
+                    else None
+                ),
             )
             if content_error not in explore.errors:
                 explore.errors.append(content_error)

--- a/tests/resources/validation_schema.json
+++ b/tests/resources/validation_schema.json
@@ -1,11 +1,13 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Validation",
+    "additionalProperties": false,
     "description": "The response from a Spectacles validator.",
     "type": "object",
     "definitions": {
         "sql_metadata": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "dimension": {
                     "type": [
@@ -30,17 +32,63 @@
                         "string",
                         "null"
                     ]
+                },
+                "sql": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 }
             }
         },
         "data_test_metadata": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "test_name": {
                     "type": [
                         "string",
                         "null"
                     ]
+                },
+                "explore_url": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "lookml_url": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "content_metadata": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "field_name": {
+                    "type": "string"
+                },
+                "content_type": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "space": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "tile_type": {
+                    "type": "string"
+                },
+                "tile_title": {
+                    "type": "string"
                 }
             }
         }
@@ -52,10 +100,14 @@
         "passed": {
             "type": "boolean"
         },
+        "status": {
+            "type": "string"
+        },
         "tested": {
             "type": "array",
             "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
                     "model": {
                         "type": "string"
@@ -74,6 +126,7 @@
             "type": "array",
             "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
                     "model": {
                         "type": "string"
@@ -90,6 +143,15 @@
                     "message": {
                         "type": "string"
                     },
+                    "type": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "detail": {
+                        "type": "string"
+                    },
                     "metadata": {
                         "anyOf": [
                             {
@@ -97,6 +159,9 @@
                             },
                             {
                                 "$ref": "#/definitions/data_test_metadata"
+                            },
+                            {
+                                "$ref": "#/definitions/content_metadata"
                             }
                         ]
                     }

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -25,6 +25,12 @@ def test_get_content_type_with_bad_keys_should_raise_key_error(validator):
         validator._get_content_type(content)
 
 
+def test_get_tile_type_with_bad_keys_should_raise_key_error(validator):
+    content = {"lookml_dashboard": "Something goes here."}
+    with pytest.raises(KeyError):
+        validator._get_content_type(content)
+
+
 class TestValidatePass:
     """Test the eye_exam Looker project on master for an explore without errors."""
 


### PR DESCRIPTION
## Change description

When we raise a content validation error for a dashboard, it can be hard to know where the error is coming from in the dashboard as there can be many tiles and filters. This PR adds two new fields to the content validation error, one specifying whether it is a visualisation or filter, and another specifying the title of the visualisation or filter. This should make it easier to pinpoint where content validation errors are coming from. 

## Type of change
- [ ] Bug fix (fixes an issue)
- [X] New feature (adds functionality)

## Related issues

Closes #374  

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
