### PR TITLE
Properly handle failed runs without dimension errors

### DIFF
--- a/spectacles/exceptions.py
+++ b/spectacles/exceptions.py
@@ -79,6 +79,7 @@ class ValidationError(GenericValidationError):
         self.model = model
         self.explore = explore
         self.metadata = metadata
+        self._ignore: bool = False
         super().__init__()
 
     def __eq__(self, other):
@@ -89,6 +90,19 @@ class ValidationError(GenericValidationError):
 
     def __repr__(self):
         return self.message
+
+    @property
+    def ignore(self) -> bool:
+        # Hide this in a property so we can skip it in `to_dict`
+        return self._ignore
+
+    @ignore.setter
+    def ignore(self, value: bool) -> None:
+        self._ignore = value
+
+    def to_dict(self) -> dict:
+        """Returns a dictionary representation, scrubbed of private attributes"""
+        return {k: v for k, v in self.__dict__.items() if not k.startswith("_")}
 
 
 class LookMLError(ValidationError):

--- a/spectacles/lookml.py
+++ b/spectacles/lookml.py
@@ -332,15 +332,22 @@ class Project(LookMlObject):
                     status = "skipped"
                 elif explore.errored and validator != "sql":
                     status = "failed"
-                    errors.extend([e.__dict__ for e in explore.errors])
+                    errors.extend([e.to_dict() for e in explore.errors])
                 elif explore.errored and fail_fast is True:
                     status = "failed"
-                    errors.append(explore.errors[0].__dict__)
+                    errors.append(explore.errors[0].to_dict())
                 elif explore.errored:
-                    for dimension in explore.dimensions:
-                        if dimension.errored:
-                            status = "failed"
-                            errors.extend([e.__dict__ for e in dimension.errors])
+                    dimension_errors = [e for d in explore.dimensions for e in d.errors]
+                    # If an explore has explore-level errors but not dimension-level
+                    # errors, return those instead. Skip anything marked as ignored.
+                    relevant_errors = [
+                        e.to_dict()
+                        for e in (dimension_errors or explore.errors)
+                        if not e.ignore
+                    ]
+                    if relevant_errors:
+                        status = "failed"
+                        errors.extend(relevant_errors)
                 test: Dict[str, Any] = {
                     "model": model.name,
                     "explore": explore.name,

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -349,12 +349,12 @@ class Runner:
                 )
 
                 for dimension in project.iter_dimensions(errored=True):
-                    dimension.errors = [
-                        error
-                        for error in dimension.errors
-                        if not isinstance(error, SqlError)
-                        or (dimension.name, error.metadata["sql"]) not in target_sql
-                    ]
+                    for error in dimension.errors:
+                        if (
+                            isinstance(error, SqlError)
+                            and (dimension.name, error.metadata["sql"]) in target_sql
+                        ):
+                            error.ignore = True
 
         results = project.get_results(validator="sql", fail_fast=fail_fast)
         return results

--- a/spectacles/validators/lookml.py
+++ b/spectacles/validators/lookml.py
@@ -57,7 +57,7 @@ class LookMLValidator:
 
         result = {
             "validator": "lookml",
-            "errors": [error.__dict__ for error in errors],
+            "errors": [error.to_dict() for error in errors],
             "status": status,
         }
         return result


### PR DESCRIPTION
## Change description

This change fixes an issue where the explore-level query would error but the dimension-level queries would pass, resulting in a run status inconsistent with error results.

This change adds some logic to the way results are retrieved from the project to return the explore-level errors if no dimension-level errors are found. However, this naive approach broke the way incremental errors are handled, since we couldn't differentiate between the incremental case and the problematic case.

So I've introduced a new attribute on the ValidationError class, `ignore`, which is used by incremental runs to tell the `get_results` method to skip those errors as duplicated.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Closes #512

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
