### PR TITLE
Skip all folders calls when not necessary

### DIFF
--- a/spectacles/validators/content.py
+++ b/spectacles/validators/content.py
@@ -20,7 +20,7 @@ class ContentValidator(Validator):
         personal_folders = self._get_personal_folders() if exclude_personal else []
 
         self.excluded_folders: List[int] = (
-            personal_folders + self._get_all_subfolders(exclude_folders)
+            (personal_folders + self._get_all_subfolders(exclude_folders))
             if exclude_folders
             else []
         )

--- a/spectacles/validators/content.py
+++ b/spectacles/validators/content.py
@@ -19,10 +19,8 @@ class ContentValidator(Validator):
         super().__init__(client, project)
         personal_folders = self._get_personal_folders() if exclude_personal else []
 
-        self.excluded_folders: List[int] = (
-            (personal_folders + self._get_all_subfolders(exclude_folders))
-            if exclude_folders
-            else []
+        self.excluded_folders: List[int] = personal_folders + (
+            self._get_all_subfolders(exclude_folders) if exclude_folders else []
         )
         self.included_folders: List[int] = (
             self._get_all_subfolders(include_folders) if include_folders else []

--- a/spectacles/validators/content.py
+++ b/spectacles/validators/content.py
@@ -19,10 +19,14 @@ class ContentValidator(Validator):
         super().__init__(client, project)
         personal_folders = self._get_personal_folders() if exclude_personal else []
 
-        self.excluded_folders: List[int] = personal_folders + self._get_all_subfolders(
-            exclude_folders
+        self.excluded_folders: List[int] = (
+            personal_folders + self._get_all_subfolders(exclude_folders)
+            if exclude_folders
+            else []
         )
-        self.included_folders: List[int] = self._get_all_subfolders(include_folders)
+        self.included_folders: List[int] = (
+            self._get_all_subfolders(include_folders) if include_folders else []
+        )
 
     def _get_personal_folders(self) -> List[int]:
         personal_folders = []


### PR DESCRIPTION
## Change description

Currently, even if a user don't ask to include specfic folders, exclude specific folders, or exclude personal folders, we still make multiple calls to the GET all folders endpoint. On some instances, that can be a very slow API call. This change fixes that behaviour.

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Closes #440  

## Checklists

### Security

- [X] Security impact of change has been considered
- [X] Code follows security best practices and guidelines

### Code review 

- [X] Pull request has a descriptive title and context useful to a reviewer
