### PR TITLE
Attach model, explore and test names to data tests with SQL errors

### DIFF
--- a/spectacles/validators/data_test.py
+++ b/spectacles/validators/data_test.py
@@ -49,6 +49,7 @@ class DataTestValidator(Validator):
         for test in selected_tests:
             model_name = test["model_name"]
             explore_name = test["explore_name"]
+            test_name = test["name"]
             query_url_params = test["query_url_params"]
 
             try:
@@ -70,19 +71,19 @@ class DataTestValidator(Validator):
             )
 
             results = self.client.run_lookml_test(
-                self.project.name, model=test["model_name"], test=test["name"]
+                self.project.name, model=model_name, test=test_name
             )
-            explore = test_to_explore[test["name"]]
+            explore = test_to_explore[test_name]
             explore.queried = True
             result = results[0]  # For a single test, list with length 1
 
             for error in result["errors"]:
                 explore.errors.append(
                     DataTestError(
-                        model=error["model_id"],
-                        explore=error["explore"],
+                        model=model_name,
+                        explore=explore_name,
                         message=error["message"],
-                        test_name=result["test_name"],
+                        test_name=test_name,
                         lookml_url=lookml_url,
                         explore_url=explore_url,
                     )


### PR DESCRIPTION
## Change description

When a SQL error occurs during a data test, we don't attach the model name, explore name and test name to the error object because the JSON response from Looker is different. This PR makes a small change to fix this.

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Checklists

### Security

- [X] Security impact of change has been considered
- [X] Code follows security best practices and guidelines

### Code review 

- [X] Pull request has a descriptive title and context useful to a reviewer
