### PR TITLE
Extend API call timeout to one hour for content validation

### DIFF
--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -799,7 +799,9 @@ class LookerClient:
     def content_validation(self) -> JsonDict:
         logger.debug("Validating all content in Looker")
         url = utils.compose_url(self.api_url, path=["content_validation"])
-        response = self.get(url=url, timeout=TIMEOUT_SEC)
+        response = self.get(
+            url=url, timeout=3600
+        )  # 1 hour timeout for content validation
 
         try:
             response.raise_for_status()


### PR DESCRIPTION
## Change description

Currently, all API calls have a 5 minute timeout. For some instances, the content validator can run for up to an hour. This PR extends the timeout for the content validation API call to one hour.

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Closes #450 

## Checklists

### Security

- [X] Security impact of change has been considered
- [X] Code follows security best practices and guidelines

### Code review 

- [X] Pull request has a descriptive title and context useful to a reviewer
