### PR TITLE
Fix profiler and chunking issue

### DIFF
--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -319,7 +319,7 @@ class Runner:
         )
 
         with self.branch_manager(ref=ref):
-            validator.run_tests(tests, profile)
+            validator.run_tests(tests, profile=profile if fail_fast else False)
 
         # Create dimension tests for the desired ref when explores errored
         if not fail_fast:

--- a/spectacles/validators/sql.py
+++ b/spectacles/validators/sql.py
@@ -120,7 +120,7 @@ def print_profile_results(
             headers=[
                 "Type",
                 "Name",
-                "Total Runtime (s)",
+                "Runtime (s)",
                 "Query IDs",
                 "Explore From Here",
             ],

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -192,7 +192,7 @@ class TestValidateFail:
 def test_create_and_run_keyboard_interrupt_cancels_queries(validator):
     validator._test_by_task_id = {
         "abc": SqlTest(
-            queries=[Query(12345)],
+            queries=[Query(12345, "https://example.looker.com/x/12345")],
             lookml_ref=None,
             query_task_id="abc",
             explore_url="https://example.looker.com/x/12345",
@@ -207,7 +207,7 @@ def test_create_and_run_keyboard_interrupt_cancels_queries(validator):
         validator.run_tests(
             [
                 SqlTest(
-                    queries=[Query(67890)],
+                    queries=[Query(67890, "https://example.looker.com/x/56789")],
                     lookml_ref=None,
                     query_task_id="def",
                     explore_url="https://example.looker.com/x/56789",


### PR DESCRIPTION
## Change description

This change makes two fixes:

### Profiler problems

When we adjusted the profiler to account for incremental and query chunking, I assumed that users would want to see the profiler results printed out by test, rather than by query. It turns out this is not that useful, as users running the profiler are trying to debug long-running queries and don't really need to know what tests they're part of. Also, on non-fail-fast runs, we were performing profiling twice.

This change goes back to the old behavior of showing profile results at the query level, and removes the redundant profiling step when in non-fail-fast mode.

### Bug in query chunking

We were not using the correct query for compiling SQL and generating the Explore from Here URL for SQL tests. This caused unexpected results when in incremental mode for Explores with more than 500 dimensions.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

N/A

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
