### PR TITLE
Log for all exception encountered when parsing Looker query results

### DIFF
--- a/spectacles/validators/sql.py
+++ b/spectacles/validators/sql.py
@@ -309,9 +309,9 @@ class SqlValidator:
             if status == "error":
                 try:
                     error_details = self._extract_error_details(result)
-                except (KeyError, TypeError, IndexError) as error:
+                except Exception as error:
                     logger.debug(
-                        f"Exiting because of unexpected query result format: {result}"
+                        f"Unable to parse unexpected query result format: {result}"
                     )
                     raise SpectaclesException(
                         name="unexpected-query-result-format",


### PR DESCRIPTION
## Change description

When extracting error details from Looker query results, we should log the query result if we're unable to parse it to assist with debugging.

In fact, we were already doing this, but for a too narrow scope of exception types. This expands the try/except to include all `Exception`, which will catch the `AttributeError` that we've been encountering.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Closes #525

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
