### PR TITLE
Assorted fixes for 2.0.5

### DIFF
--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -617,7 +617,7 @@ class LookerClient:
                 names are returned in the format 'explore_name.dimension_name'.
 
         """
-        logger.debug(f"Getting all dimensions from explore {explore}")
+        logger.debug(f"Getting all dimensions from explore {model}/{explore}")
         params = {"fields": ["fields"]}
         url = utils.compose_url(
             self.api_url,

--- a/spectacles/validators/sql.py
+++ b/spectacles/validators/sql.py
@@ -72,7 +72,7 @@ class SqlTest:
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, self.__class__):
             if self.sql and other.sql:
-                return self.sql == other.sql
+                return self.sql == other.sql and self.lookml_ref == other.lookml_ref
             else:
                 return self.lookml_ref == other.lookml_ref
         else:
@@ -81,7 +81,7 @@ class SqlTest:
     def __hash__(self) -> int:
         if self.sql is None:
             raise ValueError("Test has no SQL defined")
-        return hash(self.lookml_ref.name + self.sql)
+        return hash(self.lookml_ref.model_name + self.lookml_ref.name + self.sql)
 
     def __dict__(self):
         metadata = {"explore_url": self.explore_url}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -102,3 +102,11 @@ class TestLogDurationDecorator(unittest.TestCase):
             decorated_func = utils.log_duration(func)
             decorated_func()
         self.assertIn("INFO:spectacles:Completed validation in", cm.output[0])
+
+
+def test_chunks_returns_expected_results():
+    to_chunk = list(range(10))  # has length of 10
+    assert len(list(utils.chunks(to_chunk, 5))) == 2
+    assert len(list(utils.chunks(to_chunk, 9))) == 2
+    assert len(list(utils.chunks(to_chunk, 10))) == 1
+    assert len(list(utils.chunks(to_chunk, 11))) == 1


### PR DESCRIPTION
## Change description

A nice medley of bugfixes...

1. No longer generate an extra `create_query` call to the Looker API when an explore has N dimensions < chunk size
2. Fix an issue where 2 explores in different models with the same name and same compiled SQL caused one explore to be queried in dimension mode regardless of SQL uniqueness
3. To be safe, we're comparing explores on the hash of their SQL + fully qualified name and not just name (e.g. `model/explore` instead of `explore`

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
