### PR TITLE
Remove redundant CLI args

### DIFF
--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -505,15 +505,6 @@ def _build_select_subparser(
             The '*' wildcard selects all models or explores. For instance,\
             'model_name/*' would select all explores in the 'model_name' model.",
     )
-    base_subparser.add_argument(
-        "--exclude",
-        nargs="+",
-        default=[],
-        help="Specify the explores Spectacles should exclude when testing. \
-            List of strings in 'model_name/explore_name' format. \
-            The '*' wildcard excludes all models or explores. For instance,\
-            'model_name/*' would select all explores in the 'model_name' model.",
-    )
     return base_subparser
 
 
@@ -676,13 +667,6 @@ def _build_content_subparser(
         "--exclude-personal",
         action="store_true",
         help="Exclude errors found in content in personal folders.",
-    )
-    subparser.add_argument(
-        "--exclude-folders",
-        type=int,
-        nargs="+",
-        help="Exclude errors found in folders specified by id.",
-        default=[],
     )
     subparser.add_argument(
         "--folders",


### PR DESCRIPTION
## Change description

When we consolidated the 'include' and 'exclude' CLI args, we forgot to remove the exclude ones from the CLI itself. This is a small PR to do so.

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

No relevant issue. It is a small change and was discovered doing other work in the repo.

## Checklists

### Security

- [X] Security impact of change has been considered
- [X] Code follows security best practices and guidelines

### Code review 

- [X] Pull request has a descriptive title and context useful to a reviewer
