### PR TITLE
 Provide ability for users to pin locally imported projects to specific git refs

### DIFF
--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -1,6 +1,6 @@
 import re
 from spectacles.exceptions import LookerApiError, SqlError
-from typing import List, Optional, cast, Tuple
+from typing import Dict, List, Optional, cast, Tuple
 from dataclasses import dataclass
 import itertools
 from spectacles.client import LookerClient
@@ -33,21 +33,23 @@ def is_commit(string: str) -> bool:
 
 
 class LookerBranchManager:
-    def __init__(self, client: LookerClient, project: str, remote_reset: bool = False):
+    def __init__(
+        self,
+        client: LookerClient,
+        project: str,
+        remote_reset: bool = False,
+        pin_imports: Dict[str, str] = {},
+    ):
         """Context manager for Git branch checkout, creation, and deletion."""
         logger.debug(f"Setting up branch manager in project '{project}'")
         self.client = client
         self.project = project
         self.remote_reset = remote_reset
+        self.pin_imports = pin_imports
 
         state: ProjectState = self.get_project_state()
         self.workspace: str = state.workspace
         self.history: List[ProjectState] = [state]
-        self.imports: List[str] = self.get_project_imports()
-        logger.debug(
-            f"Project '{self.project}' imports the following projects: {self.imports}"
-        )
-
         self.commit: Optional[str] = None
         self.branch: Optional[str] = None
         self.is_temp_branch: bool = False
@@ -121,6 +123,11 @@ class LookerBranchManager:
             f"[ephemeral = {self.ephemeral}]"
         )
 
+        self.imports: List[str] = self.get_project_imports()
+        logger.debug(
+            f"Project '{self.project}' imports the following projects: {self.imports}"
+        )
+
         # Create temporary branches off production for manifest dependencies
         if not self.imports:
             logger.debug(f"Project '{self.project}' doesn't import any other projects")
@@ -131,8 +138,9 @@ class LookerBranchManager:
         else:
             logger.debug("Creating temporary branches in imported projects")
             for project in self.imports:
+                import_ref = self.pin_imports.get(project, None)
                 manager = LookerBranchManager(self.client, project)
-                manager(ephemeral=True).__enter__()
+                manager(ref=import_ref, ephemeral=True).__enter__()
                 self.import_managers.append(manager)
 
         logger.indent(-1)
@@ -239,10 +247,13 @@ class Runner:
         client: LookerClient,
         project: str,
         remote_reset: bool = False,
+        pin_imports: Dict[str, str] = {},
     ):
         self.project = project
         self.client = client
-        self.branch_manager = LookerBranchManager(client, project, remote_reset)
+        self.branch_manager = LookerBranchManager(
+            client, project, remote_reset, pin_imports
+        )
 
     def validate_sql(
         self,

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -139,7 +139,9 @@ class LookerBranchManager:
             logger.debug("Creating temporary branches in imported projects")
             for project in self.imports:
                 import_ref = self.pin_imports.get(project, None)
-                manager = LookerBranchManager(self.client, project)
+                manager = LookerBranchManager(
+                    self.client, project, pin_imports=self.pin_imports
+                )
                 manager(ref=import_ref, ephemeral=True).__enter__()
                 self.import_managers.append(manager)
 

--- a/tests/cassettes/test_runner/test_incremental_sql_with_diff_explores_and_invalid_diff_sql_should_error.yaml
+++ b/tests/cassettes/test_runner/test_incremental_sql_with_diff_explores_and_invalid_diff_sql_should_error.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -17,19 +17,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:40 GMT
+      - Tue, 05 Apr 2022 13:56:33 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - e1f0b46349e7f525
+      - 3b04fd929eb15883
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - e1f0b46349e7f525
+      - 3b04fd929eb15883
       X-B3-TraceId:
-      - 62475a9c93766e8de1f0b46349e7f525
+      - 624c4a9173d484df3b04fd929eb15883
       X-Content-Type-Options:
       - nosniff
     status:
@@ -39,7 +39,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -53,56 +53,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:40 GMT
+      - Tue, 05 Apr 2022 13:56:33 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 69d29a563ebb6592
+      - 825ca1de919a9a44
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 69d29a563ebb6592
+      - 825ca1de919a9a44
       X-B3-TraceId:
-      - 62475a9c4082c8ba69d29a563ebb6592
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
-  response:
-    body:
-      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '147'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:40 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - ed644043086ccbc8
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - ed644043086ccbc8
-      X-B3-TraceId:
-      - 62475a9ceac4e4d1ed644043086ccbc8
+      - 624c4a9133b5a680825ca1de919a9a44
       X-Content-Type-Options:
       - nosniff
     status:
@@ -116,7 +80,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -130,19 +94,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:41 GMT
+      - Tue, 05 Apr 2022 13:56:33 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - a6088d0ef0ddd61e
+      - 2ef34dd1d26e3597
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a6088d0ef0ddd61e
+      - 2ef34dd1d26e3597
       X-B3-TraceId:
-      - 62475a9d0be0af4ea6088d0ef0ddd61e
+      - 624c4a9132a1c9c42ef34dd1d26e3597
       X-Content-Type-Options:
       - nosniff
     status:
@@ -152,7 +116,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -166,19 +130,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:41 GMT
+      - Tue, 05 Apr 2022 13:56:33 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f552f592f419795a
+      - 458d72769ea36473
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f552f592f419795a
+      - 458d72769ea36473
       X-B3-TraceId:
-      - 62475a9d19d24b9ef552f592f419795a
+      - 624c4a910df8df6f458d72769ea36473
       X-Content-Type-Options:
       - nosniff
     status:
@@ -188,34 +152,34 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest","remote":"origin","remote_name":"pytest","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":"742b118d314d2478a215aa02016c09e173deec7e","can":{}}'
+      string: '{"name":"pytest-incremental-invalid-diff","remote":"origin","remote_name":"pytest-incremental-invalid-diff","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648842807,"ref":"1ddde0b0dbf09b486b13669171528fd299fbb903","remote_ref":"1ddde0b0dbf09b486b13669171528fd299fbb903","can":{}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '363'
+      - '413'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:41 GMT
+      - Tue, 05 Apr 2022 13:56:33 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 0ae518f663bfb41e
+      - 964fe725fb856600
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 0ae518f663bfb41e
+      - 964fe725fb856600
       X-B3-TraceId:
-      - 62475a9d101011bd0ae518f663bfb41e
+      - 624c4a91218f5cdc964fe725fb856600
       X-Content-Type-Options:
       - nosniff
     status:
@@ -229,12 +193,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":null,"can":{}}'
+      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648842807,"ref":"1ddde0b0dbf09b486b13669171528fd299fbb903","remote_ref":null,"can":{}}'
     headers:
       Connection:
       - keep-alive
@@ -243,20 +207,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:41 GMT
+      - Tue, 05 Apr 2022 13:56:33 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 50bbed887936beec
+      - 0bd0beb92e857485
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 50bbed887936beec
+      - 0bd0beb92e857485
       X-B3-TraceId:
-      - 62475a9d3a36155550bbed887936beec
+      - 624c4a91e4ed9bd70bd0beb92e857485
       X-Content-Type-Options:
       - nosniff
     status:
@@ -270,12 +234,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":null,"can":{}}'
+      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648842807,"ref":"1ddde0b0dbf09b486b13669171528fd299fbb903","remote_ref":null,"can":{}}'
     headers:
       Connection:
       - keep-alive
@@ -284,20 +248,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:43 GMT
+      - Tue, 05 Apr 2022 13:56:35 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 5252d4cfb86cac30
+      - c876c6ad44a475d1
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 5252d4cfb86cac30
+      - c876c6ad44a475d1
       X-B3-TraceId:
-      - 62475a9d790d8f7f5252d4cfb86cac30
+      - 624c4a91e631d997c876c6ad44a475d1
       X-Content-Type-Options:
       - nosniff
     status:
@@ -307,7 +271,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:35 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 7851d3318482bf43
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 7851d3318482bf43
+      X-B3-TraceId:
+      - 624c4a93c4a6df967851d3318482bf43
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -321,19 +321,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:43 GMT
+      - Tue, 05 Apr 2022 13:56:36 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 651c1dfe2a17c718
+      - 7dd74df1edb8e293
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 651c1dfe2a17c718
+      - 7dd74df1edb8e293
       X-B3-TraceId:
-      - 62475a9f94cfa15c651c1dfe2a17c718
+      - 624c4a9318dc3efe7dd74df1edb8e293
       X-Content-Type-Options:
       - nosniff
     status:
@@ -343,7 +343,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -357,20 +357,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:43 GMT
+      - Tue, 05 Apr 2022 13:56:36 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 76c7f907fdad309a
+      - 444e0bb212cd1330
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 76c7f907fdad309a
+      - 444e0bb212cd1330
       X-B3-TraceId:
-      - 62475a9f55d221f176c7f907fdad309a
+      - 624c4a947b37ff0e444e0bb212cd1330
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:36 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - c5d4f81e1b5a83b9
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - c5d4f81e1b5a83b9
+      X-B3-TraceId:
+      - 624c4a94c6b715fac5d4f81e1b5a83b9
       X-Content-Type-Options:
       - nosniff
     status:
@@ -380,7 +420,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:36 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 59735bd39693d0e1
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 59735bd39693d0e1
+      X-B3-TraceId:
+      - 624c4a94906d3f4159735bd39693d0e1
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:36 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 92baeaf0d0cff5e4
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 92baeaf0d0cff5e4
+      X-B3-TraceId:
+      - 624c4a9493dfbc6792baeaf0d0cff5e4
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:36 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 4197339027d2e909
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 4197339027d2e909
+      X-B3-TraceId:
+      - 624c4a9417236c7a4197339027d2e909
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:36 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 2049f2b737c3d1f1
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 2049f2b737c3d1f1
+      X-B3-TraceId:
+      - 624c4a940a9b77612049f2b737c3d1f1
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:36 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 202bced0325aee5a
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 202bced0325aee5a
+      X-B3-TraceId:
+      - 624c4a94dbb9e8b8202bced0325aee5a
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_b"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:36 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - ed66bb4f34640106
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - ed66bb4f34640106
+      X-B3-TraceId:
+      - 624c4a943263d0e1ed66bb4f34640106
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_b", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:37 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 8235e65e45c1ff58
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 8235e65e45c1ff58
+      X-B3-TraceId:
+      - 624c4a95961bde618235e65e45c1ff58
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -429,325 +737,17 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:03:43 GMT
+      - Tue, 05 Apr 2022 13:56:37 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:43 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 7bdd4843f3bee538
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 7bdd4843f3bee538
-      X-B3-TraceId:
-      - 62475a9f729c5fc97bdd4843f3bee538
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:43 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - c3b40c87905ae981
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - c3b40c87905ae981
-      X-B3-TraceId:
-      - 62475a9f2e523616c3b40c87905ae981
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:43 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - a4e691406fc3198f
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - a4e691406fc3198f
-      X-B3-TraceId:
-      - 62475a9f4722b7caa4e691406fc3198f
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:44 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - b10a1f8138a3927f
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - b10a1f8138a3927f
-      X-B3-TraceId:
-      - 62475aa07eab898db10a1f8138a3927f
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:44 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - b680447c841482d6
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - b680447c841482d6
-      X-B3-TraceId:
-      - 62475aa0c84e7a57b680447c841482d6
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:44 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - b5a2747321abbb8e
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - b5a2747321abbb8e
-      X-B3-TraceId:
-      - 62475aa011346cb5b5a2747321abbb8e
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_b"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:44 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - c2c1b75555626246
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - c2c1b75555626246
-      X-B3-TraceId:
-      - 62475aa058d74616c2c1b75555626246
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_b", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:45 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - dd7c8449135a65f4
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - dd7c8449135a65f4
-      X-B3-TraceId:
-      - 62475aa0ef758c12dd7c8449135a65f4
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models?fields=name%2Cproject_name%2Cexplores
   response:
@@ -831,20 +831,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:46 GMT
+      - Tue, 05 Apr 2022 13:56:38 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 6088e7b0658dabe3
+      - 257991f2d68b04c3
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6088e7b0658dabe3
+      - 257991f2d68b04c3
       X-B3-TraceId:
-      - 62475aa1e4a713706088e7b0658dabe3
+      - 624c4a9518ec4f5b257991f2d68b04c3
       X-Content-Type-Options:
       - nosniff
     status:
@@ -854,7 +854,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users?fields=fields
   response:
@@ -885,20 +885,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:46 GMT
+      - Tue, 05 Apr 2022 13:56:38 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 17ec32ef48371b0a
+      - 8b891c47c2611080
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 17ec32ef48371b0a
+      - 8b891c47c2611080
       X-B3-TraceId:
-      - 62475aa2c5984f5d17ec32ef48371b0a
+      - 624c4a9604ce246f8b891c47c2611080
       X-Content-Type-Options:
       - nosniff
     status:
@@ -908,7 +908,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users__fail?fields=fields
   response:
@@ -944,20 +944,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:46 GMT
+      - Tue, 05 Apr 2022 13:56:38 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - e59a37917cf84902
+      - f3aeb8abe050ecc1
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - e59a37917cf84902
+      - f3aeb8abe050ecc1
       X-B3-TraceId:
-      - 62475aa21f015595e59a37917cf84902
+      - 624c4a96e0e2c63df3aeb8abe050ecc1
       X-Content-Type-Options:
       - nosniff
     status:
@@ -973,7 +973,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -987,19 +987,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:46 GMT
+      - Tue, 05 Apr 2022 13:56:38 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - c129758ef3448d40
+      - 6ef403cd4738e078
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - c129758ef3448d40
+      - 6ef403cd4738e078
       X-B3-TraceId:
-      - 62475aa26b19619bc129758ef3448d40
+      - 624c4a96678283fe6ef403cd4738e078
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1009,7 +1009,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/2216/run/sql
   response:
@@ -1026,19 +1026,19 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:03:46 GMT
+      - Tue, 05 Apr 2022 13:56:39 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 50013b2ca4f6fcea
+      - 1ac9d3e0d632c0bb
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 50013b2ca4f6fcea
+      - 1ac9d3e0d632c0bb
       X-B3-TraceId:
-      - 62475aa22157091f50013b2ca4f6fcea
+      - 624c4a9656e1a2531ac9d3e0d632c0bb
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1054,7 +1054,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -1068,19 +1068,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:46 GMT
+      - Tue, 05 Apr 2022 13:56:39 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 84eaaa0adc475921
+      - 237807dae61808f9
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 84eaaa0adc475921
+      - 237807dae61808f9
       X-B3-TraceId:
-      - 62475aa2cf1b36e484eaaa0adc475921
+      - 624c4a9780cb5f16237807dae61808f9
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1090,7 +1090,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/1944/run/sql
   response:
@@ -1108,60 +1108,60 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:03:46 GMT
+      - Tue, 05 Apr 2022 13:56:39 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - ea1095c78dc030c5
+      - bc3cf7f36d036126
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - ea1095c78dc030c5
+      - bc3cf7f36d036126
       X-B3-TraceId:
-      - 62475aa20724df92ea1095c78dc030c5
+      - 624c4a979f98fc2dbc3cf7f36d036126
       X-Content-Type-Options:
       - nosniff
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "pytest"}'
+    body: '{"name": "pytest-incremental-invalid-diff"}'
     headers:
       Content-Length:
-      - '18'
+      - '43'
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest","remote":"origin","remote_name":"pytest","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":"742b118d314d2478a215aa02016c09e173deec7e","can":{}}'
+      string: '{"name":"pytest-incremental-invalid-diff","remote":"origin","remote_name":"pytest-incremental-invalid-diff","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648842807,"ref":"1ddde0b0dbf09b486b13669171528fd299fbb903","remote_ref":"1ddde0b0dbf09b486b13669171528fd299fbb903","can":{}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '363'
+      - '413'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:47 GMT
+      - Tue, 05 Apr 2022 13:56:40 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 4e703e7fe27efd19
+      - f8df36d4327d4933
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 4e703e7fe27efd19
+      - f8df36d4327d4933
       X-B3-TraceId:
-      - 62475aa334d2f0cf4e703e7fe27efd19
+      - 624c4a97edb6cb61f8df36d4327d4933
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1173,7 +1173,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_a
   response:
@@ -1183,19 +1183,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:03:48 GMT
+      - Tue, 05 Apr 2022 13:56:41 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - cbe2e6cb69519f32
+      - 0c1123b66433c118
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - cbe2e6cb69519f32
+      - 0c1123b66433c118
       X-B3-TraceId:
-      - 62475aa3d6ffc84ecbe2e6cb69519f32
+      - 624c4a980e7915a60c1123b66433c118
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1209,7 +1209,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -1223,20 +1223,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:49 GMT
+      - Tue, 05 Apr 2022 13:56:41 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 8ce27b863c6d8a31
+      - fa1093ac07fbfc05
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 8ce27b863c6d8a31
+      - fa1093ac07fbfc05
       X-B3-TraceId:
-      - 62475aa4644f61118ce27b863c6d8a31
+      - 624c4a99bfff366afa1093ac07fbfc05
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1248,7 +1248,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_b
   response:
@@ -1258,19 +1258,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:03:49 GMT
+      - Tue, 05 Apr 2022 13:56:41 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - d4265d84673ab177
+      - fc87d542c749da62
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - d4265d84673ab177
+      - fc87d542c749da62
       X-B3-TraceId:
-      - 62475aa5463b5a68d4265d84673ab177
+      - 624c4a997539e7abfc87d542c749da62
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1284,7 +1284,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -1298,20 +1298,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:49 GMT
+      - Tue, 05 Apr 2022 13:56:42 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - ca31003bb2fb281b
+      - 34bc194cc56899d4
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - ca31003bb2fb281b
+      - 34bc194cc56899d4
       X-B3-TraceId:
-      - 62475aa52717daefca31003bb2fb281b
+      - 624c4a99fec6ccb034bc194cc56899d4
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1325,7 +1325,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1339,19 +1339,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:50 GMT
+      - Tue, 05 Apr 2022 13:56:42 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - ca153bdd01eab1c4
+      - 63016694bd03eb23
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - ca153bdd01eab1c4
+      - 63016694bd03eb23
       X-B3-TraceId:
-      - 62475aa6277dcac9ca153bdd01eab1c4
+      - 624c4a9aaa63a9d963016694bd03eb23
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1365,7 +1365,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1379,19 +1379,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:50 GMT
+      - Tue, 05 Apr 2022 13:56:42 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 5c35675865e51b0e
+      - 447d02fc63d3d526
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 5c35675865e51b0e
+      - 447d02fc63d3d526
       X-B3-TraceId:
-      - 62475aa6cd077fc85c35675865e51b0e
+      - 624c4a9a2b8cca5a447d02fc63d3d526
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1401,7 +1401,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1415,19 +1415,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:50 GMT
+      - Tue, 05 Apr 2022 13:56:42 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - aab5533a1923b4ef
+      - 4aa87e80c6a8869c
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - aab5533a1923b4ef
+      - 4aa87e80c6a8869c
       X-B3-TraceId:
-      - 62475aa6b6c78ea8aab5533a1923b4ef
+      - 624c4a9ac8f336234aa87e80c6a8869c
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1437,34 +1437,34 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest","remote":"origin","remote_name":"pytest","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":"742b118d314d2478a215aa02016c09e173deec7e","can":{}}'
+      string: '{"name":"pytest-incremental-invalid-diff","remote":"origin","remote_name":"pytest-incremental-invalid-diff","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648842807,"ref":"1ddde0b0dbf09b486b13669171528fd299fbb903","remote_ref":"1ddde0b0dbf09b486b13669171528fd299fbb903","can":{}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '363'
+      - '413'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:50 GMT
+      - Tue, 05 Apr 2022 13:56:42 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 521160ce5f2b7ae9
+      - 2ba4d27dfad0bc4f
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 521160ce5f2b7ae9
+      - 2ba4d27dfad0bc4f
       X-B3-TraceId:
-      - 62475aa6e176812c521160ce5f2b7ae9
+      - 624c4a9aecb0289c2ba4d27dfad0bc4f
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1478,12 +1478,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"tmp_spectacles_c","remote":"origin","remote_name":"tmp_spectacles_c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":null,"can":{}}'
+      string: '{"name":"tmp_spectacles_c","remote":"origin","remote_name":"tmp_spectacles_c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648842807,"ref":"1ddde0b0dbf09b486b13669171528fd299fbb903","remote_ref":null,"can":{}}'
     headers:
       Connection:
       - keep-alive
@@ -1492,20 +1492,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:50 GMT
+      - Tue, 05 Apr 2022 13:56:43 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 7154e47f0c8e3748
+      - d422b6fadebcd956
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 7154e47f0c8e3748
+      - d422b6fadebcd956
       X-B3-TraceId:
-      - 62475aa624dc94317154e47f0c8e3748
+      - 624c4a9afccaabd5d422b6fadebcd956
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1519,12 +1519,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"tmp_spectacles_c","remote":"origin","remote_name":"tmp_spectacles_c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":null,"can":{}}'
+      string: '{"name":"tmp_spectacles_c","remote":"origin","remote_name":"tmp_spectacles_c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648842807,"ref":"1ddde0b0dbf09b486b13669171528fd299fbb903","remote_ref":null,"can":{}}'
     headers:
       Connection:
       - keep-alive
@@ -1533,20 +1533,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:52 GMT
+      - Tue, 05 Apr 2022 13:56:45 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 9881907538c08d1c
+      - b7cbc0c5e446b728
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 9881907538c08d1c
+      - b7cbc0c5e446b728
       X-B3-TraceId:
-      - 62475aa63a0a586b9881907538c08d1c
+      - 624c4a9b927c9ccfb7cbc0c5e446b728
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1556,7 +1556,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:45 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - c141ef27484b3221
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - c141ef27484b3221
+      X-B3-TraceId:
+      - 624c4a9d83d34f65c141ef27484b3221
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1570,19 +1606,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:52 GMT
+      - Tue, 05 Apr 2022 13:56:45 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 8dadce68e7d5d07f
+      - cbecdfa2d49a549a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 8dadce68e7d5d07f
+      - cbecdfa2d49a549a
       X-B3-TraceId:
-      - 62475aa811f99e028dadce68e7d5d07f
+      - 624c4a9d222d431bcbecdfa2d49a549a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1592,7 +1628,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -1606,20 +1642,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:52 GMT
+      - Tue, 05 Apr 2022 13:56:45 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f0672474c37333c4
+      - badf511b603f5188
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f0672474c37333c4
+      - badf511b603f5188
       X-B3-TraceId:
-      - 62475aa818702c00f0672474c37333c4
+      - 624c4a9d925f7e6abadf511b603f5188
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:45 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - d41996513f92c05b
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - d41996513f92c05b
+      X-B3-TraceId:
+      - 624c4a9deef664fcd41996513f92c05b
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1629,7 +1705,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:45 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - c3decebbd3d362c4
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - c3decebbd3d362c4
+      X-B3-TraceId:
+      - 624c4a9d310fdfb8c3decebbd3d362c4
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:45 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 9ebb32b7161fcf48
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 9ebb32b7161fcf48
+      X-B3-TraceId:
+      - 624c4a9d9a345e7d9ebb32b7161fcf48
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:45 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 8300174fb50cc084
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 8300174fb50cc084
+      X-B3-TraceId:
+      - 624c4a9de64cc7498300174fb50cc084
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:45 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 3d6682af24300100
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 3d6682af24300100
+      X-B3-TraceId:
+      - 624c4a9d9f5653583d6682af24300100
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:45 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - bb17c8d6ad5b9596
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - bb17c8d6ad5b9596
+      X-B3-TraceId:
+      - 624c4a9db6300a09bb17c8d6ad5b9596
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_d"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_d","remote":"origin","remote_name":"tmp_spectacles_d","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:46 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 8d3c086d523f7018
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 8d3c086d523f7018
+      X-B3-TraceId:
+      - 624c4a9db8c07d768d3c086d523f7018
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_d", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_d","remote":"origin","remote_name":"tmp_spectacles_d","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:46 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 3bdf8928591c282b
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 3bdf8928591c282b
+      X-B3-TraceId:
+      - 624c4a9e04aa1fc13bdf8928591c282b
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -1678,325 +2022,17 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:03:52 GMT
+      - Tue, 05 Apr 2022 13:56:46 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:53 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - bf6aa3bbfa9bdc9e
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - bf6aa3bbfa9bdc9e
-      X-B3-TraceId:
-      - 62475aa9a297c920bf6aa3bbfa9bdc9e
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:53 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - '8910308604812481'
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - '8910308604812481'
-      X-B3-TraceId:
-      - 62475aa93f16c6c78910308604812481
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:53 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - b7097a4b92eacce5
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - b7097a4b92eacce5
-      X-B3-TraceId:
-      - 62475aa9d69ebbcdb7097a4b92eacce5
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:53 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 834ce97bc7596e39
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 834ce97bc7596e39
-      X-B3-TraceId:
-      - 62475aa9c04eb2ba834ce97bc7596e39
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:53 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 7f573f1dceb08d0d
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 7f573f1dceb08d0d
-      X-B3-TraceId:
-      - 62475aa94b09fe497f573f1dceb08d0d
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:53 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - babfe285ab56b229
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - babfe285ab56b229
-      X-B3-TraceId:
-      - 62475aa90a39ce26babfe285ab56b229
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_d"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_d","remote":"origin","remote_name":"tmp_spectacles_d","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:53 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 5d0540eff697994e
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 5d0540eff697994e
-      X-B3-TraceId:
-      - 62475aa9a605ea895d0540eff697994e
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_d", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_d","remote":"origin","remote_name":"tmp_spectacles_d","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:54 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - a326db4863cdb7c4
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - a326db4863cdb7c4
-      X-B3-TraceId:
-      - 62475aa92b9afa30a326db4863cdb7c4
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models?fields=name%2Cproject_name%2Cexplores
   response:
@@ -2080,20 +2116,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:55 GMT
+      - Tue, 05 Apr 2022 13:56:47 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 1e22589d0228974c
+      - a167c512dcd3423e
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 1e22589d0228974c
+      - a167c512dcd3423e
       X-B3-TraceId:
-      - 62475aaab1aefe0f1e22589d0228974c
+      - 624c4a9ed3abaa0ca167c512dcd3423e
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2103,7 +2139,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users?fields=fields
   response:
@@ -2134,20 +2170,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:55 GMT
+      - Tue, 05 Apr 2022 13:56:47 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 6d64dee92d760d07
+      - 4f20e177a8312af4
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6d64dee92d760d07
+      - 4f20e177a8312af4
       X-B3-TraceId:
-      - 62475aab5657e1f86d64dee92d760d07
+      - 624c4a9f82b1e1964f20e177a8312af4
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2157,7 +2193,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users__fail?fields=fields
   response:
@@ -2193,20 +2229,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:55 GMT
+      - Tue, 05 Apr 2022 13:56:48 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - d3ba909e42616b53
+      - 845149005fec8253
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - d3ba909e42616b53
+      - 845149005fec8253
       X-B3-TraceId:
-      - 62475aab6235df3cd3ba909e42616b53
+      - 624c4a9fdd38fa1b845149005fec8253
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2222,7 +2258,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -2236,19 +2272,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:55 GMT
+      - Tue, 05 Apr 2022 13:56:48 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 6a30cbb2729f25ab
+      - 1b182129e2105df3
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6a30cbb2729f25ab
+      - 1b182129e2105df3
       X-B3-TraceId:
-      - 62475aab310335136a30cbb2729f25ab
+      - 624c4aa0098db9db1b182129e2105df3
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2258,7 +2294,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/2216/run/sql
   response:
@@ -2275,19 +2311,19 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:03:56 GMT
+      - Tue, 05 Apr 2022 13:56:48 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 6e81bb0191852649
+      - c04350d4e30ef825
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6e81bb0191852649
+      - c04350d4e30ef825
       X-B3-TraceId:
-      - 62475aab7d6ebb3d6e81bb0191852649
+      - 624c4aa0883fcec5c04350d4e30ef825
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2303,7 +2339,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -2317,19 +2353,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:56 GMT
+      - Tue, 05 Apr 2022 13:56:48 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 8fd425002b504db8
+      - 77090e7fe98462dc
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 8fd425002b504db8
+      - 77090e7fe98462dc
       X-B3-TraceId:
-      - 62475aac5a9ecc678fd425002b504db8
+      - 624c4aa03fb84d0f77090e7fe98462dc
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2339,7 +2375,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/1944/run/sql
   response:
@@ -2357,60 +2393,60 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:03:56 GMT
+      - Tue, 05 Apr 2022 13:56:48 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 6ec6819e9f9ac3a1
+      - 0e61c475395b3a58
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6ec6819e9f9ac3a1
+      - 0e61c475395b3a58
       X-B3-TraceId:
-      - 62475aacb354351b6ec6819e9f9ac3a1
+      - 624c4aa096057cb90e61c475395b3a58
       X-Content-Type-Options:
       - nosniff
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "pytest"}'
+    body: '{"name": "pytest-incremental-invalid-diff"}'
     headers:
       Content-Length:
-      - '18'
+      - '43'
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest","remote":"origin","remote_name":"pytest","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":"742b118d314d2478a215aa02016c09e173deec7e","can":{}}'
+      string: '{"name":"pytest-incremental-invalid-diff","remote":"origin","remote_name":"pytest-incremental-invalid-diff","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648842807,"ref":"1ddde0b0dbf09b486b13669171528fd299fbb903","remote_ref":"1ddde0b0dbf09b486b13669171528fd299fbb903","can":{}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '363'
+      - '413'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:57 GMT
+      - Tue, 05 Apr 2022 13:56:49 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - b796b9d33e4ecc3e
+      - c189aa94ccfc87d3
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - b796b9d33e4ecc3e
+      - c189aa94ccfc87d3
       X-B3-TraceId:
-      - 62475aac4ace0764b796b9d33e4ecc3e
+      - 624c4aa0734e9155c189aa94ccfc87d3
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2422,7 +2458,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_c
   response:
@@ -2432,19 +2468,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:03:58 GMT
+      - Tue, 05 Apr 2022 13:56:50 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - f7ae8a36318d81e1
+      - 26f8779ac036b588
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f7ae8a36318d81e1
+      - 26f8779ac036b588
       X-B3-TraceId:
-      - 62475aad81d5c17ff7ae8a36318d81e1
+      - 624c4aa14c79325f26f8779ac036b588
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2458,7 +2494,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -2472,20 +2508,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:58 GMT
+      - Tue, 05 Apr 2022 13:56:51 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 4730ede6b3cea79b
+      - 6555498d93c9f785
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 4730ede6b3cea79b
+      - 6555498d93c9f785
       X-B3-TraceId:
-      - 62475aae58d6d0134730ede6b3cea79b
+      - 624c4aa25233893c6555498d93c9f785
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2497,7 +2533,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_d
   response:
@@ -2507,19 +2543,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:03:58 GMT
+      - Tue, 05 Apr 2022 13:56:51 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 8a2066d3ecdfc19f
+      - ac8c33a84616767d
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 8a2066d3ecdfc19f
+      - ac8c33a84616767d
       X-B3-TraceId:
-      - 62475aae00f2310c8a2066d3ecdfc19f
+      - 624c4aa391871985ac8c33a84616767d
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2533,7 +2569,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -2547,20 +2583,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:59 GMT
+      - Tue, 05 Apr 2022 13:56:51 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f463587299d01a6d
+      - c75a4d5305f1f929
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f463587299d01a6d
+      - c75a4d5305f1f929
       X-B3-TraceId:
-      - 62475aae283bb17ef463587299d01a6d
+      - 624c4aa37bfb942ec75a4d5305f1f929
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2574,7 +2610,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -2588,19 +2624,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:59 GMT
+      - Tue, 05 Apr 2022 13:56:51 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 20008aff5fe01c6f
+      - ce1d4c94237ec0a8
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 20008aff5fe01c6f
+      - ce1d4c94237ec0a8
       X-B3-TraceId:
-      - 62475aaf9d71733a20008aff5fe01c6f
+      - 624c4aa3dbe456c7ce1d4c94237ec0a8
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2614,7 +2650,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -2628,19 +2664,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:59 GMT
+      - Tue, 05 Apr 2022 13:56:51 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 2a729597535b4444
+      - fb5aff152946e647
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2a729597535b4444
+      - fb5aff152946e647
       X-B3-TraceId:
-      - 62475aaf646dd8f72a729597535b4444
+      - 624c4aa3f01b7d67fb5aff152946e647
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2654,12 +2690,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest-incremental-invalid-equal","remote":"origin","remote_name":"pytest-incremental-invalid-equal","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":4,"behind_count":3,"commit_at":1648842827,"ref":"70e6771a23b75d1c3a07bf3d0e9145bcea8750d1","remote_ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","can":{}}'
+      string: '{"name":"pytest-incremental-invalid-equal","remote":"origin","remote_name":"pytest-incremental-invalid-equal","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648842827,"ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","remote_ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","can":{}}'
     headers:
       Connection:
       - keep-alive
@@ -2668,20 +2704,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:00 GMT
+      - Tue, 05 Apr 2022 13:56:52 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 78bb43293d1f05ea
+      - d931136da9cff050
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 78bb43293d1f05ea
+      - d931136da9cff050
       X-B3-TraceId:
-      - 62475aaf9badc69e78bb43293d1f05ea
+      - 624c4aa401ab220dd931136da9cff050
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2693,7 +2729,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/reset_to_remote
   response:
@@ -2703,19 +2739,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:04:01 GMT
+      - Tue, 05 Apr 2022 13:56:53 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 3e13bda5801e2f89
+      - 3fe21aa471623bdb
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 3e13bda5801e2f89
+      - 3fe21aa471623bdb
       X-B3-TraceId:
-      - 62475ab0cad8f4ef3e13bda5801e2f89
+      - 624c4aa4d36677dd3fe21aa471623bdb
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2725,7 +2761,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:53 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - faa43447c7c0da1b
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - faa43447c7c0da1b
+      X-B3-TraceId:
+      - 624c4aa57e381759faa43447c7c0da1b
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -2739,19 +2811,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:01 GMT
+      - Tue, 05 Apr 2022 13:56:53 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - ba743bdf485c1cfa
+      - dce86a04b0c7b25e
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - ba743bdf485c1cfa
+      - dce86a04b0c7b25e
       X-B3-TraceId:
-      - 62475ab171f41a59ba743bdf485c1cfa
+      - 624c4aa537b49ec1dce86a04b0c7b25e
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2761,7 +2833,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -2775,20 +2847,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:01 GMT
+      - Tue, 05 Apr 2022 13:56:53 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 594edc184ddc02ab
+      - 342ea0afaffbcca8
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 594edc184ddc02ab
+      - 342ea0afaffbcca8
       X-B3-TraceId:
-      - 62475ab195473f77594edc184ddc02ab
+      - 624c4aa5e16aa432342ea0afaffbcca8
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:54 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - e9857cffd1fad093
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - e9857cffd1fad093
+      X-B3-TraceId:
+      - 624c4aa6e4fb6556e9857cffd1fad093
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2798,7 +2910,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:54 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - cdfdaa396fdbfbfd
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - cdfdaa396fdbfbfd
+      X-B3-TraceId:
+      - 624c4aa642db6f36cdfdaa396fdbfbfd
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:54 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 8f8f8aca40aafcfb
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 8f8f8aca40aafcfb
+      X-B3-TraceId:
+      - 624c4aa6f20f2ffc8f8f8aca40aafcfb
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:54 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 52d5e4433e2ed103
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 52d5e4433e2ed103
+      X-B3-TraceId:
+      - 624c4aa60c2e928c52d5e4433e2ed103
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:54 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 5bb0dfd49bedd694
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 5bb0dfd49bedd694
+      X-B3-TraceId:
+      - 624c4aa611d5012d5bb0dfd49bedd694
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:54 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 78494d4dc7440cc6
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 78494d4dc7440cc6
+      X-B3-TraceId:
+      - 624c4aa6c8b539aa78494d4dc7440cc6
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_e"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_e","remote":"origin","remote_name":"tmp_spectacles_e","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:54 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 4970681a9a146375
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 4970681a9a146375
+      X-B3-TraceId:
+      - 624c4aa627784ad24970681a9a146375
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_e", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_e","remote":"origin","remote_name":"tmp_spectacles_e","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:55 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 3c3910a9061e05f4
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 3c3910a9061e05f4
+      X-B3-TraceId:
+      - 624c4aa6a870cb6c3c3910a9061e05f4
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -2847,320 +3227,12 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:04:01 GMT
+      - Tue, 05 Apr 2022 13:56:55 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
-- request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:01 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 3992ebb931e5b3c2
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 3992ebb931e5b3c2
-      X-B3-TraceId:
-      - 62475ab197224a033992ebb931e5b3c2
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:01 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - ef35e7687146e081
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - ef35e7687146e081
-      X-B3-TraceId:
-      - 62475ab1e9302119ef35e7687146e081
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:02 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - c7091afdaf7ac84f
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - c7091afdaf7ac84f
-      X-B3-TraceId:
-      - 62475ab17e1171fec7091afdaf7ac84f
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:02 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 6b72863e6b1af9fa
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 6b72863e6b1af9fa
-      X-B3-TraceId:
-      - 62475ab29f08f3cc6b72863e6b1af9fa
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:02 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 6147bf6c9b3e9a24
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 6147bf6c9b3e9a24
-      X-B3-TraceId:
-      - 62475ab289677d696147bf6c9b3e9a24
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:02 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 43e753d40ca1a07e
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 43e753d40ca1a07e
-      X-B3-TraceId:
-      - 62475ab2659304ab43e753d40ca1a07e
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_e"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_e","remote":"origin","remote_name":"tmp_spectacles_e","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:02 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 9a5f2d9595f8606b
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 9a5f2d9595f8606b
-      X-B3-TraceId:
-      - 62475ab23bfc307b9a5f2d9595f8606b
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_e", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_e","remote":"origin","remote_name":"tmp_spectacles_e","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:03 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - c0cedcfddf1fb064
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - c0cedcfddf1fb064
-      X-B3-TraceId:
-      - 62475ab273c13331c0cedcfddf1fb064
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
 - request:
     body: '{"query_id": 1944, "result_format": "json_detail"}'
     headers:
@@ -3169,12 +3241,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"354eba4d6bfb15f5e946ab64ccd8d366"}'
+      string: '{"id":"04af0a7bec6c32a7177619d27d8c28a0"}'
     headers:
       Connection:
       - keep-alive
@@ -3183,19 +3255,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:03 GMT
+      - Tue, 05 Apr 2022 13:56:55 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 6cb3497ad9f3691d
+      - a2e96c48d949e1dd
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6cb3497ad9f3691d
+      - a2e96c48d949e1dd
       X-B3-TraceId:
-      - 62475ab36c3d299f6cb3497ad9f3691d
+      - 624c4aa7ef0b8feda2e96c48d949e1dd
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3205,12 +3277,12 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=354eba4d6bfb15f5e946ab64ccd8d366
+    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=04af0a7bec6c32a7177619d27d8c28a0
   response:
     body:
-      string: '{"354eba4d6bfb15f5e946ab64ccd8d366":{"status":"added"}}'
+      string: '{"04af0a7bec6c32a7177619d27d8c28a0":{"status":"added"}}'
     headers:
       Connection:
       - keep-alive
@@ -3219,19 +3291,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:03 GMT
+      - Tue, 05 Apr 2022 13:56:56 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 9f4e0291de51e8bf
+      - adbf6628af4ea386
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 9f4e0291de51e8bf
+      - adbf6628af4ea386
       X-B3-TraceId:
-      - 62475ab389d274069f4e0291de51e8bf
+      - 624c4aa845eb0c66adbf6628af4ea386
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3241,12 +3313,12 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=354eba4d6bfb15f5e946ab64ccd8d366
+    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=04af0a7bec6c32a7177619d27d8c28a0
   response:
     body:
-      string: '{"354eba4d6bfb15f5e946ab64ccd8d366":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"354eba4d6bfb15f5e946ab64ccd8d366","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:04:04+00:00","aggregate_table_used_info":null,"runtime":"0.295","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.city"]},"forecast_result":null,"sql":"SELECT\n    users__fail.city  AS
+      string: '{"04af0a7bec6c32a7177619d27d8c28a0":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"04af0a7bec6c32a7177619d27d8c28a0","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:56:56+00:00","aggregate_table_used_info":null,"runtime":"0.335","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.city"]},"forecast_result":null,"sql":"SELECT\n    users__fail.city  AS
         users__fail_city,\n    users__fail.email_address  AS users__fail_email,\n    users__fail.first  AS
         users__fail_first_name,\n    users__fail.ids  AS users__fail_id,\n    users__fail.last  AS
         users__fail_last_name\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
@@ -3275,7 +3347,7 @@ interactions:
         users__fail_city,\n    users__fail.email_address  AS users__fail_email,\n    users__fail.first  AS
         users__fail_first_name,\n    users__fail.ids  AS users__fail_id,\n    users__fail.last  AS
         users__fail_last_name\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
-        (1 = 2)\nORDER BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":3,"column":17}}],"drill_menu_build_time":0.038036,"has_subtotals":false}}}'
+        (1 = 2)\nORDER BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":3,"column":17}}],"drill_menu_build_time":0.039712,"has_subtotals":false}}}'
     headers:
       Connection:
       - keep-alive
@@ -3284,20 +3356,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:04 GMT
+      - Tue, 05 Apr 2022 13:56:56 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - c64f835608ddb997
+      - eec47f71a0984104
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - c64f835608ddb997
+      - eec47f71a0984104
       X-B3-TraceId:
-      - 62475ab4a7968394c64f835608ddb997
+      - 624c4aa8732dfaadeec47f71a0984104
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3311,7 +3383,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3325,20 +3397,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:05 GMT
+      - Tue, 05 Apr 2022 13:56:57 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f5b568736f28d2bc
+      - 9965ac98762c959f
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f5b568736f28d2bc
+      - 9965ac98762c959f
       X-B3-TraceId:
-      - 62475ab57aa1a168f5b568736f28d2bc
+      - 624c4aa97fd07d749965ac98762c959f
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3350,7 +3422,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_e
   response:
@@ -3360,19 +3432,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:04:05 GMT
+      - Tue, 05 Apr 2022 13:56:58 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 4f6b5036833e963e
+      - 0f0ede59863cf0ab
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 4f6b5036833e963e
+      - 0f0ede59863cf0ab
       X-B3-TraceId:
-      - 62475ab5439be6254f6b5036833e963e
+      - 624c4aa95c11fcb50f0ede59863cf0ab
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3386,7 +3458,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3400,20 +3472,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:06 GMT
+      - Tue, 05 Apr 2022 13:56:58 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - cd9c262b306bd475
+      - 4e5bf72e987e0c22
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - cd9c262b306bd475
+      - 4e5bf72e987e0c22
       X-B3-TraceId:
-      - 62475ab5e817748ecd9c262b306bd475
+      - 624c4aaa0a4b5ced4e5bf72e987e0c22
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3427,7 +3499,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3441,19 +3513,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:06 GMT
+      - Tue, 05 Apr 2022 13:56:58 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - ee27cab4d6839ca6
+      - 4e05439a97ea2163
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - ee27cab4d6839ca6
+      - 4e05439a97ea2163
       X-B3-TraceId:
-      - 62475ab659ee7338ee27cab4d6839ca6
+      - 624c4aaa0dcbc2c34e05439a97ea2163
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3467,7 +3539,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3481,19 +3553,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:06 GMT
+      - Tue, 05 Apr 2022 13:56:58 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 719e1747f1d23fb1
+      - 30b742df6719eea4
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 719e1747f1d23fb1
+      - 30b742df6719eea4
       X-B3-TraceId:
-      - 62475ab618f359b9719e1747f1d23fb1
+      - 624c4aaa6bdf061030b742df6719eea4
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3503,7 +3575,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3517,19 +3589,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:06 GMT
+      - Tue, 05 Apr 2022 13:56:58 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 700490279ad0ad05
+      - d7b901e2543a68be
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 700490279ad0ad05
+      - d7b901e2543a68be
       X-B3-TraceId:
-      - 62475ab605785201700490279ad0ad05
+      - 624c4aaad5766a4fd7b901e2543a68be
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3539,7 +3611,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -3553,20 +3625,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:06 GMT
+      - Tue, 05 Apr 2022 13:56:59 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 1f407517e3aa7f47
+      - 769dacfa4540d47c
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 1f407517e3aa7f47
+      - 769dacfa4540d47c
       X-B3-TraceId:
-      - 62475ab67ae98baa1f407517e3aa7f47
+      - 624c4aaa432538e7769dacfa4540d47c
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3580,7 +3652,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -3594,20 +3666,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:07 GMT
+      - Tue, 05 Apr 2022 13:56:59 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 0916f8e2b32c7740
+      - 51183d563eb9d7ed
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 0916f8e2b32c7740
+      - 51183d563eb9d7ed
       X-B3-TraceId:
-      - 62475ab60f3355c70916f8e2b32c7740
+      - 624c4aab146b089e51183d563eb9d7ed
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3621,7 +3693,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -3635,20 +3707,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:07 GMT
+      - Tue, 05 Apr 2022 13:57:00 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 257b6af2264ae446
+      - e3173cfdaaa434ba
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 257b6af2264ae446
+      - e3173cfdaaa434ba
       X-B3-TraceId:
-      - 62475ab750278c25257b6af2264ae446
+      - 624c4aabeb3dd9f4e3173cfdaaa434ba
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3658,7 +3730,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:00 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 01f9a89811882e4f
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 01f9a89811882e4f
+      X-B3-TraceId:
+      - 624c4aac1ec99f8c01f9a89811882e4f
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3672,19 +3780,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:07 GMT
+      - Tue, 05 Apr 2022 13:57:00 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 90aac93287729c20
+      - be3e707897653cf3
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 90aac93287729c20
+      - be3e707897653cf3
       X-B3-TraceId:
-      - 62475ab76650fc1c90aac93287729c20
+      - 624c4aacf845f8cbbe3e707897653cf3
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3694,7 +3802,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3708,20 +3816,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:07 GMT
+      - Tue, 05 Apr 2022 13:57:00 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 787b0c18fc195764
+      - 7e2dd821e73ce4a6
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 787b0c18fc195764
+      - 7e2dd821e73ce4a6
       X-B3-TraceId:
-      - 62475ab77001f0f5787b0c18fc195764
+      - 624c4aac4c4a70b77e2dd821e73ce4a6
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:00 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 5a5dc2e1ecb3ef1a
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 5a5dc2e1ecb3ef1a
+      X-B3-TraceId:
+      - 624c4aacede2e50b5a5dc2e1ecb3ef1a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3731,7 +3879,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:00 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - e43b7332be090ae2
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - e43b7332be090ae2
+      X-B3-TraceId:
+      - 624c4aac5d76d715e43b7332be090ae2
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:00 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 52e4bf0a3c7c4718
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 52e4bf0a3c7c4718
+      X-B3-TraceId:
+      - 624c4aacb548637552e4bf0a3c7c4718
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:00 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 209658b41fb47215
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 209658b41fb47215
+      X-B3-TraceId:
+      - 624c4aac1b0191bc209658b41fb47215
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:00 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 8dec969e30590e29
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 8dec969e30590e29
+      X-B3-TraceId:
+      - 624c4aaca57598918dec969e30590e29
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:00 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 7e88f01abd8d142a
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 7e88f01abd8d142a
+      X-B3-TraceId:
+      - 624c4aac6605f2f47e88f01abd8d142a
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_g"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_g","remote":"origin","remote_name":"tmp_spectacles_g","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:01 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 11ee3db3bbbeb102
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 11ee3db3bbbeb102
+      X-B3-TraceId:
+      - 624c4aaddc15127411ee3db3bbbeb102
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_g", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_g","remote":"origin","remote_name":"tmp_spectacles_g","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:01 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - df7224c0071d1bb1
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - df7224c0071d1bb1
+      X-B3-TraceId:
+      - 624c4aada8eb43aadf7224c0071d1bb1
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -3780,320 +4196,12 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:04:08 GMT
+      - Tue, 05 Apr 2022 13:57:02 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
-- request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:08 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 81cca89c496f5292
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 81cca89c496f5292
-      X-B3-TraceId:
-      - 62475ab85862c6c081cca89c496f5292
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:08 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 079936a59a4680d0
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 079936a59a4680d0
-      X-B3-TraceId:
-      - 62475ab819575031079936a59a4680d0
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:08 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - aeadcec9eb943d1f
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - aeadcec9eb943d1f
-      X-B3-TraceId:
-      - 62475ab828b889e2aeadcec9eb943d1f
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:08 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - bde385e1e2acb815
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - bde385e1e2acb815
-      X-B3-TraceId:
-      - 62475ab829845451bde385e1e2acb815
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:08 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 8dc045de0234cce2
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 8dc045de0234cce2
-      X-B3-TraceId:
-      - 62475ab8faea3bf98dc045de0234cce2
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:08 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - c36904cb026b05a0
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - c36904cb026b05a0
-      X-B3-TraceId:
-      - 62475ab822d38b57c36904cb026b05a0
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_g"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_g","remote":"origin","remote_name":"tmp_spectacles_g","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:09 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 1bf426403bfe0842
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 1bf426403bfe0842
-      X-B3-TraceId:
-      - 62475ab8851af14d1bf426403bfe0842
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_g", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_g","remote":"origin","remote_name":"tmp_spectacles_g","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:09 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 6313e73ff9e8d880
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 6313e73ff9e8d880
-      X-B3-TraceId:
-      - 62475ab98131c4da6313e73ff9e8d880
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
 - request:
     body: '{"model": "eye_exam", "view": "users__fail", "fields": ["users__fail.city"],
       "limit": 0, "filter_expression": "1=2"}'
@@ -4103,7 +4211,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -4117,19 +4225,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:10 GMT
+      - Tue, 05 Apr 2022 13:57:02 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 45390f8485257e46
+      - 5378e081806440b9
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 45390f8485257e46
+      - 5378e081806440b9
       X-B3-TraceId:
-      - 62475ab93192cce345390f8485257e46
+      - 624c4aae59e2581f5378e081806440b9
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4144,7 +4252,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -4158,19 +4266,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:10 GMT
+      - Tue, 05 Apr 2022 13:57:02 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 477f753cd7323319
+      - e850e0400bcda199
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 477f753cd7323319
+      - e850e0400bcda199
       X-B3-TraceId:
-      - 62475abae5ea1489477f753cd7323319
+      - 624c4aae48456677e850e0400bcda199
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4185,7 +4293,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -4199,19 +4307,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:10 GMT
+      - Tue, 05 Apr 2022 13:57:02 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f6a4bd057f0bca3f
+      - f409cff28a1557f4
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f6a4bd057f0bca3f
+      - f409cff28a1557f4
       X-B3-TraceId:
-      - 62475aba91f0dbd0f6a4bd057f0bca3f
+      - 624c4aaed1cab764f409cff28a1557f4
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4226,7 +4334,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -4240,19 +4348,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:10 GMT
+      - Tue, 05 Apr 2022 13:57:02 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 2243da39be425f66
+      - 47c2711bf5ab269d
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2243da39be425f66
+      - 47c2711bf5ab269d
       X-B3-TraceId:
-      - 62475aba6a83cae72243da39be425f66
+      - 624c4aae778aa45147c2711bf5ab269d
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4267,7 +4375,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -4281,19 +4389,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:10 GMT
+      - Tue, 05 Apr 2022 13:57:03 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 2444f5f9d23a6cd5
+      - 2b69351d694b074c
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2444f5f9d23a6cd5
+      - 2b69351d694b074c
       X-B3-TraceId:
-      - 62475abad8502a0e2444f5f9d23a6cd5
+      - 624c4aaee22aa9e42b69351d694b074c
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4307,12 +4415,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"7b50a06afdabc9acfc21acec6d49b906"}'
+      string: '{"id":"cbca1e5ed0b499c33f508967b59c46bc"}'
     headers:
       Connection:
       - keep-alive
@@ -4321,19 +4429,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:10 GMT
+      - Tue, 05 Apr 2022 13:57:03 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 9aa873e027a43364
+      - befa07e862a600c4
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 9aa873e027a43364
+      - befa07e862a600c4
       X-B3-TraceId:
-      - 62475aba5fd977d69aa873e027a43364
+      - 624c4aaf6249d1f6befa07e862a600c4
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4347,12 +4455,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"b8933b673c25a03de9fe776b46e9c1a9"}'
+      string: '{"id":"bca82c70dcc864c99118a7dc4b4f9340"}'
     headers:
       Connection:
       - keep-alive
@@ -4361,19 +4469,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:10 GMT
+      - Tue, 05 Apr 2022 13:57:03 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 16a50eb9afc8003f
+      - e5e923ec62adbb27
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 16a50eb9afc8003f
+      - e5e923ec62adbb27
       X-B3-TraceId:
-      - 62475abab059ef0316a50eb9afc8003f
+      - 624c4aaf63ea982ee5e923ec62adbb27
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4387,12 +4495,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"fbd28e5f598fc067382e8d6ffeec67eb"}'
+      string: '{"id":"b02c9a52f3cd6db1737f9922013b7ae4"}'
     headers:
       Connection:
       - keep-alive
@@ -4401,19 +4509,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:11 GMT
+      - Tue, 05 Apr 2022 13:57:03 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 3548f164716274df
+      - c52bc38c17ea5cd4
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 3548f164716274df
+      - c52bc38c17ea5cd4
       X-B3-TraceId:
-      - 62475abbe0bd54dd3548f164716274df
+      - 624c4aaffc09cf20c52bc38c17ea5cd4
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4427,12 +4535,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"0d8d8a634eabdad0d6f14db3a895e479"}'
+      string: '{"id":"812416f31c45a8de66e7e918d47b9c43"}'
     headers:
       Connection:
       - keep-alive
@@ -4441,19 +4549,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:11 GMT
+      - Tue, 05 Apr 2022 13:57:03 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 724ae7b6abfe733c
+      - 18010c884c8b7b52
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 724ae7b6abfe733c
+      - 18010c884c8b7b52
       X-B3-TraceId:
-      - 62475abb7a3f29de724ae7b6abfe733c
+      - 624c4aafbdc91d5718010c884c8b7b52
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4467,12 +4575,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"63a9a644e941b993914591204766c0ad"}'
+      string: '{"id":"dc13c1fc3729163e86df5575371e3766"}'
     headers:
       Connection:
       - keep-alive
@@ -4481,19 +4589,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:11 GMT
+      - Tue, 05 Apr 2022 13:57:04 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 13692ed19b6a0363
+      - f72ff5cb15fa0a12
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 13692ed19b6a0363
+      - f72ff5cb15fa0a12
       X-B3-TraceId:
-      - 62475abb001d8ff013692ed19b6a0363
+      - 624c4aafc85dec27f72ff5cb15fa0a12
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4503,29 +4611,12 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=7b50a06afdabc9acfc21acec6d49b906%2Cb8933b673c25a03de9fe776b46e9c1a9%2Cfbd28e5f598fc067382e8d6ffeec67eb%2C0d8d8a634eabdad0d6f14db3a895e479%2C63a9a644e941b993914591204766c0ad
+    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=cbca1e5ed0b499c33f508967b59c46bc%2Cbca82c70dcc864c99118a7dc4b4f9340%2Cb02c9a52f3cd6db1737f9922013b7ae4%2C812416f31c45a8de66e7e918d47b9c43%2Cdc13c1fc3729163e86df5575371e3766
   response:
     body:
-      string: '{"0d8d8a634eabdad0d6f14db3a895e479":{"status":"running"},"63a9a644e941b993914591204766c0ad":{"status":"running"},"7b50a06afdabc9acfc21acec6d49b906":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"7b50a06afdabc9acfc21acec6d49b906","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:04:11+00:00","aggregate_table_used_info":null,"runtime":"0.496","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.city"]},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":true,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_0WW--DQT3tsibZyn8DiLYNk5Vuys"},"sql":"SELECT\n    users__fail.city  AS
-        users__fail_city\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
-        (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
-        Fail City","label_from_parameter":null,"label_short":"City","map_layer":null,"name":"users__fail.city","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users__fail","view_label":"Users
-        Fail","dynamic":false,"week_start_day":"monday","original_view":"users__fail","dimension_group":null,"error":null,"field_group_variant":"City","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users__fail","suggest_dimension":"users__fail.city","suggest_explore":"users__fail","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers__fail.view.lkml?line=20","permanent":null,"source_file":"views/users__fail.view.lkml","source_file_path":"eye_exam/views/users__fail.view.lkml","sql":"${TABLE}.city
-        ","sql_case":null,"filters":null,"times_used":0,"sorted":{"sort_index":0,"desc":false}}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users__fail","label":"Users
-        Fail","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.038487,"has_subtotals":false}},"b8933b673c25a03de9fe776b46e9c1a9":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"b8933b673c25a03de9fe776b46e9c1a9","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:04:11+00:00","aggregate_table_used_info":null,"runtime":"0.291","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.email"]},"forecast_result":null,"sql":"SELECT\n    users__fail.email_address  AS
-        users__fail_email\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
-        (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
-        Fail Email","label_from_parameter":null,"label_short":"Email","map_layer":null,"name":"users__fail.email","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users__fail","view_label":"Users
-        Fail","dynamic":false,"week_start_day":"monday","original_view":"users__fail","dimension_group":null,"error":null,"field_group_variant":"Email","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users__fail","suggest_dimension":"users__fail.email","suggest_explore":"users__fail","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers__fail.view.lkml?line=26","permanent":null,"source_file":"views/users__fail.view.lkml","source_file_path":"eye_exam/views/users__fail.view.lkml","sql":"${TABLE}.email_address
-        ","sql_case":null,"filters":null,"times_used":0,"sorted":{"sort_index":0,"desc":false}}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users__fail","label":"Users
-        Fail","description":null},"timezone":"America/New_York","data":[],"errors":[{"message":"The
-        Google BigQuery Standard SQL database encountered an error while running this
-        query.","message_details":"Query execution failed:  - Name email_address not
-        found inside users__fail at [2:17]","params":"SELECT\n    users__fail.email_address  AS
-        users__fail_email\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
-        (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":2,"column":17}}],"drill_menu_build_time":0.039811,"has_subtotals":false}},"fbd28e5f598fc067382e8d6ffeec67eb":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"fbd28e5f598fc067382e8d6ffeec67eb","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:04:11+00:00","aggregate_table_used_info":null,"runtime":"0.306","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.first_name"]},"forecast_result":null,"sql":"SELECT\n    users__fail.first  AS
+      string: '{"812416f31c45a8de66e7e918d47b9c43":{"status":"running"},"b02c9a52f3cd6db1737f9922013b7ae4":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"b02c9a52f3cd6db1737f9922013b7ae4","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:57:04+00:00","aggregate_table_used_info":null,"runtime":"0.370","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.first_name"]},"forecast_result":null,"sql":"SELECT\n    users__fail.first  AS
         users__fail_first_name\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
         (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
         Fail First Name","label_from_parameter":null,"label_short":"First Name","map_layer":null,"name":"users__fail.first_name","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users__fail","view_label":"Users
@@ -4537,29 +4628,46 @@ interactions:
         query.","message_details":"Query execution failed:  - Name first not found
         inside users__fail at [2:17]","params":"SELECT\n    users__fail.first  AS
         users__fail_first_name\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
-        (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":2,"column":17}}],"drill_menu_build_time":0.036402,"has_subtotals":false}}}'
+        (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":2,"column":17}}],"drill_menu_build_time":0.035493000000000004,"has_subtotals":false}},"bca82c70dcc864c99118a7dc4b4f9340":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"bca82c70dcc864c99118a7dc4b4f9340","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:57:03+00:00","aggregate_table_used_info":null,"runtime":"0.355","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.email"]},"forecast_result":null,"sql":"SELECT\n    users__fail.email_address  AS
+        users__fail_email\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
+        (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
+        Fail Email","label_from_parameter":null,"label_short":"Email","map_layer":null,"name":"users__fail.email","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users__fail","view_label":"Users
+        Fail","dynamic":false,"week_start_day":"monday","original_view":"users__fail","dimension_group":null,"error":null,"field_group_variant":"Email","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users__fail","suggest_dimension":"users__fail.email","suggest_explore":"users__fail","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers__fail.view.lkml?line=26","permanent":null,"source_file":"views/users__fail.view.lkml","source_file_path":"eye_exam/views/users__fail.view.lkml","sql":"${TABLE}.email_address
+        ","sql_case":null,"filters":null,"times_used":0,"sorted":{"sort_index":0,"desc":false}}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users__fail","label":"Users
+        Fail","description":null},"timezone":"America/New_York","data":[],"errors":[{"message":"The
+        Google BigQuery Standard SQL database encountered an error while running this
+        query.","message_details":"Query execution failed:  - Name email_address not
+        found inside users__fail at [2:17]","params":"SELECT\n    users__fail.email_address  AS
+        users__fail_email\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
+        (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":2,"column":17}}],"drill_menu_build_time":0.037408,"has_subtotals":false}},"cbca1e5ed0b499c33f508967b59c46bc":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"cbca1e5ed0b499c33f508967b59c46bc","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:57:03+00:00","aggregate_table_used_info":null,"runtime":"0.652","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.city"]},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":false,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_p3KmmGmjOASgiCpiOg81m3Er6ExE"},"sql":"SELECT\n    users__fail.city  AS
+        users__fail_city\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
+        (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
+        Fail City","label_from_parameter":null,"label_short":"City","map_layer":null,"name":"users__fail.city","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users__fail","view_label":"Users
+        Fail","dynamic":false,"week_start_day":"monday","original_view":"users__fail","dimension_group":null,"error":null,"field_group_variant":"City","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users__fail","suggest_dimension":"users__fail.city","suggest_explore":"users__fail","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers__fail.view.lkml?line=20","permanent":null,"source_file":"views/users__fail.view.lkml","source_file_path":"eye_exam/views/users__fail.view.lkml","sql":"${TABLE}.city
+        ","sql_case":null,"filters":null,"times_used":0,"sorted":{"sort_index":0,"desc":false}}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users__fail","label":"Users
+        Fail","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.038085,"has_subtotals":false}},"dc13c1fc3729163e86df5575371e3766":{"status":"added"}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '8421'
+      - '8432'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:11 GMT
+      - Tue, 05 Apr 2022 13:57:04 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - efe7fb76940a8b67
+      - 0ff13585f4963ec4
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - efe7fb76940a8b67
+      - 0ff13585f4963ec4
       X-B3-TraceId:
-      - 62475abba896c86fefe7fb76940a8b67
+      - 624c4ab0060299680ff13585f4963ec4
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4569,12 +4677,12 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=0d8d8a634eabdad0d6f14db3a895e479%2C63a9a644e941b993914591204766c0ad
+    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=812416f31c45a8de66e7e918d47b9c43%2Cdc13c1fc3729163e86df5575371e3766
   response:
     body:
-      string: '{"0d8d8a634eabdad0d6f14db3a895e479":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"0d8d8a634eabdad0d6f14db3a895e479","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:04:11+00:00","aggregate_table_used_info":null,"runtime":"0.331","added_params":{"query_timezone":"America/New_York"},"forecast_result":null,"sql":"SELECT\n    users__fail.ids  AS
+      string: '{"812416f31c45a8de66e7e918d47b9c43":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"812416f31c45a8de66e7e918d47b9c43","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:57:04+00:00","aggregate_table_used_info":null,"runtime":"0.325","added_params":{"query_timezone":"America/New_York"},"forecast_result":null,"sql":"SELECT\n    users__fail.ids  AS
         users__fail_id\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
         (1 = 2)\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"right","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":true,"label":"Users
         Fail ID","label_from_parameter":null,"label_short":"ID","map_layer":null,"name":"users__fail.id","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"number","user_attribute_filter_types":["number","advanced_filter_number"],"value_format":null,"view":"users__fail","view_label":"Users
@@ -4584,7 +4692,7 @@ interactions:
         Google BigQuery Standard SQL database encountered an error while running this
         query.","message_details":"Query execution failed:  - Name ids not found inside
         users__fail at [2:17]","params":"SELECT\n    users__fail.ids  AS users__fail_id\nFROM
-        looker-private-demo.ecomm.users\n   AS users__fail\nWHERE (1 = 2)\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":2,"column":17}}],"drill_menu_build_time":0.035228,"has_subtotals":false}},"63a9a644e941b993914591204766c0ad":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"63a9a644e941b993914591204766c0ad","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:04:11+00:00","aggregate_table_used_info":null,"runtime":"0.273","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.last_name"]},"forecast_result":null,"sql":"SELECT\n    users__fail.last  AS
+        looker-private-demo.ecomm.users\n   AS users__fail\nWHERE (1 = 2)\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":2,"column":17}}],"drill_menu_build_time":0.03761,"has_subtotals":false}},"dc13c1fc3729163e86df5575371e3766":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"dc13c1fc3729163e86df5575371e3766","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:57:04+00:00","aggregate_table_used_info":null,"runtime":"0.283","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.last_name"]},"forecast_result":null,"sql":"SELECT\n    users__fail.last  AS
         users__fail_last_name\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
         (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
         Fail Last Name","label_from_parameter":null,"label_short":"Last Name","map_layer":null,"name":"users__fail.last_name","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users__fail","view_label":"Users
@@ -4596,29 +4704,29 @@ interactions:
         query.","message_details":"Query execution failed:  - Name last not found
         inside users__fail at [2:17]","params":"SELECT\n    users__fail.last  AS users__fail_last_name\nFROM
         looker-private-demo.ecomm.users\n   AS users__fail\nWHERE (1 = 2)\nGROUP BY\n    1\nORDER
-        BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":2,"column":17}}],"drill_menu_build_time":0.035595999999999996,"has_subtotals":false}}}'
+        BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":2,"column":17}}],"drill_menu_build_time":0.037753999999999996,"has_subtotals":false}}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '5542'
+      - '5541'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:12 GMT
+      - Tue, 05 Apr 2022 13:57:04 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - ac7735d3eb5df58b
+      - 09f999add7367073
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - ac7735d3eb5df58b
+      - 09f999add7367073
       X-B3-TraceId:
-      - 62475abc819ce3a6ac7735d3eb5df58b
+      - 624c4ab0b6d580ce09f999add7367073
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4632,7 +4740,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -4646,20 +4754,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:13 GMT
+      - Tue, 05 Apr 2022 13:57:06 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 9b03f814e0926099
+      - e50a5fdedcc638ae
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 9b03f814e0926099
+      - e50a5fdedcc638ae
       X-B3-TraceId:
-      - 62475abcdcc91caf9b03f814e0926099
+      - 624c4ab19626d6a5e50a5fdedcc638ae
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4671,7 +4779,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_f
   response:
@@ -4681,19 +4789,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:04:13 GMT
+      - Tue, 05 Apr 2022 13:57:06 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 059ae8ea2a666c74
+      - 38491c032e60ea7b
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 059ae8ea2a666c74
+      - 38491c032e60ea7b
       X-B3-TraceId:
-      - 62475abdddb1427f059ae8ea2a666c74
+      - 624c4ab29f97a74138491c032e60ea7b
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4707,7 +4815,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -4721,20 +4829,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:14 GMT
+      - Tue, 05 Apr 2022 13:57:07 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 8c1480fd56d8a55f
+      - 0ef3c0a8226cb1a6
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 8c1480fd56d8a55f
+      - 0ef3c0a8226cb1a6
       X-B3-TraceId:
-      - 62475abdc43509ed8c1480fd56d8a55f
+      - 624c4ab278fccd440ef3c0a8226cb1a6
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4746,7 +4854,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_g
   response:
@@ -4756,19 +4864,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:04:14 GMT
+      - Tue, 05 Apr 2022 13:57:07 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 73c5695bcaea3835
+      - 333e9ccfa6af055c
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 73c5695bcaea3835
+      - 333e9ccfa6af055c
       X-B3-TraceId:
-      - 62475abef4d5695f73c5695bcaea3835
+      - 624c4ab3b4229c74333e9ccfa6af055c
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4782,7 +4890,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -4796,20 +4904,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:15 GMT
+      - Tue, 05 Apr 2022 13:57:07 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 79c059d3b6c642a0
+      - 62567e47d9f67001
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 79c059d3b6c642a0
+      - 62567e47d9f67001
       X-B3-TraceId:
-      - 62475abe06b7d41f79c059d3b6c642a0
+      - 624c4ab34b7ba51962567e47d9f67001
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4823,7 +4931,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -4837,19 +4945,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:15 GMT
+      - Tue, 05 Apr 2022 13:57:07 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - e9756071ae3d8329
+      - 4b251ad1c9a895ef
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - e9756071ae3d8329
+      - 4b251ad1c9a895ef
       X-B3-TraceId:
-      - 62475abf070bac0ae9756071ae3d8329
+      - 624c4ab310551c3c4b251ad1c9a895ef
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4863,7 +4971,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -4877,19 +4985,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:15 GMT
+      - Tue, 05 Apr 2022 13:57:08 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 566e1c7e9d362a33
+      - 8b5e1ccbfafe09ba
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 566e1c7e9d362a33
+      - 8b5e1ccbfafe09ba
       X-B3-TraceId:
-      - 62475abfe9662825566e1c7e9d362a33
+      - 624c4ab3b6256ce58b5e1ccbfafe09ba
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4899,7 +5007,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -4913,19 +5021,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:15 GMT
+      - Tue, 05 Apr 2022 13:57:08 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - a13f23ad38b5fbfe
+      - 0ca844870aeb677c
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a13f23ad38b5fbfe
+      - 0ca844870aeb677c
       X-B3-TraceId:
-      - 62475abfedad0f5aa13f23ad38b5fbfe
+      - 624c4ab4072c82f40ca844870aeb677c
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4935,7 +5043,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -4949,20 +5057,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:15 GMT
+      - Tue, 05 Apr 2022 13:57:08 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - c032186779bfc9ea
+      - 478df0b12abe87da
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - c032186779bfc9ea
+      - 478df0b12abe87da
       X-B3-TraceId:
-      - 62475abf78477240c032186779bfc9ea
+      - 624c4ab4ebb49c17478df0b12abe87da
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4976,7 +5084,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -4990,20 +5098,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:16 GMT
+      - Tue, 05 Apr 2022 13:57:08 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 8194a4dadc6c2ac2
+      - 70813bbe21088eff
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 8194a4dadc6c2ac2
+      - 70813bbe21088eff
       X-B3-TraceId:
-      - 62475abf14c3576d8194a4dadc6c2ac2
+      - 624c4ab4dc9ffb9670813bbe21088eff
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5017,7 +5125,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -5031,20 +5139,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:17 GMT
+      - Tue, 05 Apr 2022 13:57:10 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 6d1dd6f26af95a67
+      - 9b61f6995401b49e
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6d1dd6f26af95a67
+      - 9b61f6995401b49e
       X-B3-TraceId:
-      - 62475ac0ec5752606d1dd6f26af95a67
+      - 624c4ab4928116a99b61f6995401b49e
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5054,7 +5162,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:10 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 19fb4acdecfd836d
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 19fb4acdecfd836d
+      X-B3-TraceId:
+      - 624c4ab62fe06e0619fb4acdecfd836d
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -5068,19 +5212,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:18 GMT
+      - Tue, 05 Apr 2022 13:57:10 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 9af8670748e3c258
+      - 7e2b01feb4087021
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 9af8670748e3c258
+      - 7e2b01feb4087021
       X-B3-TraceId:
-      - 62475ac2cd2313e89af8670748e3c258
+      - 624c4ab667e4cc877e2b01feb4087021
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5090,7 +5234,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -5104,20 +5248,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:18 GMT
+      - Tue, 05 Apr 2022 13:57:10 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 28cd8ca78aa519f6
+      - d5bc4cf85e59d3b1
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 28cd8ca78aa519f6
+      - d5bc4cf85e59d3b1
       X-B3-TraceId:
-      - 62475ac296c901fd28cd8ca78aa519f6
+      - 624c4ab60cd33e28d5bc4cf85e59d3b1
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:11 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 043f34a56e2ab10e
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 043f34a56e2ab10e
+      X-B3-TraceId:
+      - 624c4ab6337f54fb043f34a56e2ab10e
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5127,7 +5311,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:11 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 455ccccdb23c58ac
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 455ccccdb23c58ac
+      X-B3-TraceId:
+      - 624c4ab70277ae1f455ccccdb23c58ac
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:11 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - b3bdff53beab0947
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - b3bdff53beab0947
+      X-B3-TraceId:
+      - 624c4ab7ce989e64b3bdff53beab0947
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:11 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - b7dffbc5e811ed40
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - b7dffbc5e811ed40
+      X-B3-TraceId:
+      - 624c4ab77ba76965b7dffbc5e811ed40
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:11 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 7c124c9280db77d5
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 7c124c9280db77d5
+      X-B3-TraceId:
+      - 624c4ab7fd591b7e7c124c9280db77d5
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:11 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - c414413f910e4d62
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - c414413f910e4d62
+      X-B3-TraceId:
+      - 624c4ab73ed04b00c414413f910e4d62
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_i"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_i","remote":"origin","remote_name":"tmp_spectacles_i","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:11 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 3472d8041f2f50b7
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 3472d8041f2f50b7
+      X-B3-TraceId:
+      - 624c4ab760b1a77f3472d8041f2f50b7
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_i", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_i","remote":"origin","remote_name":"tmp_spectacles_i","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:12 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 2bdccc4978540570
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 2bdccc4978540570
+      X-B3-TraceId:
+      - 624c4ab7b37aea1c2bdccc4978540570
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -5176,320 +5628,12 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:04:18 GMT
+      - Tue, 05 Apr 2022 13:57:12 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
-- request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:18 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 1c0699a8640c47d5
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 1c0699a8640c47d5
-      X-B3-TraceId:
-      - 62475ac2d3a835de1c0699a8640c47d5
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:18 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 909f02efb1225a68
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 909f02efb1225a68
-      X-B3-TraceId:
-      - 62475ac290833a87909f02efb1225a68
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:18 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 324abe66e9002309
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 324abe66e9002309
-      X-B3-TraceId:
-      - 62475ac27b232b25324abe66e9002309
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:18 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - dae0437ecb2243c9
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - dae0437ecb2243c9
-      X-B3-TraceId:
-      - 62475ac236b83bbadae0437ecb2243c9
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:18 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - b6ea17138b60f774
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - b6ea17138b60f774
-      X-B3-TraceId:
-      - 62475ac2169242cbb6ea17138b60f774
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:18 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - ee3bb0cbc522f40e
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - ee3bb0cbc522f40e
-      X-B3-TraceId:
-      - 62475ac21f2263a4ee3bb0cbc522f40e
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_i"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_i","remote":"origin","remote_name":"tmp_spectacles_i","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:19 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 8a920d39d81b5ce2
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 8a920d39d81b5ce2
-      X-B3-TraceId:
-      - 62475ac2bd2c05af8a920d39d81b5ce2
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_i", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_i","remote":"origin","remote_name":"tmp_spectacles_i","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:19 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 7808bb3216f3a5c3
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 7808bb3216f3a5c3
-      X-B3-TraceId:
-      - 62475ac3abd906fe7808bb3216f3a5c3
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
 - request:
     body: '{"model": "eye_exam", "view": "users__fail", "fields": ["users__fail.email"],
       "limit": 0, "filter_expression": "1=2"}'
@@ -5499,7 +5643,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -5513,19 +5657,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:20 GMT
+      - Tue, 05 Apr 2022 13:57:12 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - eb96a72c8a6f6961
+      - 0a869c430987aff0
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - eb96a72c8a6f6961
+      - 0a869c430987aff0
       X-B3-TraceId:
-      - 62475ac45d1875fceb96a72c8a6f6961
+      - 624c4ab8670059090a869c430987aff0
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5535,7 +5679,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/1928/run/sql
   response:
@@ -5551,19 +5695,19 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:04:20 GMT
+      - Tue, 05 Apr 2022 13:57:13 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - e7df3f20d7f2788d
+      - 28bdfd93b86e5070
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - e7df3f20d7f2788d
+      - 28bdfd93b86e5070
       X-B3-TraceId:
-      - 62475ac40521d143e7df3f20d7f2788d
+      - 624c4ab87d51cf8c28bdfd93b86e5070
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5578,7 +5722,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -5592,19 +5736,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:20 GMT
+      - Tue, 05 Apr 2022 13:57:13 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 395ccf3f1e8a933a
+      - 8e9c5f462ef2d9df
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 395ccf3f1e8a933a
+      - 8e9c5f462ef2d9df
       X-B3-TraceId:
-      - 62475ac4c691b901395ccf3f1e8a933a
+      - 624c4ab960f850c58e9c5f462ef2d9df
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5614,7 +5758,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/1929/run/sql
   response:
@@ -5630,19 +5774,19 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:04:21 GMT
+      - Tue, 05 Apr 2022 13:57:13 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 1176d34c39c5610e
+      - 778c8f47d5de77cf
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 1176d34c39c5610e
+      - 778c8f47d5de77cf
       X-B3-TraceId:
-      - 62475ac426fff2741176d34c39c5610e
+      - 624c4ab9346456ab778c8f47d5de77cf
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5657,7 +5801,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -5671,19 +5815,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:21 GMT
+      - Tue, 05 Apr 2022 13:57:13 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 15f2390240a1de96
+      - 70dfb5d6e1ea0479
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 15f2390240a1de96
+      - 70dfb5d6e1ea0479
       X-B3-TraceId:
-      - 62475ac5d436293615f2390240a1de96
+      - 624c4ab915d2c92c70dfb5d6e1ea0479
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5693,7 +5837,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/1931/run/sql
   response:
@@ -5708,19 +5852,19 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:04:21 GMT
+      - Tue, 05 Apr 2022 13:57:13 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 53a5400242c480d5
+      - 4c2de7701bc0131b
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 53a5400242c480d5
+      - 4c2de7701bc0131b
       X-B3-TraceId:
-      - 62475ac54ab8133d53a5400242c480d5
+      - 624c4ab9b9fc3da04c2de7701bc0131b
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5735,7 +5879,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -5749,19 +5893,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:21 GMT
+      - Tue, 05 Apr 2022 13:57:13 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 7cc32de02de043fc
+      - 1ee9a6243a3a648f
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 7cc32de02de043fc
+      - 1ee9a6243a3a648f
       X-B3-TraceId:
-      - 62475ac5adcc146a7cc32de02de043fc
+      - 624c4ab926c401791ee9a6243a3a648f
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5771,7 +5915,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/1932/run/sql
   response:
@@ -5787,19 +5931,19 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:04:21 GMT
+      - Tue, 05 Apr 2022 13:57:14 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - c2920b76170b9dac
+      - 6628aae92600e625
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - c2920b76170b9dac
+      - 6628aae92600e625
       X-B3-TraceId:
-      - 62475ac53e86d71ac2920b76170b9dac
+      - 624c4aba1a91dfcd6628aae92600e625
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5813,7 +5957,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -5827,20 +5971,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:22 GMT
+      - Tue, 05 Apr 2022 13:57:14 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - a465d5badc616ee4
+      - fb635f81bead46fd
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a465d5badc616ee4
+      - fb635f81bead46fd
       X-B3-TraceId:
-      - 62475ac53cd49bc3a465d5badc616ee4
+      - 624c4aba887c0b4ffb635f81bead46fd
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5852,7 +5996,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_h
   response:
@@ -5862,19 +6006,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:04:23 GMT
+      - Tue, 05 Apr 2022 13:57:15 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - ed5f766bfa422657
+      - bc651acc6be48195
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - ed5f766bfa422657
+      - bc651acc6be48195
       X-B3-TraceId:
-      - 62475ac6b5578bd4ed5f766bfa422657
+      - 624c4aba70166728bc651acc6be48195
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5888,7 +6032,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -5902,20 +6046,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:24 GMT
+      - Tue, 05 Apr 2022 13:57:16 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 9ba25c2f56e031a9
+      - c6b69d65a90d8cba
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 9ba25c2f56e031a9
+      - c6b69d65a90d8cba
       X-B3-TraceId:
-      - 62475ac7361106cc9ba25c2f56e031a9
+      - 624c4abbea7e0ed7c6b69d65a90d8cba
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5927,7 +6071,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_i
   response:
@@ -5937,19 +6081,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:04:24 GMT
+      - Tue, 05 Apr 2022 13:57:16 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 5008bd953107e886
+      - 2cea9fa6c3302660
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 5008bd953107e886
+      - 2cea9fa6c3302660
       X-B3-TraceId:
-      - 62475ac8c45f0f225008bd953107e886
+      - 624c4abc330e54502cea9fa6c3302660
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5963,7 +6107,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -5977,20 +6121,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:24 GMT
+      - Tue, 05 Apr 2022 13:57:17 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 1cb7d1127dc1d9af
+      - ab4649af4706ca87
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 1cb7d1127dc1d9af
+      - ab4649af4706ca87
       X-B3-TraceId:
-      - 62475ac8f992ad571cb7d1127dc1d9af
+      - 624c4abc6d565862ab4649af4706ca87
       X-Content-Type-Options:
       - nosniff
     status:
@@ -6004,7 +6148,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -6018,19 +6162,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:24 GMT
+      - Tue, 05 Apr 2022 13:57:17 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - d95f8682b24537d6
+      - b905aca130e66884
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - d95f8682b24537d6
+      - b905aca130e66884
       X-B3-TraceId:
-      - 62475ac81e54878bd95f8682b24537d6
+      - 624c4abde7dff2a9b905aca130e66884
       X-Content-Type-Options:
       - nosniff
     status:

--- a/tests/cassettes/test_runner/test_incremental_sql_with_diff_explores_and_invalid_existing_sql_should_error.yaml
+++ b/tests/cassettes/test_runner/test_incremental_sql_with_diff_explores_and_invalid_existing_sql_should_error.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -17,19 +17,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:22 GMT
+      - Tue, 05 Apr 2022 13:59:13 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 3426eaf6ed1c2e05
+      - c4f28c66f86d77a1
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 3426eaf6ed1c2e05
+      - c4f28c66f86d77a1
       X-B3-TraceId:
-      - 62475a4e319dc6e83426eaf6ed1c2e05
+      - 624c4b315cb634cac4f28c66f86d77a1
       X-Content-Type-Options:
       - nosniff
     status:
@@ -39,7 +39,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -53,56 +53,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:22 GMT
+      - Tue, 05 Apr 2022 13:59:13 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 224a81ec506aa3e6
+      - de0fb9354de0fba5
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 224a81ec506aa3e6
+      - de0fb9354de0fba5
       X-B3-TraceId:
-      - 62475a4ed57ca018224a81ec506aa3e6
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
-  response:
-    body:
-      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '147'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:22 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 48ab0940bba3dfd0
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 48ab0940bba3dfd0
-      X-B3-TraceId:
-      - 62475a4e6cda46dd48ab0940bba3dfd0
+      - 624c4b314809585fde0fb9354de0fba5
       X-Content-Type-Options:
       - nosniff
     status:
@@ -116,7 +80,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -130,19 +94,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:22 GMT
+      - Tue, 05 Apr 2022 13:59:14 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 33286606e6e9bbf1
+      - c8f6edbe0a079be6
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 33286606e6e9bbf1
+      - c8f6edbe0a079be6
       X-B3-TraceId:
-      - 62475a4edb18436d33286606e6e9bbf1
+      - 624c4b324da53283c8f6edbe0a079be6
       X-Content-Type-Options:
       - nosniff
     status:
@@ -152,7 +116,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -166,19 +130,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:22 GMT
+      - Tue, 05 Apr 2022 13:59:14 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 6af054e028831193
+      - 61adfafa5d0933ea
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6af054e028831193
+      - 61adfafa5d0933ea
       X-B3-TraceId:
-      - 62475a4e63edfb846af054e028831193
+      - 624c4b32d4b26f5b61adfafa5d0933ea
       X-Content-Type-Options:
       - nosniff
     status:
@@ -188,34 +152,34 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest-incremental-valid-diff","remote":"origin","remote_name":"pytest-incremental-valid-diff","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","can":{}}'
+      string: '{"name":"pytest","remote":"origin","remote_name":"pytest","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":"742b118d314d2478a215aa02016c09e173deec7e","can":{}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '409'
+      - '363'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:22 GMT
+      - Tue, 05 Apr 2022 13:59:14 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 16e77857ab0fce3b
+      - f494f902e23258b4
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 16e77857ab0fce3b
+      - f494f902e23258b4
       X-B3-TraceId:
-      - 62475a4eb19a2f5816e77857ab0fce3b
+      - 624c4b327e0afd7cf494f902e23258b4
       X-Content-Type-Options:
       - nosniff
     status:
@@ -229,12 +193,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":null,"can":{}}'
+      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":null,"can":{}}'
     headers:
       Connection:
       - keep-alive
@@ -243,20 +207,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:23 GMT
+      - Tue, 05 Apr 2022 13:59:14 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - fe847b6e7372b85f
+      - 9326e7cebe24d7fa
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - fe847b6e7372b85f
+      - 9326e7cebe24d7fa
       X-B3-TraceId:
-      - 62475a4e27121c7efe847b6e7372b85f
+      - 624c4b3205218d049326e7cebe24d7fa
       X-Content-Type-Options:
       - nosniff
     status:
@@ -270,12 +234,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":null,"can":{}}'
+      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":null,"can":{}}'
     headers:
       Connection:
       - keep-alive
@@ -284,20 +248,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:25 GMT
+      - Tue, 05 Apr 2022 13:59:16 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - d4935aac3d36be25
+      - 4770fefd85e14afd
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - d4935aac3d36be25
+      - 4770fefd85e14afd
       X-B3-TraceId:
-      - 62475a4f36c69851d4935aac3d36be25
+      - 624c4b32b56656a94770fefd85e14afd
       X-Content-Type-Options:
       - nosniff
     status:
@@ -307,7 +271,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:16 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 36299d9698bad051
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 36299d9698bad051
+      X-B3-TraceId:
+      - 624c4b3474d0295b36299d9698bad051
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -321,19 +321,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:25 GMT
+      - Tue, 05 Apr 2022 13:59:16 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - c1cd1a4fd4b63c70
+      - a993a74da4e8f97a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - c1cd1a4fd4b63c70
+      - a993a74da4e8f97a
       X-B3-TraceId:
-      - 62475a51d87d8f9ec1cd1a4fd4b63c70
+      - 624c4b34a9dd8b95a993a74da4e8f97a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -343,7 +343,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -357,20 +357,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:25 GMT
+      - Tue, 05 Apr 2022 13:59:16 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f43842158e5175f3
+      - 7a6f847abbaa7044
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f43842158e5175f3
+      - 7a6f847abbaa7044
       X-B3-TraceId:
-      - 62475a511657c2aef43842158e5175f3
+      - 624c4b34f1419ae67a6f847abbaa7044
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:16 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 0a6c8c0f2f9564b5
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 0a6c8c0f2f9564b5
+      X-B3-TraceId:
+      - 624c4b34851c64e10a6c8c0f2f9564b5
       X-Content-Type-Options:
       - nosniff
     status:
@@ -380,7 +420,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:16 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 7acadf468fbbde81
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 7acadf468fbbde81
+      X-B3-TraceId:
+      - 624c4b348f5e45347acadf468fbbde81
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:16 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 39223dd32a8bd020
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 39223dd32a8bd020
+      X-B3-TraceId:
+      - 624c4b3493c8fa1439223dd32a8bd020
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:17 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 84008cdf96a7a40e
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 84008cdf96a7a40e
+      X-B3-TraceId:
+      - 624c4b348f0bf67d84008cdf96a7a40e
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:17 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 50e993fc5a95ce73
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 50e993fc5a95ce73
+      X-B3-TraceId:
+      - 624c4b350a905a7750e993fc5a95ce73
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:17 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 9ef4d6c8a8e3228b
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 9ef4d6c8a8e3228b
+      X-B3-TraceId:
+      - 624c4b35307e81dd9ef4d6c8a8e3228b
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_b"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:17 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - ce0719b763209516
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - ce0719b763209516
+      X-B3-TraceId:
+      - 624c4b351952826ece0719b763209516
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_b", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:18 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 8e4173fc0c5340dc
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 8e4173fc0c5340dc
+      X-B3-TraceId:
+      - 624c4b35837d50d08e4173fc0c5340dc
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -429,325 +737,17 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:02:25 GMT
+      - Tue, 05 Apr 2022 13:59:18 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:25 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 00b0b425d1d55e15
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 00b0b425d1d55e15
-      X-B3-TraceId:
-      - 62475a51c0ccb22e00b0b425d1d55e15
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:25 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 011d1dae096fa635
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 011d1dae096fa635
-      X-B3-TraceId:
-      - 62475a51b0ba2017011d1dae096fa635
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:25 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - f460d457e2bab6be
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - f460d457e2bab6be
-      X-B3-TraceId:
-      - 62475a51f375574ff460d457e2bab6be
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:25 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 2ec9a7c8fcdda022
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 2ec9a7c8fcdda022
-      X-B3-TraceId:
-      - 62475a51f2afb6852ec9a7c8fcdda022
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:25 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - aa5b05d90ea16486
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - aa5b05d90ea16486
-      X-B3-TraceId:
-      - 62475a5139c6739eaa5b05d90ea16486
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:25 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - b833a07d3530d434
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - b833a07d3530d434
-      X-B3-TraceId:
-      - 62475a518ff0950bb833a07d3530d434
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_b"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:26 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - d44f08abef91d6e7
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - d44f08abef91d6e7
-      X-B3-TraceId:
-      - 62475a523d9ff085d44f08abef91d6e7
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_b", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:26 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - c5a55ee27ea799a9
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - c5a55ee27ea799a9
-      X-B3-TraceId:
-      - 62475a52dfbf6091c5a55ee27ea799a9
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models?fields=name%2Cproject_name%2Cexplores
   response:
@@ -831,20 +831,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:27 GMT
+      - Tue, 05 Apr 2022 13:59:19 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - a1628234296b6317
+      - b56331e8b3f8999c
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a1628234296b6317
+      - b56331e8b3f8999c
       X-B3-TraceId:
-      - 62475a5312836cffa1628234296b6317
+      - 624c4b3601ccca21b56331e8b3f8999c
       X-Content-Type-Options:
       - nosniff
     status:
@@ -854,7 +854,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users?fields=fields
   response:
@@ -885,20 +885,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:27 GMT
+      - Tue, 05 Apr 2022 13:59:19 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - dd01985f3ec4ef4b
+      - d87850635d207c98
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - dd01985f3ec4ef4b
+      - d87850635d207c98
       X-B3-TraceId:
-      - 62475a5368f90d36dd01985f3ec4ef4b
+      - 624c4b3717d19935d87850635d207c98
       X-Content-Type-Options:
       - nosniff
     status:
@@ -908,7 +908,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users__fail?fields=fields
   response:
@@ -944,20 +944,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:28 GMT
+      - Tue, 05 Apr 2022 13:59:19 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - e951550f3d3c7bb2
+      - 706ba8dcd11aafda
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - e951550f3d3c7bb2
+      - 706ba8dcd11aafda
       X-B3-TraceId:
-      - 62475a544b05e783e951550f3d3c7bb2
+      - 624c4b37ed104062706ba8dcd11aafda
       X-Content-Type-Options:
       - nosniff
     status:
@@ -973,7 +973,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -987,19 +987,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:28 GMT
+      - Tue, 05 Apr 2022 13:59:19 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 99480fb64ef414cd
+      - 444b3057ea358e1b
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 99480fb64ef414cd
+      - 444b3057ea358e1b
       X-B3-TraceId:
-      - 62475a546c021b1d99480fb64ef414cd
+      - 624c4b377a2dbab8444b3057ea358e1b
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1009,7 +1009,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/2216/run/sql
   response:
@@ -1026,19 +1026,19 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:02:28 GMT
+      - Tue, 05 Apr 2022 13:59:19 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f7d10f190696180e
+      - 5166bf5244abf653
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f7d10f190696180e
+      - 5166bf5244abf653
       X-B3-TraceId:
-      - 62475a54b2e5de8bf7d10f190696180e
+      - 624c4b379cfcefd35166bf5244abf653
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1054,7 +1054,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -1068,19 +1068,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:28 GMT
+      - Tue, 05 Apr 2022 13:59:19 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f9a7c53267eac693
+      - 21683e971cfc581d
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f9a7c53267eac693
+      - 21683e971cfc581d
       X-B3-TraceId:
-      - 62475a54269c6df6f9a7c53267eac693
+      - 624c4b37f047f8fa21683e971cfc581d
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1090,7 +1090,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/1944/run/sql
   response:
@@ -1108,60 +1108,60 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:02:28 GMT
+      - Tue, 05 Apr 2022 13:59:19 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 1adc0fe06ed751e5
+      - fd9a5e09c1305ba9
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 1adc0fe06ed751e5
+      - fd9a5e09c1305ba9
       X-B3-TraceId:
-      - 62475a54aa88aa7b1adc0fe06ed751e5
+      - 624c4b377d9d5f8bfd9a5e09c1305ba9
       X-Content-Type-Options:
       - nosniff
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "pytest-incremental-valid-diff"}'
+    body: '{"name": "pytest"}'
     headers:
       Content-Length:
-      - '41'
+      - '18'
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest-incremental-valid-diff","remote":"origin","remote_name":"pytest-incremental-valid-diff","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","can":{}}'
+      string: '{"name":"pytest","remote":"origin","remote_name":"pytest","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":"742b118d314d2478a215aa02016c09e173deec7e","can":{}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '409'
+      - '363'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:29 GMT
+      - Tue, 05 Apr 2022 13:59:20 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 281e1f7a8646725e
+      - 37cb51087bafbf17
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 281e1f7a8646725e
+      - 37cb51087bafbf17
       X-B3-TraceId:
-      - 62475a542538ca2c281e1f7a8646725e
+      - 624c4b37b7c6915d37cb51087bafbf17
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1173,7 +1173,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_a
   response:
@@ -1183,19 +1183,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:02:30 GMT
+      - Tue, 05 Apr 2022 13:59:21 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - fd019d81d6c77f27
+      - 94bc866812b3b4de
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - fd019d81d6c77f27
+      - 94bc866812b3b4de
       X-B3-TraceId:
-      - 62475a553eb0d529fd019d81d6c77f27
+      - 624c4b3864a1458094bc866812b3b4de
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1209,7 +1209,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -1223,20 +1223,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:31 GMT
+      - Tue, 05 Apr 2022 13:59:22 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - d5687765ab2c0b2c
+      - 881ab668bcfeb70c
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - d5687765ab2c0b2c
+      - 881ab668bcfeb70c
       X-B3-TraceId:
-      - 62475a561517d31bd5687765ab2c0b2c
+      - 624c4b39eec67f4d881ab668bcfeb70c
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1248,7 +1248,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_b
   response:
@@ -1258,19 +1258,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:02:31 GMT
+      - Tue, 05 Apr 2022 13:59:22 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 2a0517dee6296327
+      - cf6b0f77d9ac1d97
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2a0517dee6296327
+      - cf6b0f77d9ac1d97
       X-B3-TraceId:
-      - 62475a57c20726062a0517dee6296327
+      - 624c4b3a3f4419c1cf6b0f77d9ac1d97
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1284,7 +1284,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -1298,20 +1298,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:31 GMT
+      - Tue, 05 Apr 2022 13:59:22 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 598a404cef81bdaf
+      - d1057ace842aca2a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 598a404cef81bdaf
+      - d1057ace842aca2a
       X-B3-TraceId:
-      - 62475a57469b3eb8598a404cef81bdaf
+      - 624c4b3a58b1b367d1057ace842aca2a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1325,7 +1325,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1339,19 +1339,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:31 GMT
+      - Tue, 05 Apr 2022 13:59:23 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 0ffab49835bdeeb1
+      - d991717100e4373c
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 0ffab49835bdeeb1
+      - d991717100e4373c
       X-B3-TraceId:
-      - 62475a573554388e0ffab49835bdeeb1
+      - 624c4b3b823e5dded991717100e4373c
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1365,7 +1365,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1379,19 +1379,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:31 GMT
+      - Tue, 05 Apr 2022 13:59:23 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - faafe0994ee260f4
+      - 52c020bea5e8d02a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - faafe0994ee260f4
+      - 52c020bea5e8d02a
       X-B3-TraceId:
-      - 62475a57d0db971dfaafe0994ee260f4
+      - 624c4b3bb1c2cbe352c020bea5e8d02a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1401,7 +1401,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1415,19 +1415,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:32 GMT
+      - Tue, 05 Apr 2022 13:59:23 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f0b6c20d342ac3e2
+      - 5ed9c43191160004
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f0b6c20d342ac3e2
+      - 5ed9c43191160004
       X-B3-TraceId:
-      - 62475a589ebc88f9f0b6c20d342ac3e2
+      - 624c4b3bfad1156e5ed9c43191160004
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1437,34 +1437,34 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest-incremental-valid-diff","remote":"origin","remote_name":"pytest-incremental-valid-diff","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","can":{}}'
+      string: '{"name":"pytest","remote":"origin","remote_name":"pytest","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":"742b118d314d2478a215aa02016c09e173deec7e","can":{}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '409'
+      - '363'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:32 GMT
+      - Tue, 05 Apr 2022 13:59:23 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 21d115fe085b8f4c
+      - 85ebb9e000fb97f3
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 21d115fe085b8f4c
+      - 85ebb9e000fb97f3
       X-B3-TraceId:
-      - 62475a58417e834e21d115fe085b8f4c
+      - 624c4b3bd3eed55485ebb9e000fb97f3
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1478,12 +1478,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"tmp_spectacles_c","remote":"origin","remote_name":"tmp_spectacles_c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":null,"can":{}}'
+      string: '{"name":"tmp_spectacles_c","remote":"origin","remote_name":"tmp_spectacles_c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":null,"can":{}}'
     headers:
       Connection:
       - keep-alive
@@ -1492,20 +1492,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:32 GMT
+      - Tue, 05 Apr 2022 13:59:23 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 6cf09daeb2db9827
+      - 460a42f7bbfd89f3
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6cf09daeb2db9827
+      - 460a42f7bbfd89f3
       X-B3-TraceId:
-      - 62475a58b0ae822b6cf09daeb2db9827
+      - 624c4b3b6d8d998e460a42f7bbfd89f3
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1519,12 +1519,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"tmp_spectacles_c","remote":"origin","remote_name":"tmp_spectacles_c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":null,"can":{}}'
+      string: '{"name":"tmp_spectacles_c","remote":"origin","remote_name":"tmp_spectacles_c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":null,"can":{}}'
     headers:
       Connection:
       - keep-alive
@@ -1533,20 +1533,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:34 GMT
+      - Tue, 05 Apr 2022 13:59:25 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 4463fd3dc3eacaf7
+      - 6e894fb546f5ce88
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 4463fd3dc3eacaf7
+      - 6e894fb546f5ce88
       X-B3-TraceId:
-      - 62475a587decc3554463fd3dc3eacaf7
+      - 624c4b3b49d1704d6e894fb546f5ce88
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1556,7 +1556,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:25 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 35128c7f447a65c3
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 35128c7f447a65c3
+      X-B3-TraceId:
+      - 624c4b3d64ebf8ec35128c7f447a65c3
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1570,19 +1606,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:34 GMT
+      - Tue, 05 Apr 2022 13:59:25 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 9c92b16692358e94
+      - acfc38ee5c7faa91
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 9c92b16692358e94
+      - acfc38ee5c7faa91
       X-B3-TraceId:
-      - 62475a5af0737d119c92b16692358e94
+      - 624c4b3d910887ddacfc38ee5c7faa91
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1592,7 +1628,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -1606,20 +1642,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:34 GMT
+      - Tue, 05 Apr 2022 13:59:25 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 77a872e0ea4150b1
+      - 52043c13e6be9e04
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 77a872e0ea4150b1
+      - 52043c13e6be9e04
       X-B3-TraceId:
-      - 62475a5a7c856be277a872e0ea4150b1
+      - 624c4b3d4ab6ff0752043c13e6be9e04
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:26 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - a706e7b5d03bbe45
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - a706e7b5d03bbe45
+      X-B3-TraceId:
+      - 624c4b3dded621ada706e7b5d03bbe45
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1629,7 +1705,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:26 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 492503172692f6a4
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 492503172692f6a4
+      X-B3-TraceId:
+      - 624c4b3e3a8e9e14492503172692f6a4
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:26 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 4248278dafa6e533
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 4248278dafa6e533
+      X-B3-TraceId:
+      - 624c4b3ee989d5284248278dafa6e533
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:26 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 5f05b3ce97cd0c33
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 5f05b3ce97cd0c33
+      X-B3-TraceId:
+      - 624c4b3e3132eb9d5f05b3ce97cd0c33
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:26 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 6e0fad755d9d61de
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 6e0fad755d9d61de
+      X-B3-TraceId:
+      - 624c4b3e30dae80a6e0fad755d9d61de
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:26 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - d0a3b827d4951342
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - d0a3b827d4951342
+      X-B3-TraceId:
+      - 624c4b3e4068c656d0a3b827d4951342
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_d"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_d","remote":"origin","remote_name":"tmp_spectacles_d","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:26 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 7d47dbad7544588d
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 7d47dbad7544588d
+      X-B3-TraceId:
+      - 624c4b3ed36bc13f7d47dbad7544588d
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_d", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_d","remote":"origin","remote_name":"tmp_spectacles_d","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:27 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 5cc45188f8a1e62a
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 5cc45188f8a1e62a
+      X-B3-TraceId:
+      - 624c4b3eea305c325cc45188f8a1e62a
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -1678,325 +2022,17 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:02:34 GMT
+      - Tue, 05 Apr 2022 13:59:27 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:35 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 2d95cef356b3f667
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 2d95cef356b3f667
-      X-B3-TraceId:
-      - 62475a5b38559e812d95cef356b3f667
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:35 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 1a1169fb12215782
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 1a1169fb12215782
-      X-B3-TraceId:
-      - 62475a5b06acca7e1a1169fb12215782
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:35 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 05cd7ab647e19bbe
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 05cd7ab647e19bbe
-      X-B3-TraceId:
-      - 62475a5b93a2f28605cd7ab647e19bbe
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:35 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - c43fc76bf4fd5e13
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - c43fc76bf4fd5e13
-      X-B3-TraceId:
-      - 62475a5b5db14a37c43fc76bf4fd5e13
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:35 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 52287629aa8087df
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 52287629aa8087df
-      X-B3-TraceId:
-      - 62475a5bd318c0c752287629aa8087df
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:35 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - ce39b6b430bccf1c
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - ce39b6b430bccf1c
-      X-B3-TraceId:
-      - 62475a5b3de417c4ce39b6b430bccf1c
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_d"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_d","remote":"origin","remote_name":"tmp_spectacles_d","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:35 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - e8284f47fac7cb9d
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - e8284f47fac7cb9d
-      X-B3-TraceId:
-      - 62475a5b37a05a84e8284f47fac7cb9d
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_d", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_d","remote":"origin","remote_name":"tmp_spectacles_d","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:36 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - facc47b8d3a49d25
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - facc47b8d3a49d25
-      X-B3-TraceId:
-      - 62475a5b0709646ffacc47b8d3a49d25
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models?fields=name%2Cproject_name%2Cexplores
   response:
@@ -2080,20 +2116,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:37 GMT
+      - Tue, 05 Apr 2022 13:59:28 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - bd288381c4039500
+      - f6dc6051d16e5796
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - bd288381c4039500
+      - f6dc6051d16e5796
       X-B3-TraceId:
-      - 62475a5cf2c97022bd288381c4039500
+      - 624c4b3f22e733dff6dc6051d16e5796
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2103,7 +2139,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users?fields=fields
   response:
@@ -2134,20 +2170,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:37 GMT
+      - Tue, 05 Apr 2022 13:59:28 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - fb7a1dd7cc703612
+      - 548566e436c9bb63
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - fb7a1dd7cc703612
+      - 548566e436c9bb63
       X-B3-TraceId:
-      - 62475a5d56b7a8b7fb7a1dd7cc703612
+      - 624c4b4078a92600548566e436c9bb63
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2157,7 +2193,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users__fail?fields=fields
   response:
@@ -2193,20 +2229,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:37 GMT
+      - Tue, 05 Apr 2022 13:59:28 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 24d0bbe459da5457
+      - 22beafa0f3c5095e
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 24d0bbe459da5457
+      - 22beafa0f3c5095e
       X-B3-TraceId:
-      - 62475a5dc5ec831c24d0bbe459da5457
+      - 624c4b40dbdf521322beafa0f3c5095e
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2222,7 +2258,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -2236,19 +2272,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:37 GMT
+      - Tue, 05 Apr 2022 13:59:28 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 15f5bf2dd19ab69b
+      - 783180c98e0f2bc2
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 15f5bf2dd19ab69b
+      - 783180c98e0f2bc2
       X-B3-TraceId:
-      - 62475a5d422592c715f5bf2dd19ab69b
+      - 624c4b409406b74d783180c98e0f2bc2
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2258,7 +2294,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/2216/run/sql
   response:
@@ -2275,19 +2311,19 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:02:37 GMT
+      - Tue, 05 Apr 2022 13:59:28 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - e1c3f269c1be4d37
+      - 2591319f42364589
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - e1c3f269c1be4d37
+      - 2591319f42364589
       X-B3-TraceId:
-      - 62475a5d5e878571e1c3f269c1be4d37
+      - 624c4b40d95d0e402591319f42364589
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2303,7 +2339,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -2317,19 +2353,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:37 GMT
+      - Tue, 05 Apr 2022 13:59:28 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 590d8a4c1f3ae07e
+      - 2ad0934cd1398a78
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 590d8a4c1f3ae07e
+      - 2ad0934cd1398a78
       X-B3-TraceId:
-      - 62475a5d49e8735c590d8a4c1f3ae07e
+      - 624c4b40b040ebff2ad0934cd1398a78
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2339,7 +2375,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/1944/run/sql
   response:
@@ -2357,60 +2393,60 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:02:38 GMT
+      - Tue, 05 Apr 2022 13:59:29 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 1620c881e96bbbcc
+      - 047079dec9d8514e
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 1620c881e96bbbcc
+      - 047079dec9d8514e
       X-B3-TraceId:
-      - 62475a5eee5348c41620c881e96bbbcc
+      - 624c4b40a1a95ab1047079dec9d8514e
       X-Content-Type-Options:
       - nosniff
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "pytest-incremental-valid-diff"}'
+    body: '{"name": "pytest"}'
     headers:
       Content-Length:
-      - '41'
+      - '18'
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest-incremental-valid-diff","remote":"origin","remote_name":"pytest-incremental-valid-diff","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","can":{}}'
+      string: '{"name":"pytest","remote":"origin","remote_name":"pytest","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":"742b118d314d2478a215aa02016c09e173deec7e","can":{}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '409'
+      - '363'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:38 GMT
+      - Tue, 05 Apr 2022 13:59:29 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 85894b4e34f3178e
+      - 7ba07a9e89dddff3
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 85894b4e34f3178e
+      - 7ba07a9e89dddff3
       X-B3-TraceId:
-      - 62475a5eefb1079185894b4e34f3178e
+      - 624c4b41a3e31f407ba07a9e89dddff3
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2422,7 +2458,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_c
   response:
@@ -2432,19 +2468,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:02:39 GMT
+      - Tue, 05 Apr 2022 13:59:30 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 5c69c8b4c6bd7b09
+      - 173e0b1edce1b0b0
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 5c69c8b4c6bd7b09
+      - 173e0b1edce1b0b0
       X-B3-TraceId:
-      - 62475a5eaf6204715c69c8b4c6bd7b09
+      - 624c4b410b7c3023173e0b1edce1b0b0
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2458,7 +2494,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -2472,20 +2508,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:40 GMT
+      - Tue, 05 Apr 2022 13:59:31 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - ad9b866c41ea93af
+      - 3270a4572567f20a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - ad9b866c41ea93af
+      - 3270a4572567f20a
       X-B3-TraceId:
-      - 62475a5f9d0e9ae7ad9b866c41ea93af
+      - 624c4b423d0e12f33270a4572567f20a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2497,7 +2533,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_d
   response:
@@ -2507,19 +2543,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:02:40 GMT
+      - Tue, 05 Apr 2022 13:59:31 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - be75aed46714ecd0
+      - 21b280c0bfb4c448
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - be75aed46714ecd0
+      - 21b280c0bfb4c448
       X-B3-TraceId:
-      - 62475a60d724561cbe75aed46714ecd0
+      - 624c4b43293122a021b280c0bfb4c448
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2533,7 +2569,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -2547,20 +2583,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:41 GMT
+      - Tue, 05 Apr 2022 13:59:32 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 00d909540f80c809
+      - 63d4e37589306c21
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 00d909540f80c809
+      - 63d4e37589306c21
       X-B3-TraceId:
-      - 62475a6096efcd5700d909540f80c809
+      - 624c4b43a10da78563d4e37589306c21
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2574,7 +2610,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -2588,19 +2624,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:41 GMT
+      - Tue, 05 Apr 2022 13:59:32 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 22c57e672d8fae95
+      - 74b190bc8b1e5013
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 22c57e672d8fae95
+      - 74b190bc8b1e5013
       X-B3-TraceId:
-      - 62475a61c39450c422c57e672d8fae95
+      - 624c4b44e628ad1a74b190bc8b1e5013
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2614,7 +2650,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -2628,19 +2664,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:41 GMT
+      - Tue, 05 Apr 2022 13:59:32 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 99da42f68865d6bf
+      - f4adefa6a0d087b8
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 99da42f68865d6bf
+      - f4adefa6a0d087b8
       X-B3-TraceId:
-      - 62475a6124b4a40e99da42f68865d6bf
+      - 624c4b44ad4fe48cf4adefa6a0d087b8
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2654,12 +2690,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest-incremental-fix-prod","remote":"origin","remote_name":"pytest-incremental-fix-prod","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":5,"behind_count":4,"commit_at":1648842776,"ref":"6a71188e1a67308c9f2e7ea6babe559e06fb4d1b","remote_ref":"1172557d86a21f99522c87fb8b9811fef51b3265","can":{}}'
+      string: '{"name":"pytest-incremental-fix-prod","remote":"origin","remote_name":"pytest-incremental-fix-prod","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648842776,"ref":"1172557d86a21f99522c87fb8b9811fef51b3265","remote_ref":"1172557d86a21f99522c87fb8b9811fef51b3265","can":{}}'
     headers:
       Connection:
       - keep-alive
@@ -2668,20 +2704,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:42 GMT
+      - Tue, 05 Apr 2022 13:59:33 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 6d125b3e596c4821
+      - 8cb120b3e5c1a3f5
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6d125b3e596c4821
+      - 8cb120b3e5c1a3f5
       X-B3-TraceId:
-      - 62475a617215ee226d125b3e596c4821
+      - 624c4b44f722d1f28cb120b3e5c1a3f5
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2693,7 +2729,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/reset_to_remote
   response:
@@ -2703,19 +2739,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:02:43 GMT
+      - Tue, 05 Apr 2022 13:59:34 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - e14c46b324ee55fd
+      - 59e5f1639502d695
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - e14c46b324ee55fd
+      - 59e5f1639502d695
       X-B3-TraceId:
-      - 62475a62b8d96771e14c46b324ee55fd
+      - 624c4b4504a4898059e5f1639502d695
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2725,7 +2761,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:34 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 77574f3ec20ea6df
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 77574f3ec20ea6df
+      X-B3-TraceId:
+      - 624c4b466a51398577574f3ec20ea6df
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -2739,19 +2811,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:43 GMT
+      - Tue, 05 Apr 2022 13:59:34 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - fa38ee2dd086e1d9
+      - 1c9dfa74f0614805
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - fa38ee2dd086e1d9
+      - 1c9dfa74f0614805
       X-B3-TraceId:
-      - 62475a639e1f43bffa38ee2dd086e1d9
+      - 624c4b469797f9a61c9dfa74f0614805
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2761,7 +2833,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -2775,20 +2847,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:43 GMT
+      - Tue, 05 Apr 2022 13:59:34 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - c7ae317b23a8636d
+      - d699251c1ac4a6ba
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - c7ae317b23a8636d
+      - d699251c1ac4a6ba
       X-B3-TraceId:
-      - 62475a635f70e231c7ae317b23a8636d
+      - 624c4b465bf02b76d699251c1ac4a6ba
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:34 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 9b1bf0b8295bc15d
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 9b1bf0b8295bc15d
+      X-B3-TraceId:
+      - 624c4b463d8487d69b1bf0b8295bc15d
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2798,7 +2910,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:34 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - e21428ac82372ec6
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - e21428ac82372ec6
+      X-B3-TraceId:
+      - 624c4b46d03c0507e21428ac82372ec6
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:34 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 60a895846c459ac9
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 60a895846c459ac9
+      X-B3-TraceId:
+      - 624c4b4619c2e13660a895846c459ac9
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:34 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - ba5db7c64975009d
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - ba5db7c64975009d
+      X-B3-TraceId:
+      - 624c4b461c0924b1ba5db7c64975009d
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:34 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - acd373d1addb714f
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - acd373d1addb714f
+      X-B3-TraceId:
+      - 624c4b4603d9876cacd373d1addb714f
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:34 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 94f088219c3b1031
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 94f088219c3b1031
+      X-B3-TraceId:
+      - 624c4b468fd29bb694f088219c3b1031
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_e"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_e","remote":"origin","remote_name":"tmp_spectacles_e","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:35 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - f30e44729b39ce0b
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - f30e44729b39ce0b
+      X-B3-TraceId:
+      - 624c4b46f5bd6282f30e44729b39ce0b
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_e", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_e","remote":"origin","remote_name":"tmp_spectacles_e","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:35 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - b47214155d05c546
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - b47214155d05c546
+      X-B3-TraceId:
+      - 624c4b47e0cc4e90b47214155d05c546
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -2847,320 +3227,12 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:02:43 GMT
+      - Tue, 05 Apr 2022 13:59:36 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
-- request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:43 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 1152aa3b9886573a
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 1152aa3b9886573a
-      X-B3-TraceId:
-      - 62475a633bdce3971152aa3b9886573a
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:43 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 893851d67bb64f99
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 893851d67bb64f99
-      X-B3-TraceId:
-      - 62475a63ce86e018893851d67bb64f99
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:43 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - c12c7ddbb69fb6ed
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - c12c7ddbb69fb6ed
-      X-B3-TraceId:
-      - 62475a63c3fb398fc12c7ddbb69fb6ed
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:43 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 3adf724924ef7735
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 3adf724924ef7735
-      X-B3-TraceId:
-      - 62475a63511070d23adf724924ef7735
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:43 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 08bb3665bb199cb3
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 08bb3665bb199cb3
-      X-B3-TraceId:
-      - 62475a6386c27c3408bb3665bb199cb3
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:43 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 86c3bc4373e21f9c
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 86c3bc4373e21f9c
-      X-B3-TraceId:
-      - 62475a635031ed7386c3bc4373e21f9c
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_e"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_e","remote":"origin","remote_name":"tmp_spectacles_e","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:44 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 2e0814661de3ff08
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 2e0814661de3ff08
-      X-B3-TraceId:
-      - 62475a631aebcafa2e0814661de3ff08
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_e", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_e","remote":"origin","remote_name":"tmp_spectacles_e","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:44 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 8ea2ae08a16cd7a0
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 8ea2ae08a16cd7a0
-      X-B3-TraceId:
-      - 62475a64e5be140d8ea2ae08a16cd7a0
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
 - request:
     body: '{"query_id": 1944, "result_format": "json_detail"}'
     headers:
@@ -3169,12 +3241,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"85227798deb198dfad83d6d7f88fedae"}'
+      string: '{"id":"30429acb7e4e75adaab92e4cdbe113e3"}'
     headers:
       Connection:
       - keep-alive
@@ -3183,19 +3255,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:45 GMT
+      - Tue, 05 Apr 2022 13:59:36 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - abc257e9d3c7550e
+      - 35a6dcc30fd017f5
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - abc257e9d3c7550e
+      - 35a6dcc30fd017f5
       X-B3-TraceId:
-      - 62475a649bbf07d1abc257e9d3c7550e
+      - 624c4b48917c86a935a6dcc30fd017f5
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3205,12 +3277,12 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=85227798deb198dfad83d6d7f88fedae
+    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=30429acb7e4e75adaab92e4cdbe113e3
   response:
     body:
-      string: '{"85227798deb198dfad83d6d7f88fedae":{"status":"added"}}'
+      string: '{"30429acb7e4e75adaab92e4cdbe113e3":{"status":"added"}}'
     headers:
       Connection:
       - keep-alive
@@ -3219,19 +3291,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:45 GMT
+      - Tue, 05 Apr 2022 13:59:36 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 096631cc5e764aba
+      - f904e9b49df98cb1
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 096631cc5e764aba
+      - f904e9b49df98cb1
       X-B3-TraceId:
-      - 62475a65ba1d29f2096631cc5e764aba
+      - 624c4b48bd804268f904e9b49df98cb1
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3241,12 +3313,12 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=85227798deb198dfad83d6d7f88fedae
+    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=30429acb7e4e75adaab92e4cdbe113e3
   response:
     body:
-      string: '{"85227798deb198dfad83d6d7f88fedae":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"85227798deb198dfad83d6d7f88fedae","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:02:45+00:00","aggregate_table_used_info":null,"runtime":"0.317","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.city"]},"forecast_result":null,"sql":"SELECT\n    users__fail.city_  AS
+      string: '{"30429acb7e4e75adaab92e4cdbe113e3":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"30429acb7e4e75adaab92e4cdbe113e3","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:59:36+00:00","aggregate_table_used_info":null,"runtime":"0.322","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.city"]},"forecast_result":null,"sql":"SELECT\n    users__fail.city_  AS
         users__fail_city,\n    users__fail.email_address_  AS users__fail_email,\n    users__fail.first_name  AS
         users__fail_first_name,\n    users__fail.id  AS users__fail_id,\n    users__fail.last_name  AS
         users__fail_last_name\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
@@ -3275,7 +3347,7 @@ interactions:
         users__fail_city,\n    users__fail.email_address_  AS users__fail_email,\n    users__fail.first_name  AS
         users__fail_first_name,\n    users__fail.id  AS users__fail_id,\n    users__fail.last_name  AS
         users__fail_last_name\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
-        (1 = 2)\nORDER BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":2,"column":17}}],"drill_menu_build_time":0.037958,"has_subtotals":false}}}'
+        (1 = 2)\nORDER BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":2,"column":17}}],"drill_menu_build_time":0.039182,"has_subtotals":false}}}'
     headers:
       Connection:
       - keep-alive
@@ -3284,20 +3356,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:46 GMT
+      - Tue, 05 Apr 2022 13:59:37 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - d1bbe7253959c6e6
+      - 780bec6381d4a42f
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - d1bbe7253959c6e6
+      - 780bec6381d4a42f
       X-B3-TraceId:
-      - 62475a661f30548cd1bbe7253959c6e6
+      - 624c4b49f9ef9632780bec6381d4a42f
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3311,7 +3383,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3325,20 +3397,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:47 GMT
+      - Tue, 05 Apr 2022 13:59:38 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 3a434851e67f8691
+      - d099ee8a3768b62d
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 3a434851e67f8691
+      - d099ee8a3768b62d
       X-B3-TraceId:
-      - 62475a66665106793a434851e67f8691
+      - 624c4b49e4d226a1d099ee8a3768b62d
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3350,7 +3422,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_e
   response:
@@ -3360,19 +3432,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:02:47 GMT
+      - Tue, 05 Apr 2022 13:59:38 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - e3503c3a7448055b
+      - 83600ff070501e21
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - e3503c3a7448055b
+      - 83600ff070501e21
       X-B3-TraceId:
-      - 62475a6717a2ef62e3503c3a7448055b
+      - 624c4b4a76a3022883600ff070501e21
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3386,7 +3458,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3400,20 +3472,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:47 GMT
+      - Tue, 05 Apr 2022 13:59:39 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 9e3eb16902610e87
+      - 7cdfc9a6a0f46605
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 9e3eb16902610e87
+      - 7cdfc9a6a0f46605
       X-B3-TraceId:
-      - 62475a67ee7a80d29e3eb16902610e87
+      - 624c4b4a2a9842237cdfc9a6a0f46605
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3427,7 +3499,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3441,19 +3513,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:48 GMT
+      - Tue, 05 Apr 2022 13:59:39 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f7a6a57bdee41b32
+      - 5944e820dac775c1
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f7a6a57bdee41b32
+      - 5944e820dac775c1
       X-B3-TraceId:
-      - 62475a6823deed27f7a6a57bdee41b32
+      - 624c4b4ba207b4385944e820dac775c1
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3467,7 +3539,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3481,19 +3553,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:48 GMT
+      - Tue, 05 Apr 2022 13:59:39 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 2fe5e0958230b357
+      - dc2464a6697fee2a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2fe5e0958230b357
+      - dc2464a6697fee2a
       X-B3-TraceId:
-      - 62475a685f7acdf52fe5e0958230b357
+      - 624c4b4bce7e8356dc2464a6697fee2a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3503,7 +3575,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3517,19 +3589,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:48 GMT
+      - Tue, 05 Apr 2022 13:59:39 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 3255cb006c286237
+      - 999ed5dc2ea99cd1
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 3255cb006c286237
+      - 999ed5dc2ea99cd1
       X-B3-TraceId:
-      - 62475a686a50d35d3255cb006c286237
+      - 624c4b4b12111407999ed5dc2ea99cd1
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3539,7 +3611,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -3553,20 +3625,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:48 GMT
+      - Tue, 05 Apr 2022 13:59:39 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 6bebb37c6dc10552
+      - a9fb4f72e8419b64
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6bebb37c6dc10552
+      - a9fb4f72e8419b64
       X-B3-TraceId:
-      - 62475a68f3efbeeb6bebb37c6dc10552
+      - 624c4b4b21aacd3ca9fb4f72e8419b64
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3580,7 +3652,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -3594,20 +3666,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:48 GMT
+      - Tue, 05 Apr 2022 13:59:39 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - d2dc6cf3ec81c68b
+      - 97f44a9ee61a4069
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - d2dc6cf3ec81c68b
+      - 97f44a9ee61a4069
       X-B3-TraceId:
-      - 62475a68b524e626d2dc6cf3ec81c68b
+      - 624c4b4b1857408b97f44a9ee61a4069
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3621,7 +3693,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -3635,20 +3707,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:49 GMT
+      - Tue, 05 Apr 2022 13:59:40 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 01fa3759a1a88f69
+      - cb1ceee553f74063
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 01fa3759a1a88f69
+      - cb1ceee553f74063
       X-B3-TraceId:
-      - 62475a6894a3a86501fa3759a1a88f69
+      - 624c4b4b98789c92cb1ceee553f74063
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3658,7 +3730,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:40 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - ade225223d6e9764
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - ade225223d6e9764
+      X-B3-TraceId:
+      - 624c4b4cb528006bade225223d6e9764
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3672,19 +3780,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:49 GMT
+      - Tue, 05 Apr 2022 13:59:40 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 52ec30e3dbd1d32a
+      - 9afd0f7d38eedc7e
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 52ec30e3dbd1d32a
+      - 9afd0f7d38eedc7e
       X-B3-TraceId:
-      - 62475a6980212fb052ec30e3dbd1d32a
+      - 624c4b4cd423b6ef9afd0f7d38eedc7e
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3694,7 +3802,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3708,20 +3816,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:49 GMT
+      - Tue, 05 Apr 2022 13:59:40 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f6ca06d01348e1ee
+      - c562d7d6bb3f23ad
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f6ca06d01348e1ee
+      - c562d7d6bb3f23ad
       X-B3-TraceId:
-      - 62475a69d9fc2a62f6ca06d01348e1ee
+      - 624c4b4ce0299293c562d7d6bb3f23ad
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:40 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - b76f5d70c6f583c6
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - b76f5d70c6f583c6
+      X-B3-TraceId:
+      - 624c4b4cbf36460cb76f5d70c6f583c6
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3731,7 +3879,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:40 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - bb0642a62c070cf8
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - bb0642a62c070cf8
+      X-B3-TraceId:
+      - 624c4b4cbb01dc0cbb0642a62c070cf8
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:40 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 40c0f3bd1b7c0342
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 40c0f3bd1b7c0342
+      X-B3-TraceId:
+      - 624c4b4ca0d8985b40c0f3bd1b7c0342
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:41 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 2fa2f14e3f6bf1f6
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 2fa2f14e3f6bf1f6
+      X-B3-TraceId:
+      - 624c4b4d3e4404062fa2f14e3f6bf1f6
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:41 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 57c8091b51e5588a
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 57c8091b51e5588a
+      X-B3-TraceId:
+      - 624c4b4db795558257c8091b51e5588a
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:41 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 38c35001b80b5f1c
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 38c35001b80b5f1c
+      X-B3-TraceId:
+      - 624c4b4d5cc5df7b38c35001b80b5f1c
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_g"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_g","remote":"origin","remote_name":"tmp_spectacles_g","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:41 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 26849321091dd0e6
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 26849321091dd0e6
+      X-B3-TraceId:
+      - 624c4b4d4cf9db4b26849321091dd0e6
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_g", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_g","remote":"origin","remote_name":"tmp_spectacles_g","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:42 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - ce53becc87087659
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - ce53becc87087659
+      X-B3-TraceId:
+      - 624c4b4d02f699d7ce53becc87087659
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -3780,320 +4196,12 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:02:49 GMT
+      - Tue, 05 Apr 2022 13:59:42 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
-- request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:49 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 4f2b0bd70354d15b
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 4f2b0bd70354d15b
-      X-B3-TraceId:
-      - 62475a695414d4564f2b0bd70354d15b
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:49 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 916c71524088ff1c
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 916c71524088ff1c
-      X-B3-TraceId:
-      - 62475a692b292820916c71524088ff1c
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:49 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 7f1947fe985b90a0
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 7f1947fe985b90a0
-      X-B3-TraceId:
-      - 62475a6908fbd0f27f1947fe985b90a0
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:50 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - ebcc27d5c71f0bbb
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - ebcc27d5c71f0bbb
-      X-B3-TraceId:
-      - 62475a6af8fba6a3ebcc27d5c71f0bbb
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:50 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 6af49f29a234fff7
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 6af49f29a234fff7
-      X-B3-TraceId:
-      - 62475a6a63514d316af49f29a234fff7
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:50 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - eab51512dfeec151
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - eab51512dfeec151
-      X-B3-TraceId:
-      - 62475a6a25345354eab51512dfeec151
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_g"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_g","remote":"origin","remote_name":"tmp_spectacles_g","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:50 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - ec0f0de1c4610a49
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - ec0f0de1c4610a49
-      X-B3-TraceId:
-      - 62475a6a46f0b6b2ec0f0de1c4610a49
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_g", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_g","remote":"origin","remote_name":"tmp_spectacles_g","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:51 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 716468387d5028b3
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 716468387d5028b3
-      X-B3-TraceId:
-      - 62475a6a2501f08f716468387d5028b3
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
 - request:
     body: '{"model": "eye_exam", "view": "users__fail", "fields": ["users__fail.city"],
       "limit": 0, "filter_expression": "1=2"}'
@@ -4103,7 +4211,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -4117,19 +4225,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:51 GMT
+      - Tue, 05 Apr 2022 13:59:42 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 9bf6fd4834b93446
+      - 3749c4088da8a027
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 9bf6fd4834b93446
+      - 3749c4088da8a027
       X-B3-TraceId:
-      - 62475a6b71ffc5029bf6fd4834b93446
+      - 624c4b4eb99065d23749c4088da8a027
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4144,7 +4252,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -4158,19 +4266,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:51 GMT
+      - Tue, 05 Apr 2022 13:59:42 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - d1a1d55a7a95c821
+      - 86ed4d3dbc54acab
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - d1a1d55a7a95c821
+      - 86ed4d3dbc54acab
       X-B3-TraceId:
-      - 62475a6b8f3373bad1a1d55a7a95c821
+      - 624c4b4ec104117f86ed4d3dbc54acab
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4185,7 +4293,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -4199,19 +4307,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:51 GMT
+      - Tue, 05 Apr 2022 13:59:42 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - a55f41497bf9100d
+      - 855efd269f6385e7
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a55f41497bf9100d
+      - 855efd269f6385e7
       X-B3-TraceId:
-      - 62475a6b1089636ba55f41497bf9100d
+      - 624c4b4e9d05eb1f855efd269f6385e7
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4226,7 +4334,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -4240,19 +4348,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:52 GMT
+      - Tue, 05 Apr 2022 13:59:43 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 8c2d1aa132cadafb
+      - 595c962eb18dc088
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 8c2d1aa132cadafb
+      - 595c962eb18dc088
       X-B3-TraceId:
-      - 62475a6b71c866df8c2d1aa132cadafb
+      - 624c4b4f3f00401b595c962eb18dc088
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4267,7 +4375,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -4281,19 +4389,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:52 GMT
+      - Tue, 05 Apr 2022 13:59:43 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - b1aa3d973773c77f
+      - 28e2eccacdcae301
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - b1aa3d973773c77f
+      - 28e2eccacdcae301
       X-B3-TraceId:
-      - 62475a6c35b359beb1aa3d973773c77f
+      - 624c4b4fdd073d6128e2eccacdcae301
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4307,12 +4415,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"4aa82cc6a60af9f006c3843ee67a8d44"}'
+      string: '{"id":"bee5aaf7f83c0dd8e938e0f47b7085d4"}'
     headers:
       Connection:
       - keep-alive
@@ -4321,19 +4429,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:52 GMT
+      - Tue, 05 Apr 2022 13:59:43 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 3d300fbdcb9e4f87
+      - 9375c03b625d827f
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 3d300fbdcb9e4f87
+      - 9375c03b625d827f
       X-B3-TraceId:
-      - 62475a6c70ac2e493d300fbdcb9e4f87
+      - 624c4b4fb6baa11d9375c03b625d827f
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4347,12 +4455,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"56c4d6141733eb9b120dc3283c56fbd5"}'
+      string: '{"id":"58ac86d59d2ae384a33a6703190d0171"}'
     headers:
       Connection:
       - keep-alive
@@ -4361,19 +4469,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:52 GMT
+      - Tue, 05 Apr 2022 13:59:43 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - b321e839de7d48d3
+      - 508bea7ebe89bc05
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - b321e839de7d48d3
+      - 508bea7ebe89bc05
       X-B3-TraceId:
-      - 62475a6cc1d23c80b321e839de7d48d3
+      - 624c4b4f1b425cda508bea7ebe89bc05
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4387,12 +4495,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"8ec6a080a55a50ad7c070bfb9cd558ec"}'
+      string: '{"id":"f018042a14b931dbd81bf9ba49eab3f6"}'
     headers:
       Connection:
       - keep-alive
@@ -4401,19 +4509,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:52 GMT
+      - Tue, 05 Apr 2022 13:59:43 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 425a25c8ebe08bc3
+      - 00f05d0b7f54b572
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 425a25c8ebe08bc3
+      - 00f05d0b7f54b572
       X-B3-TraceId:
-      - 62475a6c2ee8cbe0425a25c8ebe08bc3
+      - 624c4b4f194f3ab100f05d0b7f54b572
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4427,12 +4535,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"85ba0f22b2a3d72c7d3284d970b25492"}'
+      string: '{"id":"bf11036200724d5a23276b794050c658"}'
     headers:
       Connection:
       - keep-alive
@@ -4441,19 +4549,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:52 GMT
+      - Tue, 05 Apr 2022 13:59:43 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - d4d32293b9d469eb
+      - bc98669040f96721
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - d4d32293b9d469eb
+      - bc98669040f96721
       X-B3-TraceId:
-      - 62475a6c34f7de5ed4d32293b9d469eb
+      - 624c4b4fd19d9676bc98669040f96721
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4467,12 +4575,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"caaffc24ecdc5c39c084008c0ffc4ada"}'
+      string: '{"id":"542441b6dfb303c7a9604253cab6de5a"}'
     headers:
       Connection:
       - keep-alive
@@ -4481,19 +4589,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:53 GMT
+      - Tue, 05 Apr 2022 13:59:44 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - be9c12febb0ec846
+      - 899991ea74c3eb18
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - be9c12febb0ec846
+      - 899991ea74c3eb18
       X-B3-TraceId:
-      - 62475a6c2a9698c9be9c12febb0ec846
+      - 624c4b5077a4905f899991ea74c3eb18
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4503,23 +4611,12 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=4aa82cc6a60af9f006c3843ee67a8d44%2C56c4d6141733eb9b120dc3283c56fbd5%2C8ec6a080a55a50ad7c070bfb9cd558ec%2C85ba0f22b2a3d72c7d3284d970b25492%2Ccaaffc24ecdc5c39c084008c0ffc4ada
+    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=bee5aaf7f83c0dd8e938e0f47b7085d4%2C58ac86d59d2ae384a33a6703190d0171%2Cf018042a14b931dbd81bf9ba49eab3f6%2Cbf11036200724d5a23276b794050c658%2C542441b6dfb303c7a9604253cab6de5a
   response:
     body:
-      string: '{"4aa82cc6a60af9f006c3843ee67a8d44":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"4aa82cc6a60af9f006c3843ee67a8d44","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:02:52+00:00","aggregate_table_used_info":null,"runtime":"0.324","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.city"]},"forecast_result":null,"sql":"SELECT\n    users__fail.city_  AS
-        users__fail_city\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
-        (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
-        Fail City","label_from_parameter":null,"label_short":"City","map_layer":null,"name":"users__fail.city","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users__fail","view_label":"Users
-        Fail","dynamic":false,"week_start_day":"monday","original_view":"users__fail","dimension_group":null,"error":null,"field_group_variant":"City","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users__fail","suggest_dimension":"users__fail.city","suggest_explore":"users__fail","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers__fail.view.lkml?line=20","permanent":null,"source_file":"views/users__fail.view.lkml","source_file_path":"eye_exam/views/users__fail.view.lkml","sql":"${TABLE}.city_
-        ","sql_case":null,"filters":null,"times_used":0,"sorted":{"sort_index":0,"desc":false}}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users__fail","label":"Users
-        Fail","description":null},"timezone":"America/New_York","data":[],"errors":[{"message":"The
-        Google BigQuery Standard SQL database encountered an error while running this
-        query.","message_details":"Query execution failed:  - Name city_ not found
-        inside users__fail at [2:17]","params":"SELECT\n    users__fail.city_  AS
-        users__fail_city\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
-        (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":2,"column":17}}],"drill_menu_build_time":0.035552,"has_subtotals":false}},"56c4d6141733eb9b120dc3283c56fbd5":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"56c4d6141733eb9b120dc3283c56fbd5","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:02:52+00:00","aggregate_table_used_info":null,"runtime":"0.316","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.email"]},"forecast_result":null,"sql":"SELECT\n    users__fail.email_address_  AS
+      string: '{"542441b6dfb303c7a9604253cab6de5a":{"status":"added"},"58ac86d59d2ae384a33a6703190d0171":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"58ac86d59d2ae384a33a6703190d0171","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:59:43+00:00","aggregate_table_used_info":null,"runtime":"0.286","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.email"]},"forecast_result":null,"sql":"SELECT\n    users__fail.email_address_  AS
         users__fail_email\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
         (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
         Fail Email","label_from_parameter":null,"label_short":"Email","map_layer":null,"name":"users__fail.email","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users__fail","view_label":"Users
@@ -4530,79 +4627,40 @@ interactions:
         query.","message_details":"Query execution failed:  - Name email_address_
         not found inside users__fail at [2:17]","params":"SELECT\n    users__fail.email_address_  AS
         users__fail_email\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
-        (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":2,"column":17}}],"drill_menu_build_time":0.036197,"has_subtotals":false}},"85ba0f22b2a3d72c7d3284d970b25492":{"status":"running"},"8ec6a080a55a50ad7c070bfb9cd558ec":{"status":"running"},"caaffc24ecdc5c39c084008c0ffc4ada":{"status":"added"}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '5863'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:53 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 1ded87ad4158f836
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 1ded87ad4158f836
-      X-B3-TraceId:
-      - 62475a6d652deb7c1ded87ad4158f836
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=8ec6a080a55a50ad7c070bfb9cd558ec%2C85ba0f22b2a3d72c7d3284d970b25492%2Ccaaffc24ecdc5c39c084008c0ffc4ada
-  response:
-    body:
-      string: '{"85ba0f22b2a3d72c7d3284d970b25492":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"85ba0f22b2a3d72c7d3284d970b25492","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:02:53+00:00","aggregate_table_used_info":null,"runtime":"0.483","added_params":{"query_timezone":"America/New_York"},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":true,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_axhgFCCGiWXrG-bVx6QTRKtgEv4e"},"sql":"SELECT\n    users__fail.id  AS
-        users__fail_id\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
-        (1 = 2)\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"right","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":true,"label":"Users
-        Fail ID","label_from_parameter":null,"label_short":"ID","map_layer":null,"name":"users__fail.id","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"number","user_attribute_filter_types":["number","advanced_filter_number"],"value_format":null,"view":"users__fail","view_label":"Users
-        Fail","dynamic":false,"week_start_day":"monday","original_view":"users__fail","dimension_group":null,"error":null,"field_group_variant":"ID","measure":false,"parameter":false,"primary_key":true,"project_name":"eye_exam","scope":"users__fail","suggest_dimension":"users__fail.id","suggest_explore":"users__fail","suggestable":false,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers__fail.view.lkml?line=8","permanent":null,"source_file":"views/users__fail.view.lkml","source_file_path":"eye_exam/views/users__fail.view.lkml","sql":"${TABLE}.id
-        ","sql_case":null,"filters":null,"times_used":0}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users__fail","label":"Users
-        Fail","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.037502,"has_subtotals":false}},"8ec6a080a55a50ad7c070bfb9cd558ec":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"8ec6a080a55a50ad7c070bfb9cd558ec","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:02:53+00:00","aggregate_table_used_info":null,"runtime":"0.473","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.first_name"]},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":true,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_SrQQljuZ_-qmfNE_jRoVpGYgi7pL"},"sql":"SELECT\n    users__fail.first_name  AS
-        users__fail_first_name\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
+        (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":2,"column":17}}],"drill_menu_build_time":0.036551999999999994,"has_subtotals":false}},"bee5aaf7f83c0dd8e938e0f47b7085d4":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"bee5aaf7f83c0dd8e938e0f47b7085d4","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:59:43+00:00","aggregate_table_used_info":null,"runtime":"0.292","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.city"]},"forecast_result":null,"sql":"SELECT\n    users__fail.city_  AS
+        users__fail_city\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
         (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
-        Fail First Name","label_from_parameter":null,"label_short":"First Name","map_layer":null,"name":"users__fail.first_name","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users__fail","view_label":"Users
-        Fail","dynamic":false,"week_start_day":"monday","original_view":"users__fail","dimension_group":null,"error":null,"field_group_variant":"First
-        Name","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users__fail","suggest_dimension":"users__fail.first_name","suggest_explore":"users__fail","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers__fail.view.lkml?line=32","permanent":null,"source_file":"views/users__fail.view.lkml","source_file_path":"eye_exam/views/users__fail.view.lkml","sql":"${TABLE}.first_name
+        Fail City","label_from_parameter":null,"label_short":"City","map_layer":null,"name":"users__fail.city","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users__fail","view_label":"Users
+        Fail","dynamic":false,"week_start_day":"monday","original_view":"users__fail","dimension_group":null,"error":null,"field_group_variant":"City","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users__fail","suggest_dimension":"users__fail.city","suggest_explore":"users__fail","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers__fail.view.lkml?line=20","permanent":null,"source_file":"views/users__fail.view.lkml","source_file_path":"eye_exam/views/users__fail.view.lkml","sql":"${TABLE}.city_
         ","sql_case":null,"filters":null,"times_used":0,"sorted":{"sort_index":0,"desc":false}}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users__fail","label":"Users
-        Fail","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.035415,"has_subtotals":false}},"caaffc24ecdc5c39c084008c0ffc4ada":{"status":"running"}}'
+        Fail","description":null},"timezone":"America/New_York","data":[],"errors":[{"message":"The
+        Google BigQuery Standard SQL database encountered an error while running this
+        query.","message_details":"Query execution failed:  - Name city_ not found
+        inside users__fail at [2:17]","params":"SELECT\n    users__fail.city_  AS
+        users__fail_city\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
+        (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":2,"column":17}}],"drill_menu_build_time":0.037549,"has_subtotals":false}},"bf11036200724d5a23276b794050c658":{"status":"running"},"f018042a14b931dbd81bf9ba49eab3f6":{"status":"running"}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '5128'
+      - '5875'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:53 GMT
+      - Tue, 05 Apr 2022 13:59:44 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - b66ed82b34bb319d
+      - 0e292bd8dd62d411
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - b66ed82b34bb319d
+      - 0e292bd8dd62d411
       X-B3-TraceId:
-      - 62475a6de0c75784b66ed82b34bb319d
+      - 624c4b500d6cc1890e292bd8dd62d411
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4612,41 +4670,54 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=caaffc24ecdc5c39c084008c0ffc4ada
+    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=f018042a14b931dbd81bf9ba49eab3f6%2Cbf11036200724d5a23276b794050c658%2C542441b6dfb303c7a9604253cab6de5a
   response:
     body:
-      string: '{"caaffc24ecdc5c39c084008c0ffc4ada":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"caaffc24ecdc5c39c084008c0ffc4ada","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:02:53+00:00","aggregate_table_used_info":null,"runtime":"0.524","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.last_name"]},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":true,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_udqmCHTtCvW-mktVti0iUNPdiphk"},"sql":"SELECT\n    users__fail.last_name  AS
+      string: '{"542441b6dfb303c7a9604253cab6de5a":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"542441b6dfb303c7a9604253cab6de5a","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:59:44+00:00","aggregate_table_used_info":null,"runtime":"0.528","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.last_name"]},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":false,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_QFvf18VINF2yq53GsWWpNmdarasn"},"sql":"SELECT\n    users__fail.last_name  AS
         users__fail_last_name\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
         (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
         Fail Last Name","label_from_parameter":null,"label_short":"Last Name","map_layer":null,"name":"users__fail.last_name","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users__fail","view_label":"Users
         Fail","dynamic":false,"week_start_day":"monday","original_view":"users__fail","dimension_group":null,"error":null,"field_group_variant":"Last
         Name","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users__fail","suggest_dimension":"users__fail.last_name","suggest_explore":"users__fail","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers__fail.view.lkml?line=38","permanent":null,"source_file":"views/users__fail.view.lkml","source_file_path":"eye_exam/views/users__fail.view.lkml","sql":"${TABLE}.last_name
         ","sql_case":null,"filters":null,"times_used":0,"sorted":{"sort_index":0,"desc":false}}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users__fail","label":"Users
-        Fail","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.036029,"has_subtotals":false}}}'
+        Fail","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.037524,"has_subtotals":false}},"bf11036200724d5a23276b794050c658":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"bf11036200724d5a23276b794050c658","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:59:44+00:00","aggregate_table_used_info":null,"runtime":"0.540","added_params":{"query_timezone":"America/New_York"},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":true,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_43BJByN7b-w4SeAa_0nLJf4H0DWW"},"sql":"SELECT\n    users__fail.id  AS
+        users__fail_id\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
+        (1 = 2)\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"right","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":true,"label":"Users
+        Fail ID","label_from_parameter":null,"label_short":"ID","map_layer":null,"name":"users__fail.id","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"number","user_attribute_filter_types":["number","advanced_filter_number"],"value_format":null,"view":"users__fail","view_label":"Users
+        Fail","dynamic":false,"week_start_day":"monday","original_view":"users__fail","dimension_group":null,"error":null,"field_group_variant":"ID","measure":false,"parameter":false,"primary_key":true,"project_name":"eye_exam","scope":"users__fail","suggest_dimension":"users__fail.id","suggest_explore":"users__fail","suggestable":false,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers__fail.view.lkml?line=8","permanent":null,"source_file":"views/users__fail.view.lkml","source_file_path":"eye_exam/views/users__fail.view.lkml","sql":"${TABLE}.id
+        ","sql_case":null,"filters":null,"times_used":0}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users__fail","label":"Users
+        Fail","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.037927,"has_subtotals":false}},"f018042a14b931dbd81bf9ba49eab3f6":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"f018042a14b931dbd81bf9ba49eab3f6","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:59:44+00:00","aggregate_table_used_info":null,"runtime":"0.591","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.first_name"]},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":false,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_FZfypC869qPC5ywmrrrEbRjPSgPt"},"sql":"SELECT\n    users__fail.first_name  AS
+        users__fail_first_name\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
+        (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
+        Fail First Name","label_from_parameter":null,"label_short":"First Name","map_layer":null,"name":"users__fail.first_name","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users__fail","view_label":"Users
+        Fail","dynamic":false,"week_start_day":"monday","original_view":"users__fail","dimension_group":null,"error":null,"field_group_variant":"First
+        Name","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users__fail","suggest_dimension":"users__fail.first_name","suggest_explore":"users__fail","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers__fail.view.lkml?line=32","permanent":null,"source_file":"views/users__fail.view.lkml","source_file_path":"eye_exam/views/users__fail.view.lkml","sql":"${TABLE}.first_name
+        ","sql_case":null,"filters":null,"times_used":0,"sorted":{"sort_index":0,"desc":false}}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users__fail","label":"Users
+        Fail","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.036506,"has_subtotals":false}}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '2614'
+      - '7687'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:54 GMT
+      - Tue, 05 Apr 2022 13:59:44 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 467cbfacbc9b362b
+      - 234d4919d4947019
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 467cbfacbc9b362b
+      - 234d4919d4947019
       X-B3-TraceId:
-      - 62475a6e76bf1a56467cbfacbc9b362b
+      - 624c4b50707b6e5a234d4919d4947019
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4660,7 +4731,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -4674,20 +4745,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:55 GMT
+      - Tue, 05 Apr 2022 13:59:46 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f983b24d1f6090e0
+      - cea7680c5c327ab0
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f983b24d1f6090e0
+      - cea7680c5c327ab0
       X-B3-TraceId:
-      - 62475a6efe8ece6af983b24d1f6090e0
+      - 624c4b516d5a2baacea7680c5c327ab0
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4699,7 +4770,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_f
   response:
@@ -4709,19 +4780,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:02:55 GMT
+      - Tue, 05 Apr 2022 13:59:46 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - bb5d64f452215fdf
+      - 869cfa1f5a54152f
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - bb5d64f452215fdf
+      - 869cfa1f5a54152f
       X-B3-TraceId:
-      - 62475a6f644fc814bb5d64f452215fdf
+      - 624c4b523e1393d4869cfa1f5a54152f
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4735,7 +4806,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -4749,20 +4820,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:56 GMT
+      - Tue, 05 Apr 2022 13:59:47 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 4b2212b613f277bb
+      - 2751bfad005dc620
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 4b2212b613f277bb
+      - 2751bfad005dc620
       X-B3-TraceId:
-      - 62475a6f5c9b5bb54b2212b613f277bb
+      - 624c4b52f65aa77f2751bfad005dc620
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4774,7 +4845,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_g
   response:
@@ -4784,19 +4855,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:02:56 GMT
+      - Tue, 05 Apr 2022 13:59:47 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - a89d83aa0530c174
+      - 2ea6deac23da4a15
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a89d83aa0530c174
+      - 2ea6deac23da4a15
       X-B3-TraceId:
-      - 62475a7014bead39a89d83aa0530c174
+      - 624c4b5379076c1d2ea6deac23da4a15
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4810,7 +4881,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -4824,20 +4895,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:57 GMT
+      - Tue, 05 Apr 2022 13:59:47 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 21df0ef38543bf07
+      - e861f8a32b4a22f2
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 21df0ef38543bf07
+      - e861f8a32b4a22f2
       X-B3-TraceId:
-      - 62475a70d35729c321df0ef38543bf07
+      - 624c4b53fdbf936fe861f8a32b4a22f2
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4851,7 +4922,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -4865,19 +4936,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:57 GMT
+      - Tue, 05 Apr 2022 13:59:48 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - b0e16af70bfb235e
+      - cc9be5c77aef2d1a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - b0e16af70bfb235e
+      - cc9be5c77aef2d1a
       X-B3-TraceId:
-      - 62475a7131854e2db0e16af70bfb235e
+      - 624c4b53289ce938cc9be5c77aef2d1a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4891,7 +4962,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -4905,19 +4976,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:57 GMT
+      - Tue, 05 Apr 2022 13:59:48 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 3cf324ffdd973941
+      - 571978e63646e602
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 3cf324ffdd973941
+      - 571978e63646e602
       X-B3-TraceId:
-      - 62475a71b0e5b46b3cf324ffdd973941
+      - 624c4b54583cc8be571978e63646e602
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4927,7 +4998,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -4941,19 +5012,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:57 GMT
+      - Tue, 05 Apr 2022 13:59:48 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 841d8378900b20c4
+      - ab9b0e3c16e92e12
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 841d8378900b20c4
+      - ab9b0e3c16e92e12
       X-B3-TraceId:
-      - 62475a7134e08ca5841d8378900b20c4
+      - 624c4b54bdc58829ab9b0e3c16e92e12
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4963,7 +5034,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -4977,20 +5048,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:57 GMT
+      - Tue, 05 Apr 2022 13:59:48 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 8b6b772560deb277
+      - bcdb889287b4df81
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 8b6b772560deb277
+      - bcdb889287b4df81
       X-B3-TraceId:
-      - 62475a716929a0278b6b772560deb277
+      - 624c4b542018b4dfbcdb889287b4df81
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5004,7 +5075,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -5018,20 +5089,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:58 GMT
+      - Tue, 05 Apr 2022 13:59:48 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 6c3638fef225a32b
+      - 8672349173b07ede
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6c3638fef225a32b
+      - 8672349173b07ede
       X-B3-TraceId:
-      - 62475a71613d52866c3638fef225a32b
+      - 624c4b54db82b5878672349173b07ede
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5045,7 +5116,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -5059,20 +5130,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:00 GMT
+      - Tue, 05 Apr 2022 13:59:50 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - a63a27a26005393c
+      - 6d6fa9f1098cdd7a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a63a27a26005393c
+      - 6d6fa9f1098cdd7a
       X-B3-TraceId:
-      - 62475a725e577e49a63a27a26005393c
+      - 624c4b54770839e56d6fa9f1098cdd7a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5082,7 +5153,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:50 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 1a5689cef03b2d2e
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 1a5689cef03b2d2e
+      X-B3-TraceId:
+      - 624c4b5629ebe8451a5689cef03b2d2e
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -5096,19 +5203,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:00 GMT
+      - Tue, 05 Apr 2022 13:59:50 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 15e9a7e18bc2ef3b
+      - bc7b12397b00daff
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 15e9a7e18bc2ef3b
+      - bc7b12397b00daff
       X-B3-TraceId:
-      - 62475a74bc546c1715e9a7e18bc2ef3b
+      - 624c4b56db7b0b4fbc7b12397b00daff
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5118,7 +5225,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -5132,20 +5239,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:00 GMT
+      - Tue, 05 Apr 2022 13:59:50 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 2923608311bb2d32
+      - 272b212f76cf6026
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2923608311bb2d32
+      - 272b212f76cf6026
       X-B3-TraceId:
-      - 62475a7428e843102923608311bb2d32
+      - 624c4b56ae521aa8272b212f76cf6026
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:50 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - d016ecbb5d15ae30
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - d016ecbb5d15ae30
+      X-B3-TraceId:
+      - 624c4b569253f8a2d016ecbb5d15ae30
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5155,7 +5302,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:51 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 898b54bfbccb7e35
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 898b54bfbccb7e35
+      X-B3-TraceId:
+      - 624c4b579f8e2418898b54bfbccb7e35
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:51 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - e0523726706cef31
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - e0523726706cef31
+      X-B3-TraceId:
+      - 624c4b57beae5ec1e0523726706cef31
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:51 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 2361d3d59be7d9ff
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 2361d3d59be7d9ff
+      X-B3-TraceId:
+      - 624c4b57ac5856172361d3d59be7d9ff
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:51 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 981a373e0c2219ea
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 981a373e0c2219ea
+      X-B3-TraceId:
+      - 624c4b57e4ae2ec1981a373e0c2219ea
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:51 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - deff970a14dd0d5e
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - deff970a14dd0d5e
+      X-B3-TraceId:
+      - 624c4b573084d8a4deff970a14dd0d5e
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_i"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_i","remote":"origin","remote_name":"tmp_spectacles_i","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:51 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 66d1ac793672ff20
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 66d1ac793672ff20
+      X-B3-TraceId:
+      - 624c4b57428f7a3066d1ac793672ff20
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_i", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_i","remote":"origin","remote_name":"tmp_spectacles_i","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:52 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 166a113e1853265c
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 166a113e1853265c
+      X-B3-TraceId:
+      - 624c4b575d19c8ab166a113e1853265c
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -5204,320 +5619,12 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:03:00 GMT
+      - Tue, 05 Apr 2022 13:59:52 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
-- request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:00 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 015b3d60c711197f
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 015b3d60c711197f
-      X-B3-TraceId:
-      - 62475a7479bed7c9015b3d60c711197f
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:00 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - ab8955a1e761d22d
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - ab8955a1e761d22d
-      X-B3-TraceId:
-      - 62475a74fc71832fab8955a1e761d22d
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:00 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 90d2765f990ce541
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 90d2765f990ce541
-      X-B3-TraceId:
-      - 62475a743025645690d2765f990ce541
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:00 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 184a15a7bacb5243
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 184a15a7bacb5243
-      X-B3-TraceId:
-      - 62475a745f729ae6184a15a7bacb5243
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:00 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 1151d2a7e71e0629
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 1151d2a7e71e0629
-      X-B3-TraceId:
-      - 62475a7409165d851151d2a7e71e0629
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:00 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - b6a383bceeb2f015
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - b6a383bceeb2f015
-      X-B3-TraceId:
-      - 62475a74f8b443d8b6a383bceeb2f015
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_i"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_i","remote":"origin","remote_name":"tmp_spectacles_i","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:01 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 73d0ef5a6d6ab1d9
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 73d0ef5a6d6ab1d9
-      X-B3-TraceId:
-      - 62475a75cf35f36573d0ef5a6d6ab1d9
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_i", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_i","remote":"origin","remote_name":"tmp_spectacles_i","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:01 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 459a48f11d7ce143
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 459a48f11d7ce143
-      X-B3-TraceId:
-      - 62475a75b4f6220e459a48f11d7ce143
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
 - request:
     body: '{"model": "eye_exam", "view": "users__fail", "fields": ["users__fail.city"],
       "limit": 0, "filter_expression": "1=2"}'
@@ -5527,7 +5634,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -5541,19 +5648,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:02 GMT
+      - Tue, 05 Apr 2022 13:59:52 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - e737e3bc20209651
+      - 6aa10d18635c280a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - e737e3bc20209651
+      - 6aa10d18635c280a
       X-B3-TraceId:
-      - 62475a765bbf1c6de737e3bc20209651
+      - 624c4b580cdfbed36aa10d18635c280a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5563,7 +5670,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/1919/run/sql
   response:
@@ -5579,19 +5686,19 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:03:02 GMT
+      - Tue, 05 Apr 2022 13:59:53 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - ba0ec203c49afcf2
+      - 9c2d01f5d9bf1f0d
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - ba0ec203c49afcf2
+      - 9c2d01f5d9bf1f0d
       X-B3-TraceId:
-      - 62475a76742e105cba0ec203c49afcf2
+      - 624c4b599eaf0f169c2d01f5d9bf1f0d
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5606,7 +5713,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -5620,19 +5727,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:02 GMT
+      - Tue, 05 Apr 2022 13:59:53 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - a18b8f7703d7a895
+      - 0e3496a584af72c4
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a18b8f7703d7a895
+      - 0e3496a584af72c4
       X-B3-TraceId:
-      - 62475a76db077ca1a18b8f7703d7a895
+      - 624c4b59ebbeca4c0e3496a584af72c4
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5642,7 +5749,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/1928/run/sql
   response:
@@ -5658,19 +5765,19 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:03:03 GMT
+      - Tue, 05 Apr 2022 13:59:53 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 197276f9b0e4aadd
+      - 4380b2d2bc015001
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 197276f9b0e4aadd
+      - 4380b2d2bc015001
       X-B3-TraceId:
-      - 62475a76593eb520197276f9b0e4aadd
+      - 624c4b59a65df75a4380b2d2bc015001
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5684,7 +5791,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -5698,20 +5805,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:03 GMT
+      - Tue, 05 Apr 2022 13:59:54 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 442aaed32296267d
+      - 248e3fd280b9be5d
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 442aaed32296267d
+      - 248e3fd280b9be5d
       X-B3-TraceId:
-      - 62475a773a15cc09442aaed32296267d
+      - 624c4b599ff47e1f248e3fd280b9be5d
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5723,7 +5830,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_h
   response:
@@ -5733,19 +5840,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:03:04 GMT
+      - Tue, 05 Apr 2022 13:59:55 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 09a1f27420e1f573
+      - 7fb4cd90efd7684d
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 09a1f27420e1f573
+      - 7fb4cd90efd7684d
       X-B3-TraceId:
-      - 62475a7757b5091b09a1f27420e1f573
+      - 624c4b5a39bb48fb7fb4cd90efd7684d
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5759,7 +5866,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -5773,20 +5880,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:05 GMT
+      - Tue, 05 Apr 2022 13:59:55 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 63ab0e6607f1b0ae
+      - ce9b4f7051dcf4d2
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 63ab0e6607f1b0ae
+      - ce9b4f7051dcf4d2
       X-B3-TraceId:
-      - 62475a78c3c9313d63ab0e6607f1b0ae
+      - 624c4b5bd857ed9dce9b4f7051dcf4d2
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5798,7 +5905,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_i
   response:
@@ -5808,19 +5915,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:03:05 GMT
+      - Tue, 05 Apr 2022 13:59:56 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 6c0a130c56490d38
+      - b1d870bd77e58218
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6c0a130c56490d38
+      - b1d870bd77e58218
       X-B3-TraceId:
-      - 62475a79b68876166c0a130c56490d38
+      - 624c4b5b2c68486bb1d870bd77e58218
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5834,7 +5941,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -5848,20 +5955,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:06 GMT
+      - Tue, 05 Apr 2022 13:59:56 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 794254430247594f
+      - 3195d6790718eac7
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 794254430247594f
+      - 3195d6790718eac7
       X-B3-TraceId:
-      - 62475a79137380fb794254430247594f
+      - 624c4b5cead3dbe13195d6790718eac7
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5875,7 +5982,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -5889,19 +5996,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:06 GMT
+      - Tue, 05 Apr 2022 13:59:56 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f34a201554816a71
+      - 8801b26679da3fb7
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f34a201554816a71
+      - 8801b26679da3fb7
       X-B3-TraceId:
-      - 62475a7a9e65d9e3f34a201554816a71
+      - 624c4b5c7f2c667d8801b26679da3fb7
       X-Content-Type-Options:
       - nosniff
     status:

--- a/tests/cassettes/test_runner/test_incremental_sql_with_diff_explores_and_invalid_sql_should_error.yaml
+++ b/tests/cassettes/test_runner/test_incremental_sql_with_diff_explores_and_invalid_sql_should_error.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -17,19 +17,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:04 GMT
+      - Tue, 05 Apr 2022 13:55:46 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - ad8f30c7fdaecc9c
+      - a1fccf0f161436d8
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - ad8f30c7fdaecc9c
+      - a1fccf0f161436d8
       X-B3-TraceId:
-      - 62475af0bc122c27ad8f30c7fdaecc9c
+      - 624c4a624b9a0079a1fccf0f161436d8
       X-Content-Type-Options:
       - nosniff
     status:
@@ -39,7 +39,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -53,56 +53,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:04 GMT
+      - Tue, 05 Apr 2022 13:55:47 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 632e89d4c976b390
+      - 20433a91f05731ad
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 632e89d4c976b390
+      - 20433a91f05731ad
       X-B3-TraceId:
-      - 62475af0f12154c6632e89d4c976b390
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
-  response:
-    body:
-      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '147'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:04 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - a8b0473d26023dd4
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - a8b0473d26023dd4
-      X-B3-TraceId:
-      - 62475af094280346a8b0473d26023dd4
+      - 624c4a62b942ccab20433a91f05731ad
       X-Content-Type-Options:
       - nosniff
     status:
@@ -116,7 +80,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -130,19 +94,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:04 GMT
+      - Tue, 05 Apr 2022 13:55:47 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - b531e12fe789e9cf
+      - 7ed1b47ee0c2024a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - b531e12fe789e9cf
+      - 7ed1b47ee0c2024a
       X-B3-TraceId:
-      - 62475af0621ae0a5b531e12fe789e9cf
+      - 624c4a63455acca37ed1b47ee0c2024a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -152,7 +116,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -166,19 +130,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:04 GMT
+      - Tue, 05 Apr 2022 13:55:47 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 636460f75560e2c1
+      - 1a32f3a1279eef70
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 636460f75560e2c1
+      - 1a32f3a1279eef70
       X-B3-TraceId:
-      - 62475af09f4d2c71636460f75560e2c1
+      - 624c4a63e6bfcb791a32f3a1279eef70
       X-Content-Type-Options:
       - nosniff
     status:
@@ -188,34 +152,34 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest-incremental-equal","remote":"origin","remote_name":"pytest-incremental-equal","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":"742b118d314d2478a215aa02016c09e173deec7e","can":{}}'
+      string: '{"name":"pytest","remote":"origin","remote_name":"pytest","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":"742b118d314d2478a215aa02016c09e173deec7e","can":{}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '399'
+      - '363'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:04 GMT
+      - Tue, 05 Apr 2022 13:55:47 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - a07b64a798886d50
+      - dd421eb72ada840d
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a07b64a798886d50
+      - dd421eb72ada840d
       X-B3-TraceId:
-      - 62475af06f2eb772a07b64a798886d50
+      - 624c4a63c777ab9ddd421eb72ada840d
       X-Content-Type-Options:
       - nosniff
     status:
@@ -229,7 +193,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -243,20 +207,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:05 GMT
+      - Tue, 05 Apr 2022 13:55:47 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 8e9a12ec63b17725
+      - 529a4ea0086e80e0
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 8e9a12ec63b17725
+      - 529a4ea0086e80e0
       X-B3-TraceId:
-      - 62475af0587a4b4f8e9a12ec63b17725
+      - 624c4a6326f378bc529a4ea0086e80e0
       X-Content-Type-Options:
       - nosniff
     status:
@@ -270,7 +234,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -284,20 +248,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:07 GMT
+      - Tue, 05 Apr 2022 13:55:51 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 296b8a2b66b615ef
+      - ffc42aaa5181666b
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 296b8a2b66b615ef
+      - ffc42aaa5181666b
       X-B3-TraceId:
-      - 62475af17cb7d413296b8a2b66b615ef
+      - 624c4a63192d1539ffc42aaa5181666b
       X-Content-Type-Options:
       - nosniff
     status:
@@ -307,7 +271,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:55:51 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 4c43c08f0f03f964
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 4c43c08f0f03f964
+      X-B3-TraceId:
+      - 624c4a67c76819dc4c43c08f0f03f964
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -321,19 +321,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:07 GMT
+      - Tue, 05 Apr 2022 13:55:51 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 935532f474733023
+      - 611e6cfee2e31302
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 935532f474733023
+      - 611e6cfee2e31302
       X-B3-TraceId:
-      - 62475af339865b88935532f474733023
+      - 624c4a67b556bf27611e6cfee2e31302
       X-Content-Type-Options:
       - nosniff
     status:
@@ -343,7 +343,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -357,20 +357,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:07 GMT
+      - Tue, 05 Apr 2022 13:55:51 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 692612d1aed24436
+      - acb20c2a522d164f
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 692612d1aed24436
+      - acb20c2a522d164f
       X-B3-TraceId:
-      - 62475af3390f1e28692612d1aed24436
+      - 624c4a6716453e4dacb20c2a522d164f
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:55:52 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 1ae1095377ae4392
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 1ae1095377ae4392
+      X-B3-TraceId:
+      - 624c4a68c6cfe4081ae1095377ae4392
       X-Content-Type-Options:
       - nosniff
     status:
@@ -380,7 +420,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:55:52 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 34a0d33e52bfe749
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 34a0d33e52bfe749
+      X-B3-TraceId:
+      - 624c4a68a57ec86834a0d33e52bfe749
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:55:52 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 39f31a82362cfc63
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 39f31a82362cfc63
+      X-B3-TraceId:
+      - 624c4a68f219d43e39f31a82362cfc63
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:55:52 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 4d0f3b34fe3eee0d
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 4d0f3b34fe3eee0d
+      X-B3-TraceId:
+      - 624c4a687857aa3b4d0f3b34fe3eee0d
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:55:52 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 1d4325abb398d229
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 1d4325abb398d229
+      X-B3-TraceId:
+      - 624c4a68ff2ddbc21d4325abb398d229
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:55:52 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 474c610bebac895c
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 474c610bebac895c
+      X-B3-TraceId:
+      - 624c4a6809aad0ec474c610bebac895c
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_b"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:55:52 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - f989fe091e4d498f
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - f989fe091e4d498f
+      X-B3-TraceId:
+      - 624c4a6871a92771f989fe091e4d498f
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_b", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:55:53 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 379760963f03d8dc
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 379760963f03d8dc
+      X-B3-TraceId:
+      - 624c4a6881c1cc17379760963f03d8dc
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -429,325 +737,17 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:05:07 GMT
+      - Tue, 05 Apr 2022 13:55:53 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:07 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 6d5b14002f24602c
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 6d5b14002f24602c
-      X-B3-TraceId:
-      - 62475af3b0f2a7626d5b14002f24602c
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:07 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 2358e08bba0fd255
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 2358e08bba0fd255
-      X-B3-TraceId:
-      - 62475af3aa7269bc2358e08bba0fd255
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:07 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - c1b6f2f806e59004
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - c1b6f2f806e59004
-      X-B3-TraceId:
-      - 62475af30ce6f5acc1b6f2f806e59004
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:07 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - e37474739883575f
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - e37474739883575f
-      X-B3-TraceId:
-      - 62475af3d2d7f0b8e37474739883575f
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:07 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 4c50885306bbe233
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 4c50885306bbe233
-      X-B3-TraceId:
-      - 62475af38ae212034c50885306bbe233
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:07 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 1c99e20815395caf
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 1c99e20815395caf
-      X-B3-TraceId:
-      - 62475af32de1a97a1c99e20815395caf
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_b"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:08 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 42072b6597943c0f
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 42072b6597943c0f
-      X-B3-TraceId:
-      - 62475af370ca024542072b6597943c0f
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_b", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:08 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 23ab867ea7780e0c
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 23ab867ea7780e0c
-      X-B3-TraceId:
-      - 62475af41230093723ab867ea7780e0c
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models?fields=name%2Cproject_name%2Cexplores
   response:
@@ -831,20 +831,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:09 GMT
+      - Tue, 05 Apr 2022 13:55:54 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - b017c517e5aa3197
+      - 5a16e2764b1aef7f
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - b017c517e5aa3197
+      - 5a16e2764b1aef7f
       X-B3-TraceId:
-      - 62475af49b5994cbb017c517e5aa3197
+      - 624c4a69445ff2725a16e2764b1aef7f
       X-Content-Type-Options:
       - nosniff
     status:
@@ -854,7 +854,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users?fields=fields
   response:
@@ -885,20 +885,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:09 GMT
+      - Tue, 05 Apr 2022 13:55:54 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 61befd8925e4b746
+      - a6ff81b9fddd6d44
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 61befd8925e4b746
+      - a6ff81b9fddd6d44
       X-B3-TraceId:
-      - 62475af5df617e6f61befd8925e4b746
+      - 624c4a6abd7044faa6ff81b9fddd6d44
       X-Content-Type-Options:
       - nosniff
     status:
@@ -908,7 +908,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users__fail?fields=fields
   response:
@@ -944,20 +944,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:09 GMT
+      - Tue, 05 Apr 2022 13:55:54 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 6e0043d5d2d62310
+      - 79902ca70833817a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6e0043d5d2d62310
+      - 79902ca70833817a
       X-B3-TraceId:
-      - 62475af5999979246e0043d5d2d62310
+      - 624c4a6a4a38e1db79902ca70833817a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -973,7 +973,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -987,19 +987,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:10 GMT
+      - Tue, 05 Apr 2022 13:55:54 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - bcd065eb39e2aa93
+      - 9b0ca60fbffc2fde
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - bcd065eb39e2aa93
+      - 9b0ca60fbffc2fde
       X-B3-TraceId:
-      - 62475af6685a58cbbcd065eb39e2aa93
+      - 624c4a6a00d4ebad9b0ca60fbffc2fde
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1009,7 +1009,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/2216/run/sql
   response:
@@ -1026,19 +1026,19 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:05:10 GMT
+      - Tue, 05 Apr 2022 13:55:54 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 0e5b5c53bf8a8937
+      - c084dd986093d814
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 0e5b5c53bf8a8937
+      - c084dd986093d814
       X-B3-TraceId:
-      - 62475af6b9c212390e5b5c53bf8a8937
+      - 624c4a6a93130216c084dd986093d814
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1054,7 +1054,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -1068,19 +1068,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:10 GMT
+      - Tue, 05 Apr 2022 13:55:55 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - a9a3580651feaa00
+      - 28ff6301b208beb0
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a9a3580651feaa00
+      - 28ff6301b208beb0
       X-B3-TraceId:
-      - 62475af66ba72948a9a3580651feaa00
+      - 624c4a6abad97f9e28ff6301b208beb0
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1090,7 +1090,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/1944/run/sql
   response:
@@ -1108,60 +1108,60 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:05:10 GMT
+      - Tue, 05 Apr 2022 13:55:55 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 906328570311d4f4
+      - c364c18cc7deedc2
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 906328570311d4f4
+      - c364c18cc7deedc2
       X-B3-TraceId:
-      - 62475af654cd391c906328570311d4f4
+      - 624c4a6b069a6a49c364c18cc7deedc2
       X-Content-Type-Options:
       - nosniff
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "pytest-incremental-equal"}'
+    body: '{"name": "pytest"}'
     headers:
       Content-Length:
-      - '36'
+      - '18'
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest-incremental-equal","remote":"origin","remote_name":"pytest-incremental-equal","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":"742b118d314d2478a215aa02016c09e173deec7e","can":{}}'
+      string: '{"name":"pytest","remote":"origin","remote_name":"pytest","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":"742b118d314d2478a215aa02016c09e173deec7e","can":{}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '399'
+      - '363'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:11 GMT
+      - Tue, 05 Apr 2022 13:55:55 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 3ed1613780b64b31
+      - 313c8ef41a2ee2fe
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 3ed1613780b64b31
+      - 313c8ef41a2ee2fe
       X-B3-TraceId:
-      - 62475af61e160cab3ed1613780b64b31
+      - 624c4a6b423b451f313c8ef41a2ee2fe
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1173,7 +1173,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_a
   response:
@@ -1183,19 +1183,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:05:12 GMT
+      - Tue, 05 Apr 2022 13:55:56 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - a7809e21ff1675f6
+      - 0d17efbead71b15a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a7809e21ff1675f6
+      - 0d17efbead71b15a
       X-B3-TraceId:
-      - 62475af7ed7105b9a7809e21ff1675f6
+      - 624c4a6c0f54c9370d17efbead71b15a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1209,7 +1209,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -1223,20 +1223,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:12 GMT
+      - Tue, 05 Apr 2022 13:55:57 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 24ab8064f0df322b
+      - e2608cb48f5b7dee
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 24ab8064f0df322b
+      - e2608cb48f5b7dee
       X-B3-TraceId:
-      - 62475af820bfc51324ab8064f0df322b
+      - 624c4a6c3dc852ade2608cb48f5b7dee
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1248,7 +1248,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_b
   response:
@@ -1258,19 +1258,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:05:13 GMT
+      - Tue, 05 Apr 2022 13:55:57 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 02382d7d25e97ff2
+      - ca04aa95d6bc72ad
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 02382d7d25e97ff2
+      - ca04aa95d6bc72ad
       X-B3-TraceId:
-      - 62475af80e1063f602382d7d25e97ff2
+      - 624c4a6da2b3b6c0ca04aa95d6bc72ad
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1284,7 +1284,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -1298,20 +1298,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:13 GMT
+      - Tue, 05 Apr 2022 13:55:58 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 3c06a7224f3a1f4f
+      - ebe9ad18168fdc85
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 3c06a7224f3a1f4f
+      - ebe9ad18168fdc85
       X-B3-TraceId:
-      - 62475af9521ae28e3c06a7224f3a1f4f
+      - 624c4a6dcbab4093ebe9ad18168fdc85
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1325,7 +1325,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1339,19 +1339,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:13 GMT
+      - Tue, 05 Apr 2022 13:55:58 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - d35ce3020f7bcf6a
+      - d6032706eabc97f6
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - d35ce3020f7bcf6a
+      - d6032706eabc97f6
       X-B3-TraceId:
-      - 62475af9f59364c4d35ce3020f7bcf6a
+      - 624c4a6ea454d743d6032706eabc97f6
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1365,7 +1365,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1379,19 +1379,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:13 GMT
+      - Tue, 05 Apr 2022 13:55:58 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - b3e0e39cb9548e5b
+      - 6768f31790b0fcdd
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - b3e0e39cb9548e5b
+      - 6768f31790b0fcdd
       X-B3-TraceId:
-      - 62475af9d69f1261b3e0e39cb9548e5b
+      - 624c4a6e2ce00e7c6768f31790b0fcdd
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1401,7 +1401,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1415,19 +1415,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:13 GMT
+      - Tue, 05 Apr 2022 13:55:58 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 903d110efe6c1a78
+      - bdef0f49886a316d
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 903d110efe6c1a78
+      - bdef0f49886a316d
       X-B3-TraceId:
-      - 62475af9f914c1a6903d110efe6c1a78
+      - 624c4a6e40093cffbdef0f49886a316d
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1437,34 +1437,34 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest-incremental-equal","remote":"origin","remote_name":"pytest-incremental-equal","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":"742b118d314d2478a215aa02016c09e173deec7e","can":{}}'
+      string: '{"name":"pytest","remote":"origin","remote_name":"pytest","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":"742b118d314d2478a215aa02016c09e173deec7e","can":{}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '399'
+      - '363'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:14 GMT
+      - Tue, 05 Apr 2022 13:55:58 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 19b8171c6df11511
+      - 4c0bcb3d9448df0a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 19b8171c6df11511
+      - 4c0bcb3d9448df0a
       X-B3-TraceId:
-      - 62475af9c642816219b8171c6df11511
+      - 624c4a6ebc13e87b4c0bcb3d9448df0a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1478,7 +1478,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -1492,20 +1492,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:14 GMT
+      - Tue, 05 Apr 2022 13:55:59 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - ac81184a624b8c76
+      - dbff12ee5310726e
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - ac81184a624b8c76
+      - dbff12ee5310726e
       X-B3-TraceId:
-      - 62475afa5495dddcac81184a624b8c76
+      - 624c4a6e350a6bd6dbff12ee5310726e
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1519,7 +1519,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -1533,20 +1533,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:16 GMT
+      - Tue, 05 Apr 2022 13:56:01 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 5ec00fe9e46a2ddc
+      - d0c34f07fd4b8dad
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 5ec00fe9e46a2ddc
+      - d0c34f07fd4b8dad
       X-B3-TraceId:
-      - 62475afa00bbe0485ec00fe9e46a2ddc
+      - 624c4a6f6425311dd0c34f07fd4b8dad
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1556,7 +1556,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:01 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 4d882e10a3c0a57f
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 4d882e10a3c0a57f
+      X-B3-TraceId:
+      - 624c4a716a79dcde4d882e10a3c0a57f
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1570,19 +1606,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:16 GMT
+      - Tue, 05 Apr 2022 13:56:01 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 68569b9559af04a2
+      - 2253907c26f35b0d
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 68569b9559af04a2
+      - 2253907c26f35b0d
       X-B3-TraceId:
-      - 62475afc2e2eb7ae68569b9559af04a2
+      - 624c4a719d8a64c02253907c26f35b0d
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1592,7 +1628,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -1606,20 +1642,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:16 GMT
+      - Tue, 05 Apr 2022 13:56:01 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 0e4936bd024a4ca2
+      - a81a2c7bee45e614
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 0e4936bd024a4ca2
+      - a81a2c7bee45e614
       X-B3-TraceId:
-      - 62475afcf00fd7ce0e4936bd024a4ca2
+      - 624c4a7167c4de42a81a2c7bee45e614
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:01 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 408fddb37b21a771
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 408fddb37b21a771
+      X-B3-TraceId:
+      - 624c4a715e536b5b408fddb37b21a771
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1629,7 +1705,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:01 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 23c23162a77f2d31
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 23c23162a77f2d31
+      X-B3-TraceId:
+      - 624c4a71a9ca319e23c23162a77f2d31
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:01 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - f88b698424fd76b1
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - f88b698424fd76b1
+      X-B3-TraceId:
+      - 624c4a71784e188df88b698424fd76b1
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:01 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 2d431bad22576af0
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 2d431bad22576af0
+      X-B3-TraceId:
+      - 624c4a71f3e285362d431bad22576af0
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:01 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 95c3ebb47bf93ed2
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 95c3ebb47bf93ed2
+      X-B3-TraceId:
+      - 624c4a71e58f921a95c3ebb47bf93ed2
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:01 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 96e509d59e0e4fd1
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 96e509d59e0e4fd1
+      X-B3-TraceId:
+      - 624c4a71cccac94f96e509d59e0e4fd1
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_d"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_d","remote":"origin","remote_name":"tmp_spectacles_d","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:02 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - e0d0041ba467c615
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - e0d0041ba467c615
+      X-B3-TraceId:
+      - 624c4a710af17f65e0d0041ba467c615
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_d", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_d","remote":"origin","remote_name":"tmp_spectacles_d","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:02 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 79f7f85a70e8ebbe
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 79f7f85a70e8ebbe
+      X-B3-TraceId:
+      - 624c4a728c272a3979f7f85a70e8ebbe
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -1678,325 +2022,17 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:05:16 GMT
+      - Tue, 05 Apr 2022 13:56:02 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:16 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 5d8d14ac04758fd7
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 5d8d14ac04758fd7
-      X-B3-TraceId:
-      - 62475afc7c907ca25d8d14ac04758fd7
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:16 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 2329d68f9bd84bf3
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 2329d68f9bd84bf3
-      X-B3-TraceId:
-      - 62475afcef9d878f2329d68f9bd84bf3
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:16 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - e44c4fa6442e13ce
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - e44c4fa6442e13ce
-      X-B3-TraceId:
-      - 62475afce39db476e44c4fa6442e13ce
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:17 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - e9e67862068dd65c
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - e9e67862068dd65c
-      X-B3-TraceId:
-      - 62475afcbac5d68be9e67862068dd65c
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:17 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 943195629d2e6480
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 943195629d2e6480
-      X-B3-TraceId:
-      - 62475afd4fdea0eb943195629d2e6480
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:17 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 471c48eb2db18be0
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 471c48eb2db18be0
-      X-B3-TraceId:
-      - 62475afd739a8fc8471c48eb2db18be0
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_d"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_d","remote":"origin","remote_name":"tmp_spectacles_d","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:17 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - c7340c6f30edc733
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - c7340c6f30edc733
-      X-B3-TraceId:
-      - 62475afd17b38947c7340c6f30edc733
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_d", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_d","remote":"origin","remote_name":"tmp_spectacles_d","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:18 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 4b9ea4238294e119
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 4b9ea4238294e119
-      X-B3-TraceId:
-      - 62475afddeea4caa4b9ea4238294e119
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models?fields=name%2Cproject_name%2Cexplores
   response:
@@ -2080,20 +2116,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:19 GMT
+      - Tue, 05 Apr 2022 13:56:03 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 2cdd31a55205f4d3
+      - 781f85fe8db35430
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2cdd31a55205f4d3
+      - 781f85fe8db35430
       X-B3-TraceId:
-      - 62475afe253f04ab2cdd31a55205f4d3
+      - 624c4a73cc65bb74781f85fe8db35430
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2103,7 +2139,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users?fields=fields
   response:
@@ -2134,20 +2170,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:19 GMT
+      - Tue, 05 Apr 2022 13:56:03 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 111c424cff3773a0
+      - 229f670e08636718
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 111c424cff3773a0
+      - 229f670e08636718
       X-B3-TraceId:
-      - 62475affe588ec95111c424cff3773a0
+      - 624c4a73d90b50a1229f670e08636718
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2157,7 +2193,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users__fail?fields=fields
   response:
@@ -2193,20 +2229,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:19 GMT
+      - Tue, 05 Apr 2022 13:56:04 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 69f847efba5a19ef
+      - 57d705ec50e88b24
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 69f847efba5a19ef
+      - 57d705ec50e88b24
       X-B3-TraceId:
-      - 62475aff0cdd780569f847efba5a19ef
+      - 624c4a734b3bdbf957d705ec50e88b24
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2222,7 +2258,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -2236,19 +2272,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:19 GMT
+      - Tue, 05 Apr 2022 13:56:04 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 3b5c1e5ed7593618
+      - 77825da414d48f03
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 3b5c1e5ed7593618
+      - 77825da414d48f03
       X-B3-TraceId:
-      - 62475aff88085b533b5c1e5ed7593618
+      - 624c4a7405adfadf77825da414d48f03
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2258,7 +2294,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/2216/run/sql
   response:
@@ -2275,19 +2311,19 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:05:19 GMT
+      - Tue, 05 Apr 2022 13:56:04 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 7b22956086605ef5
+      - 3d40dacbc52f08dd
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 7b22956086605ef5
+      - 3d40dacbc52f08dd
       X-B3-TraceId:
-      - 62475affa9b4e3927b22956086605ef5
+      - 624c4a741a2b27843d40dacbc52f08dd
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2303,7 +2339,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -2317,19 +2353,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:19 GMT
+      - Tue, 05 Apr 2022 13:56:04 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 2fe50093bd619e27
+      - c33a42f2716cb8f1
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2fe50093bd619e27
+      - c33a42f2716cb8f1
       X-B3-TraceId:
-      - 62475aff4e1049582fe50093bd619e27
+      - 624c4a74eecde5fac33a42f2716cb8f1
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2339,7 +2375,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/1944/run/sql
   response:
@@ -2357,60 +2393,60 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:05:19 GMT
+      - Tue, 05 Apr 2022 13:56:04 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 2c39fe803ec557f3
+      - 14833c1bce9e834f
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2c39fe803ec557f3
+      - 14833c1bce9e834f
       X-B3-TraceId:
-      - 62475affe48a597e2c39fe803ec557f3
+      - 624c4a74c7143b0614833c1bce9e834f
       X-Content-Type-Options:
       - nosniff
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "pytest-incremental-equal"}'
+    body: '{"name": "pytest"}'
     headers:
       Content-Length:
-      - '36'
+      - '18'
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest-incremental-equal","remote":"origin","remote_name":"pytest-incremental-equal","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":"742b118d314d2478a215aa02016c09e173deec7e","can":{}}'
+      string: '{"name":"pytest","remote":"origin","remote_name":"pytest","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":"742b118d314d2478a215aa02016c09e173deec7e","can":{}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '399'
+      - '363'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:20 GMT
+      - Tue, 05 Apr 2022 13:56:05 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - a2ed86f39755a372
+      - f8f9ecd4793bc1e5
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a2ed86f39755a372
+      - f8f9ecd4793bc1e5
       X-B3-TraceId:
-      - 62475b001b5b08b5a2ed86f39755a372
+      - 624c4a74198e5d76f8f9ecd4793bc1e5
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2422,7 +2458,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_c
   response:
@@ -2432,19 +2468,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:05:21 GMT
+      - Tue, 05 Apr 2022 13:56:06 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - c78581838c3ca2b4
+      - 59ac1b3515a9ce6d
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - c78581838c3ca2b4
+      - 59ac1b3515a9ce6d
       X-B3-TraceId:
-      - 62475b004ba47dedc78581838c3ca2b4
+      - 624c4a758f039e2459ac1b3515a9ce6d
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2458,7 +2494,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -2472,20 +2508,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:22 GMT
+      - Tue, 05 Apr 2022 13:56:07 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - ab101d52a62565cf
+      - cc59a2aff5fe7751
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - ab101d52a62565cf
+      - cc59a2aff5fe7751
       X-B3-TraceId:
-      - 62475b01801bd02eab101d52a62565cf
+      - 624c4a769b953ab9cc59a2aff5fe7751
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2497,7 +2533,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_d
   response:
@@ -2507,19 +2543,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:05:22 GMT
+      - Tue, 05 Apr 2022 13:56:07 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 032da69564a7c77f
+      - 4f94c78d5e26e5d9
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 032da69564a7c77f
+      - 4f94c78d5e26e5d9
       X-B3-TraceId:
-      - 62475b021d6c9e6b032da69564a7c77f
+      - 624c4a77526d19544f94c78d5e26e5d9
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2533,7 +2569,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -2547,20 +2583,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:23 GMT
+      - Tue, 05 Apr 2022 13:56:07 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 962d2791818ca885
+      - d2097ff539206539
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 962d2791818ca885
+      - d2097ff539206539
       X-B3-TraceId:
-      - 62475b02e1268e78962d2791818ca885
+      - 624c4a77db77a0ebd2097ff539206539
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2574,7 +2610,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -2588,19 +2624,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:23 GMT
+      - Tue, 05 Apr 2022 13:56:08 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 2fc9d8141822e910
+      - 487737355deb27d9
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2fc9d8141822e910
+      - 487737355deb27d9
       X-B3-TraceId:
-      - 62475b0398021e4d2fc9d8141822e910
+      - 624c4a77ae65ce9c487737355deb27d9
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2614,7 +2650,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -2628,19 +2664,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:23 GMT
+      - Tue, 05 Apr 2022 13:56:08 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 15a1b1fc05f415b3
+      - c43b1cbd81635d61
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 15a1b1fc05f415b3
+      - c43b1cbd81635d61
       X-B3-TraceId:
-      - 62475b03e6cd5c8f15a1b1fc05f415b3
+      - 624c4a781e5dd62dc43b1cbd81635d61
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2654,12 +2690,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest-incremental-invalid-diff","remote":"origin","remote_name":"pytest-incremental-invalid-diff","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":4,"behind_count":3,"commit_at":1648842807,"ref":"bc08eac2b8258d5c67dea3094d34bb93bd45e22b","remote_ref":"1ddde0b0dbf09b486b13669171528fd299fbb903","can":{}}'
+      string: '{"name":"pytest-incremental-invalid-diff","remote":"origin","remote_name":"pytest-incremental-invalid-diff","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648842807,"ref":"1ddde0b0dbf09b486b13669171528fd299fbb903","remote_ref":"1ddde0b0dbf09b486b13669171528fd299fbb903","can":{}}'
     headers:
       Connection:
       - keep-alive
@@ -2668,20 +2704,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:24 GMT
+      - Tue, 05 Apr 2022 13:56:08 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 7f3abea26e7bfb43
+      - ab678ec78af6bc22
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 7f3abea26e7bfb43
+      - ab678ec78af6bc22
       X-B3-TraceId:
-      - 62475b0391162df97f3abea26e7bfb43
+      - 624c4a789dd9ee04ab678ec78af6bc22
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2693,7 +2729,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/reset_to_remote
   response:
@@ -2703,19 +2739,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:05:25 GMT
+      - Tue, 05 Apr 2022 13:56:09 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - b2b8a01dfc44ddf6
+      - 4231edccd69b25de
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - b2b8a01dfc44ddf6
+      - 4231edccd69b25de
       X-B3-TraceId:
-      - 62475b0496c5a4b9b2b8a01dfc44ddf6
+      - 624c4a7832f521b64231edccd69b25de
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2725,7 +2761,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:09 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 37075bce80636b60
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 37075bce80636b60
+      X-B3-TraceId:
+      - 624c4a79e6b35a3f37075bce80636b60
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -2739,19 +2811,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:25 GMT
+      - Tue, 05 Apr 2022 13:56:10 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 2c48270f2f6eb1e8
+      - 2aa3b734126f57f6
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2c48270f2f6eb1e8
+      - 2aa3b734126f57f6
       X-B3-TraceId:
-      - 62475b05360a313a2c48270f2f6eb1e8
+      - 624c4a7a336715dc2aa3b734126f57f6
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2761,7 +2833,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -2775,20 +2847,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:25 GMT
+      - Tue, 05 Apr 2022 13:56:10 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 0c4181c72d3f56f4
+      - 2f91045ec9f44b43
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 0c4181c72d3f56f4
+      - 2f91045ec9f44b43
       X-B3-TraceId:
-      - 62475b05736f64bf0c4181c72d3f56f4
+      - 624c4a7a4dc8d6742f91045ec9f44b43
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:10 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 1a858cd118154cdc
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 1a858cd118154cdc
+      X-B3-TraceId:
+      - 624c4a7a80c525c31a858cd118154cdc
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2798,7 +2910,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:10 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 21be4f5e769869f8
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 21be4f5e769869f8
+      X-B3-TraceId:
+      - 624c4a7a3bd1b86821be4f5e769869f8
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:10 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - c76620e203721591
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - c76620e203721591
+      X-B3-TraceId:
+      - 624c4a7a2215399fc76620e203721591
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:10 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 083312039a002917
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 083312039a002917
+      X-B3-TraceId:
+      - 624c4a7a42450112083312039a002917
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:10 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - b36773bfae97ae3b
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - b36773bfae97ae3b
+      X-B3-TraceId:
+      - 624c4a7a5301c6bfb36773bfae97ae3b
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:10 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 100fdf2f921f90e9
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 100fdf2f921f90e9
+      X-B3-TraceId:
+      - 624c4a7aec3c9144100fdf2f921f90e9
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_e"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_e","remote":"origin","remote_name":"tmp_spectacles_e","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:11 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 1161dff7c952f65d
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 1161dff7c952f65d
+      X-B3-TraceId:
+      - 624c4a7ab8d13dac1161dff7c952f65d
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_e", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_e","remote":"origin","remote_name":"tmp_spectacles_e","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:11 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 11168293d0bf8a9a
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 11168293d0bf8a9a
+      X-B3-TraceId:
+      - 624c4a7bd2b043c211168293d0bf8a9a
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -2847,320 +3227,12 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:05:25 GMT
+      - Tue, 05 Apr 2022 13:56:11 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
-- request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:25 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - ea45546f610af380
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - ea45546f610af380
-      X-B3-TraceId:
-      - 62475b0592184cf2ea45546f610af380
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:25 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - a92343cafaf14a83
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - a92343cafaf14a83
-      X-B3-TraceId:
-      - 62475b056e84895da92343cafaf14a83
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:25 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - cc8104d1f5fdfc26
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - cc8104d1f5fdfc26
-      X-B3-TraceId:
-      - 62475b05a41644e5cc8104d1f5fdfc26
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:25 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - d264f12d035d9968
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - d264f12d035d9968
-      X-B3-TraceId:
-      - 62475b057382cefbd264f12d035d9968
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:25 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 8be67afb695fcede
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 8be67afb695fcede
-      X-B3-TraceId:
-      - 62475b059a7c59268be67afb695fcede
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:25 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 99f08a2f4c801933
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 99f08a2f4c801933
-      X-B3-TraceId:
-      - 62475b05dad143fa99f08a2f4c801933
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_e"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_e","remote":"origin","remote_name":"tmp_spectacles_e","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:26 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 9a5d898f9701b96c
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 9a5d898f9701b96c
-      X-B3-TraceId:
-      - 62475b06bc75440b9a5d898f9701b96c
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_e", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_e","remote":"origin","remote_name":"tmp_spectacles_e","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:26 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 1e7aa91ffcc50966
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 1e7aa91ffcc50966
-      X-B3-TraceId:
-      - 62475b06f272c2e51e7aa91ffcc50966
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
 - request:
     body: '{"query_id": 2216, "result_format": "json_detail"}'
     headers:
@@ -3169,12 +3241,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"c0905c93108f42478173ef4f6916d9c9"}'
+      string: '{"id":"6e4a44891e74bf2cce28e460c2f9dbd4"}'
     headers:
       Connection:
       - keep-alive
@@ -3183,19 +3255,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:27 GMT
+      - Tue, 05 Apr 2022 13:56:12 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - b805e7a9c53716e6
+      - bcbf85c9bff84526
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - b805e7a9c53716e6
+      - bcbf85c9bff84526
       X-B3-TraceId:
-      - 62475b07011de600b805e7a9c53716e6
+      - 624c4a7b02177728bcbf85c9bff84526
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3205,12 +3277,12 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=c0905c93108f42478173ef4f6916d9c9
+    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=6e4a44891e74bf2cce28e460c2f9dbd4
   response:
     body:
-      string: '{"c0905c93108f42478173ef4f6916d9c9":{"status":"added"}}'
+      string: '{"6e4a44891e74bf2cce28e460c2f9dbd4":{"status":"added"}}'
     headers:
       Connection:
       - keep-alive
@@ -3219,19 +3291,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:27 GMT
+      - Tue, 05 Apr 2022 13:56:12 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - a7970d5418deaf49
+      - f4745b5d8661f71b
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a7970d5418deaf49
+      - f4745b5d8661f71b
       X-B3-TraceId:
-      - 62475b07a977066ea7970d5418deaf49
+      - 624c4a7c3553e4abf4745b5d8661f71b
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3241,12 +3313,12 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=c0905c93108f42478173ef4f6916d9c9
+    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=6e4a44891e74bf2cce28e460c2f9dbd4
   response:
     body:
-      string: '{"c0905c93108f42478173ef4f6916d9c9":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"c0905c93108f42478173ef4f6916d9c9","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:05:27+00:00","aggregate_table_used_info":null,"runtime":"0.344","added_params":{"query_timezone":"America/New_York","sorts":["users.city"]},"forecast_result":null,"sql":"SELECT\n    users.city  AS
+      string: '{"6e4a44891e74bf2cce28e460c2f9dbd4":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"6e4a44891e74bf2cce28e460c2f9dbd4","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:56:12+00:00","aggregate_table_used_info":null,"runtime":"0.374","added_params":{"query_timezone":"America/New_York","sorts":["users.city"]},"forecast_result":null,"sql":"SELECT\n    users.city  AS
         users_city,\n    users.email  AS users_email,\n    users.first_name  AS users_first_name,\n    users.id  AS
         users_id,\n    users.last_name  AS users_last_name,\n    users.state + 10  AS
         users_state\nFROM looker-private-demo.ecomm.users\n     AS users\nWHERE (1
@@ -3275,7 +3347,7 @@ interactions:
         users_email,\n    users.first_name  AS users_first_name,\n    users.id  AS
         users_id,\n    users.last_name  AS users_last_name,\n    users.state + 10  AS
         users_state\nFROM looker-private-demo.ecomm.users\n     AS users\nWHERE (1
-        = 2)\nORDER BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":7,"column":5}}],"drill_menu_build_time":0.068224,"has_subtotals":false}}}'
+        = 2)\nORDER BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":7,"column":5}}],"drill_menu_build_time":0.071668,"has_subtotals":false}}}'
     headers:
       Connection:
       - keep-alive
@@ -3284,20 +3356,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:28 GMT
+      - Tue, 05 Apr 2022 13:56:12 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - a6ebef38e4d45fb3
+      - fe5fbd1323375315
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a6ebef38e4d45fb3
+      - fe5fbd1323375315
       X-B3-TraceId:
-      - 62475b08e6365215a6ebef38e4d45fb3
+      - 624c4a7c20eb78b2fe5fbd1323375315
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3311,7 +3383,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3325,20 +3397,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:29 GMT
+      - Tue, 05 Apr 2022 13:56:14 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 7c3b4c2fefd2f6dc
+      - bd90b4a395535e1c
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 7c3b4c2fefd2f6dc
+      - bd90b4a395535e1c
       X-B3-TraceId:
-      - 62475b08d97b3d047c3b4c2fefd2f6dc
+      - 624c4a7daad9239bbd90b4a395535e1c
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3350,7 +3422,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_e
   response:
@@ -3360,19 +3432,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:05:29 GMT
+      - Tue, 05 Apr 2022 13:56:14 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 7b560fb538bc9fff
+      - 5da1763fb495e844
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 7b560fb538bc9fff
+      - 5da1763fb495e844
       X-B3-TraceId:
-      - 62475b091b60f0b37b560fb538bc9fff
+      - 624c4a7e73d932cd5da1763fb495e844
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3386,7 +3458,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3400,20 +3472,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:30 GMT
+      - Tue, 05 Apr 2022 13:56:15 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 514d2efcb3836e66
+      - 9a2095a0a1431dd4
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 514d2efcb3836e66
+      - 9a2095a0a1431dd4
       X-B3-TraceId:
-      - 62475b0965af4384514d2efcb3836e66
+      - 624c4a7edf7e8f069a2095a0a1431dd4
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3427,7 +3499,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3441,19 +3513,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:30 GMT
+      - Tue, 05 Apr 2022 13:56:15 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - cc7d77c2711c03a1
+      - e27e47d12bc99994
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - cc7d77c2711c03a1
+      - e27e47d12bc99994
       X-B3-TraceId:
-      - 62475b0a274c89adcc7d77c2711c03a1
+      - 624c4a7f234ae035e27e47d12bc99994
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3467,7 +3539,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3481,19 +3553,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:30 GMT
+      - Tue, 05 Apr 2022 13:56:15 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 1953c394777bcc3d
+      - 20b9fda3ba965656
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 1953c394777bcc3d
+      - 20b9fda3ba965656
       X-B3-TraceId:
-      - 62475b0acb4f4fdf1953c394777bcc3d
+      - 624c4a7fafc7c8e620b9fda3ba965656
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3503,7 +3575,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3517,19 +3589,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:30 GMT
+      - Tue, 05 Apr 2022 13:56:15 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - b79a741b79299eff
+      - 8d3f950d04f7da57
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - b79a741b79299eff
+      - 8d3f950d04f7da57
       X-B3-TraceId:
-      - 62475b0a235ae02fb79a741b79299eff
+      - 624c4a7f3b1a47d08d3f950d04f7da57
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3539,7 +3611,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -3553,20 +3625,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:30 GMT
+      - Tue, 05 Apr 2022 13:56:15 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - fe8510b85bbff7c0
+      - 0cf13f99852be86a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - fe8510b85bbff7c0
+      - 0cf13f99852be86a
       X-B3-TraceId:
-      - 62475b0add13d24dfe8510b85bbff7c0
+      - 624c4a7ff6f9c5380cf13f99852be86a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3580,7 +3652,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -3594,20 +3666,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:30 GMT
+      - Tue, 05 Apr 2022 13:56:16 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 07c2efa101cd8828
+      - 5e1060f31bb8f889
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 07c2efa101cd8828
+      - 5e1060f31bb8f889
       X-B3-TraceId:
-      - 62475b0ae737380d07c2efa101cd8828
+      - 624c4a7f4dbfed3e5e1060f31bb8f889
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3621,7 +3693,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -3635,20 +3707,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:31 GMT
+      - Tue, 05 Apr 2022 13:56:16 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 01178fe0ff99c285
+      - f94c657ceaeb4538
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 01178fe0ff99c285
+      - f94c657ceaeb4538
       X-B3-TraceId:
-      - 62475b0aa332fb7601178fe0ff99c285
+      - 624c4a8008f6331cf94c657ceaeb4538
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3658,7 +3730,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:16 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 0eb8611c75772c4c
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 0eb8611c75772c4c
+      X-B3-TraceId:
+      - 624c4a80eacc98040eb8611c75772c4c
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3672,19 +3780,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:31 GMT
+      - Tue, 05 Apr 2022 13:56:16 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 4211921fb923f9dc
+      - c95f52fd76001e99
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 4211921fb923f9dc
+      - c95f52fd76001e99
       X-B3-TraceId:
-      - 62475b0b5ae8a88a4211921fb923f9dc
+      - 624c4a80dc133521c95f52fd76001e99
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3694,7 +3802,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3708,20 +3816,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:31 GMT
+      - Tue, 05 Apr 2022 13:56:16 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 744ac7ecc76d57dc
+      - fdb451449784b949
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 744ac7ecc76d57dc
+      - fdb451449784b949
       X-B3-TraceId:
-      - 62475b0b01ee89dc744ac7ecc76d57dc
+      - 624c4a80d45a008dfdb451449784b949
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:17 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - f868fd62696fda65
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - f868fd62696fda65
+      X-B3-TraceId:
+      - 624c4a8170cc4597f868fd62696fda65
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3731,7 +3879,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:17 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - d434c42da4f01c1b
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - d434c42da4f01c1b
+      X-B3-TraceId:
+      - 624c4a81c6277df2d434c42da4f01c1b
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:17 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - c4a6f2c8bd2f2ebe
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - c4a6f2c8bd2f2ebe
+      X-B3-TraceId:
+      - 624c4a8107572514c4a6f2c8bd2f2ebe
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:17 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 98a26cbd1641648f
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 98a26cbd1641648f
+      X-B3-TraceId:
+      - 624c4a81ce370cf798a26cbd1641648f
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:17 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 5a2e390042496630
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 5a2e390042496630
+      X-B3-TraceId:
+      - 624c4a8116f006905a2e390042496630
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:17 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - e95c1bcf9790d120
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - e95c1bcf9790d120
+      X-B3-TraceId:
+      - 624c4a81bb575e51e95c1bcf9790d120
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_g"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_g","remote":"origin","remote_name":"tmp_spectacles_g","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:17 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - fb16c7bb25c04d85
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - fb16c7bb25c04d85
+      X-B3-TraceId:
+      - 624c4a818d8b4434fb16c7bb25c04d85
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_g", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_g","remote":"origin","remote_name":"tmp_spectacles_g","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:18 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - d7670e974819dfd9
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - d7670e974819dfd9
+      X-B3-TraceId:
+      - 624c4a818598bb3ed7670e974819dfd9
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -3780,320 +4196,12 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:05:31 GMT
+      - Tue, 05 Apr 2022 13:56:18 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
-- request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:32 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - b7bdb80b642943f6
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - b7bdb80b642943f6
-      X-B3-TraceId:
-      - 62475b0b23260351b7bdb80b642943f6
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:32 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - a87ba939ced7abdf
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - a87ba939ced7abdf
-      X-B3-TraceId:
-      - 62475b0cc0fb9e74a87ba939ced7abdf
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:32 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - e384594b01ceba09
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - e384594b01ceba09
-      X-B3-TraceId:
-      - 62475b0ce41e7e4ce384594b01ceba09
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:32 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - afc4d2f00364ea9b
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - afc4d2f00364ea9b
-      X-B3-TraceId:
-      - 62475b0cc3e2a23dafc4d2f00364ea9b
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:32 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - ef4efbdf1c60c6c2
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - ef4efbdf1c60c6c2
-      X-B3-TraceId:
-      - 62475b0c82c7951eef4efbdf1c60c6c2
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:32 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 025e3879cc699e3b
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 025e3879cc699e3b
-      X-B3-TraceId:
-      - 62475b0cf718043e025e3879cc699e3b
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_g"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_g","remote":"origin","remote_name":"tmp_spectacles_g","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:32 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - aaeb402dd58e1a69
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - aaeb402dd58e1a69
-      X-B3-TraceId:
-      - 62475b0c4266230daaeb402dd58e1a69
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_g", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_g","remote":"origin","remote_name":"tmp_spectacles_g","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:33 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - d2ecb26bc7d021e7
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - d2ecb26bc7d021e7
-      X-B3-TraceId:
-      - 62475b0ca9d7dbfad2ecb26bc7d021e7
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
 - request:
     body: '{"model": "eye_exam", "view": "users", "fields": ["users.city"], "limit":
       0, "filter_expression": "1=2"}'
@@ -4103,7 +4211,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -4117,19 +4225,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:33 GMT
+      - Tue, 05 Apr 2022 13:56:18 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - a18442cc9084898a
+      - 5e451d2e976432d5
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a18442cc9084898a
+      - 5e451d2e976432d5
       X-B3-TraceId:
-      - 62475b0dce4aca7ba18442cc9084898a
+      - 624c4a82ba79b97e5e451d2e976432d5
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4144,7 +4252,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -4158,19 +4266,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:34 GMT
+      - Tue, 05 Apr 2022 13:56:19 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 07d8a534e56bddc4
+      - 5b40fd58079a3dd6
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 07d8a534e56bddc4
+      - 5b40fd58079a3dd6
       X-B3-TraceId:
-      - 62475b0d448101bc07d8a534e56bddc4
+      - 624c4a8313ac17fa5b40fd58079a3dd6
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4185,7 +4293,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -4199,19 +4307,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:34 GMT
+      - Tue, 05 Apr 2022 13:56:19 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 086324a28ec50456
+      - f5e83ad6521f396d
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 086324a28ec50456
+      - f5e83ad6521f396d
       X-B3-TraceId:
-      - 62475b0ed6cf0792086324a28ec50456
+      - 624c4a8301b5780cf5e83ad6521f396d
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4226,7 +4334,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -4240,19 +4348,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:34 GMT
+      - Tue, 05 Apr 2022 13:56:19 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 9294462d7e03c86c
+      - 07900552cdf0bc69
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 9294462d7e03c86c
+      - 07900552cdf0bc69
       X-B3-TraceId:
-      - 62475b0eb841f8649294462d7e03c86c
+      - 624c4a834f03fbbd07900552cdf0bc69
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4267,7 +4375,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -4281,19 +4389,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:34 GMT
+      - Tue, 05 Apr 2022 13:56:19 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 9b2a15b7848b75cf
+      - b531dfeaea5515ee
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 9b2a15b7848b75cf
+      - b531dfeaea5515ee
       X-B3-TraceId:
-      - 62475b0e7cc786ec9b2a15b7848b75cf
+      - 624c4a83cdc45621b531dfeaea5515ee
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4308,7 +4416,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -4322,19 +4430,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:34 GMT
+      - Tue, 05 Apr 2022 13:56:19 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 7fe492c75252f994
+      - 954be1bf6f7a2e07
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 7fe492c75252f994
+      - 954be1bf6f7a2e07
       X-B3-TraceId:
-      - 62475b0ee70348957fe492c75252f994
+      - 624c4a830c57eae6954be1bf6f7a2e07
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4348,12 +4456,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"fbef3d7a532bdb70d66d2fa99b0c0e3c"}'
+      string: '{"id":"e124898d0ada3c4dfed336f773b0df83"}'
     headers:
       Connection:
       - keep-alive
@@ -4362,19 +4470,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:34 GMT
+      - Tue, 05 Apr 2022 13:56:19 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - dee8470f5fefabc0
+      - 360365f1cce74892
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - dee8470f5fefabc0
+      - 360365f1cce74892
       X-B3-TraceId:
-      - 62475b0e5224e5a5dee8470f5fefabc0
+      - 624c4a83ef67b97b360365f1cce74892
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4388,12 +4496,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"500a1747bce025758b74e193d0fbe4fc"}'
+      string: '{"id":"70edd34ca9f96be3e9b333a4b1515ece"}'
     headers:
       Connection:
       - keep-alive
@@ -4402,19 +4510,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:34 GMT
+      - Tue, 05 Apr 2022 13:56:20 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 4a533a465c19f8c6
+      - 6720564941ac9319
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 4a533a465c19f8c6
+      - 6720564941ac9319
       X-B3-TraceId:
-      - 62475b0ec84255624a533a465c19f8c6
+      - 624c4a837f6b91026720564941ac9319
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4428,12 +4536,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"1945f0a294a1389c7b892c12abeae2a8"}'
+      string: '{"id":"961e283824f176b72a252fc090356cff"}'
     headers:
       Connection:
       - keep-alive
@@ -4442,19 +4550,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:35 GMT
+      - Tue, 05 Apr 2022 13:56:20 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 0e956fa60a1eaa12
+      - 6cd65e075b79d5cd
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 0e956fa60a1eaa12
+      - 6cd65e075b79d5cd
       X-B3-TraceId:
-      - 62475b0feba4c2200e956fa60a1eaa12
+      - 624c4a8403c9bac26cd65e075b79d5cd
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4468,12 +4576,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"2cecb6252e32a19b0b502de1c2e375ed"}'
+      string: '{"id":"1af53c02bddc7ec744dba12eb090404a"}'
     headers:
       Connection:
       - keep-alive
@@ -4482,19 +4590,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:35 GMT
+      - Tue, 05 Apr 2022 13:56:20 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 068fb6d65521ecf1
+      - ca1cddf4262af9a9
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 068fb6d65521ecf1
+      - ca1cddf4262af9a9
       X-B3-TraceId:
-      - 62475b0f4b2ab997068fb6d65521ecf1
+      - 624c4a84e599799dca1cddf4262af9a9
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4508,12 +4616,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"5b7eeb7e6c2f5c35a7a8813f311976ec"}'
+      string: '{"id":"c21bc687c577b710653c5dea7c37b2bc"}'
     headers:
       Connection:
       - keep-alive
@@ -4522,19 +4630,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:35 GMT
+      - Tue, 05 Apr 2022 13:56:20 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 3d83d2aad5f862e9
+      - b9927bc9c0354af0
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 3d83d2aad5f862e9
+      - b9927bc9c0354af0
       X-B3-TraceId:
-      - 62475b0fff08b2253d83d2aad5f862e9
+      - 624c4a84cb948a56b9927bc9c0354af0
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4548,12 +4656,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"bf657a881746d01a0ea50a85d9462a61"}'
+      string: '{"id":"c0a693c9b5eb83eb5a1e63abdae1a989"}'
     headers:
       Connection:
       - keep-alive
@@ -4562,19 +4670,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:35 GMT
+      - Tue, 05 Apr 2022 13:56:20 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 1de09ba65445062c
+      - 7c0cf55c9afbdd81
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 1de09ba65445062c
+      - 7c0cf55c9afbdd81
       X-B3-TraceId:
-      - 62475b0fb94e82021de09ba65445062c
+      - 624c4a840174d5067c0cf55c9afbdd81
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4584,47 +4692,42 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=fbef3d7a532bdb70d66d2fa99b0c0e3c%2C500a1747bce025758b74e193d0fbe4fc%2C1945f0a294a1389c7b892c12abeae2a8%2C2cecb6252e32a19b0b502de1c2e375ed%2C5b7eeb7e6c2f5c35a7a8813f311976ec%2Cbf657a881746d01a0ea50a85d9462a61
+    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=e124898d0ada3c4dfed336f773b0df83%2C70edd34ca9f96be3e9b333a4b1515ece%2C961e283824f176b72a252fc090356cff%2C1af53c02bddc7ec744dba12eb090404a%2Cc21bc687c577b710653c5dea7c37b2bc%2Cc0a693c9b5eb83eb5a1e63abdae1a989
   response:
     body:
-      string: '{"1945f0a294a1389c7b892c12abeae2a8":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"1945f0a294a1389c7b892c12abeae2a8","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:05:35+00:00","aggregate_table_used_info":null,"runtime":"0.465","added_params":{"query_timezone":"America/New_York","sorts":["users.first_name"]},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":true,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_PCPfqceS9SfLPsL5aW0W8skOn7nb"},"sql":"SELECT\n    users.first_name  AS
-        users_first_name\nFROM looker-private-demo.ecomm.users\n     AS users\nWHERE
-        (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
-        First Name","label_from_parameter":null,"label_short":"First Name","map_layer":null,"name":"users.first_name","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users","view_label":"Users","dynamic":false,"week_start_day":"monday","original_view":"users","dimension_group":null,"error":null,"field_group_variant":"First
-        Name","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.first_name","suggest_explore":"users","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=33","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.first_name
-        ","sql_case":null,"filters":null,"times_used":0,"sorted":{"sort_index":0,"desc":false}}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users","label":"Users","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.035016000000000005,"has_subtotals":false}},"2cecb6252e32a19b0b502de1c2e375ed":{"status":"running"},"500a1747bce025758b74e193d0fbe4fc":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"500a1747bce025758b74e193d0fbe4fc","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:05:35+00:00","aggregate_table_used_info":null,"runtime":"0.531","added_params":{"query_timezone":"America/New_York","sorts":["users.email"]},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":true,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_ER_LMFPbojD9Uxi-6Yz6k35bqAYM"},"sql":"SELECT\n    users.email  AS
+      string: '{"1af53c02bddc7ec744dba12eb090404a":{"status":"running"},"70edd34ca9f96be3e9b333a4b1515ece":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"70edd34ca9f96be3e9b333a4b1515ece","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:56:20+00:00","aggregate_table_used_info":null,"runtime":"0.523","added_params":{"query_timezone":"America/New_York","sorts":["users.email"]},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":false,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_U11lSZeVJw5X49m3rMILO8YMe2AL"},"sql":"SELECT\n    users.email  AS
         users_email\nFROM looker-private-demo.ecomm.users\n     AS users\nWHERE (1
         = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
         Email","label_from_parameter":null,"label_short":"Email","map_layer":null,"name":"users.email","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users","view_label":"Users","dynamic":false,"week_start_day":"monday","original_view":"users","dimension_group":null,"error":null,"field_group_variant":"Email","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.email","suggest_explore":"users","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=28","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.email
-        ","sql_case":null,"filters":null,"times_used":0,"sorted":{"sort_index":0,"desc":false}}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users","label":"Users","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.058591,"has_subtotals":false}},"5b7eeb7e6c2f5c35a7a8813f311976ec":{"status":"running"},"bf657a881746d01a0ea50a85d9462a61":{"status":"running"},"fbef3d7a532bdb70d66d2fa99b0c0e3c":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"fbef3d7a532bdb70d66d2fa99b0c0e3c","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:05:35+00:00","aggregate_table_used_info":null,"runtime":"0.487","added_params":{"query_timezone":"America/New_York","sorts":["users.city"]},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":true,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_tlVJ8OCiw8UXpZjFL3JYSEvvQESV"},"sql":"SELECT\n    users.city  AS
+        ","sql_case":null,"filters":null,"times_used":0,"sorted":{"sort_index":0,"desc":false}}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users","label":"Users","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.051133,"has_subtotals":false}},"961e283824f176b72a252fc090356cff":{"status":"running"},"c0a693c9b5eb83eb5a1e63abdae1a989":{"status":"added"},"c21bc687c577b710653c5dea7c37b2bc":{"status":"running"},"e124898d0ada3c4dfed336f773b0df83":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"e124898d0ada3c4dfed336f773b0df83","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:56:20+00:00","aggregate_table_used_info":null,"runtime":"0.604","added_params":{"query_timezone":"America/New_York","sorts":["users.city"]},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":false,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_EncgZr3FdMRIjtSlcUEj0jy0GVu3"},"sql":"SELECT\n    users.city  AS
         users_city\nFROM looker-private-demo.ecomm.users\n     AS users\nWHERE (1
         = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
         City","label_from_parameter":null,"label_short":"City","map_layer":null,"name":"users.city","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users","view_label":"Users","dynamic":false,"week_start_day":"monday","original_view":"users","dimension_group":null,"error":null,"field_group_variant":"City","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.city","suggest_explore":"users","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=23","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.city
-        ","sql_case":null,"filters":null,"times_used":0,"sorted":{"sort_index":0,"desc":false}}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users","label":"Users","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.049747,"has_subtotals":false}}}'
+        ","sql_case":null,"filters":null,"times_used":0,"sorted":{"sort_index":0,"desc":false}}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users","label":"Users","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.054928,"has_subtotals":false}}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '7657'
+      - '5176'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:35 GMT
+      - Tue, 05 Apr 2022 13:56:20 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - deac9cd292965a19
+      - f74846efdb833141
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - deac9cd292965a19
+      - f74846efdb833141
       X-B3-TraceId:
-      - 62475b0f1256844adeac9cd292965a19
+      - 624c4a84e86e7b75f74846efdb833141
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4634,21 +4737,21 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=2cecb6252e32a19b0b502de1c2e375ed%2C5b7eeb7e6c2f5c35a7a8813f311976ec%2Cbf657a881746d01a0ea50a85d9462a61
+    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=961e283824f176b72a252fc090356cff%2C1af53c02bddc7ec744dba12eb090404a%2Cc21bc687c577b710653c5dea7c37b2bc%2Cc0a693c9b5eb83eb5a1e63abdae1a989
   response:
     body:
-      string: '{"2cecb6252e32a19b0b502de1c2e375ed":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"2cecb6252e32a19b0b502de1c2e375ed","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:05:35+00:00","aggregate_table_used_info":null,"runtime":"0.476","added_params":{"query_timezone":"America/New_York"},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":true,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_R2DUR54b-A8Du5KWrLagoZST9He1"},"sql":"SELECT\n    users.id  AS
+      string: '{"1af53c02bddc7ec744dba12eb090404a":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"1af53c02bddc7ec744dba12eb090404a","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:56:20+00:00","aggregate_table_used_info":null,"runtime":"0.515","added_params":{"query_timezone":"America/New_York"},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":false,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_i91HQzCth-BetdMzuOtf6EK5BISa"},"sql":"SELECT\n    users.id  AS
         users_id\nFROM looker-private-demo.ecomm.users\n     AS users\nWHERE (1 =
         2)\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"right","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":true,"label":"Users
         ID","label_from_parameter":null,"label_short":"ID","map_layer":null,"name":"users.id","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"number","user_attribute_filter_types":["number","advanced_filter_number"],"value_format":null,"view":"users","view_label":"Users","dynamic":false,"week_start_day":"monday","original_view":"users","dimension_group":null,"error":null,"field_group_variant":"ID","measure":false,"parameter":false,"primary_key":true,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.id","suggest_explore":"users","suggestable":false,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=6","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.id
-        ","sql_case":null,"filters":null,"times_used":0}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users","label":"Users","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.036324999999999996,"has_subtotals":false}},"5b7eeb7e6c2f5c35a7a8813f311976ec":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"5b7eeb7e6c2f5c35a7a8813f311976ec","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:05:36+00:00","aggregate_table_used_info":null,"runtime":"0.462","added_params":{"query_timezone":"America/New_York","sorts":["users.last_name"]},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":true,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_YXmFO2fJ7YrhzYOl8Gjpv0Iy-9Fk"},"sql":"SELECT\n    users.last_name  AS
-        users_last_name\nFROM looker-private-demo.ecomm.users\n     AS users\nWHERE
+        ","sql_case":null,"filters":null,"times_used":0}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users","label":"Users","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.035986,"has_subtotals":false}},"961e283824f176b72a252fc090356cff":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"961e283824f176b72a252fc090356cff","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:56:20+00:00","aggregate_table_used_info":null,"runtime":"0.623","added_params":{"query_timezone":"America/New_York","sorts":["users.first_name"]},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":false,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_K0j2M9P6OX3xKm1iEUb5fIXDjTNX"},"sql":"SELECT\n    users.first_name  AS
+        users_first_name\nFROM looker-private-demo.ecomm.users\n     AS users\nWHERE
         (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
-        Last Name","label_from_parameter":null,"label_short":"Last Name","map_layer":null,"name":"users.last_name","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users","view_label":"Users","dynamic":false,"week_start_day":"monday","original_view":"users","dimension_group":null,"error":null,"field_group_variant":"Last
-        Name","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.last_name","suggest_explore":"users","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=38","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.last_name
-        ","sql_case":null,"filters":null,"times_used":0,"sorted":{"sort_index":0,"desc":false}}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users","label":"Users","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.035369,"has_subtotals":false}},"bf657a881746d01a0ea50a85d9462a61":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"bf657a881746d01a0ea50a85d9462a61","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:05:36+00:00","aggregate_table_used_info":null,"runtime":"0.318","added_params":{"query_timezone":"America/New_York","sorts":["users.state"]},"forecast_result":null,"sql":"SELECT\n    users.state
+        First Name","label_from_parameter":null,"label_short":"First Name","map_layer":null,"name":"users.first_name","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users","view_label":"Users","dynamic":false,"week_start_day":"monday","original_view":"users","dimension_group":null,"error":null,"field_group_variant":"First
+        Name","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.first_name","suggest_explore":"users","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=33","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.first_name
+        ","sql_case":null,"filters":null,"times_used":0,"sorted":{"sort_index":0,"desc":false}}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users","label":"Users","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.041376,"has_subtotals":false}},"c0a693c9b5eb83eb5a1e63abdae1a989":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"c0a693c9b5eb83eb5a1e63abdae1a989","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:56:21+00:00","aggregate_table_used_info":null,"runtime":"0.284","added_params":{"query_timezone":"America/New_York","sorts":["users.state"]},"forecast_result":null,"sql":"SELECT\n    users.state
         + 10  AS users_state\nFROM looker-private-demo.ecomm.users\n     AS users\nWHERE
         (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
         State","label_from_parameter":null,"label_short":"State","map_layer":{"url":"/data/us_states.topo-402e425f99.json","name":"us_states","feature_key":"usa","property_key":null,"property_label_key":null,"projection":"albersUsa","format":"","extents_json_url":null,"max_zoom_level":null,"min_zoom_level":null},"name":"users.state","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users","view_label":"Users","dynamic":false,"week_start_day":"monday","original_view":"users","dimension_group":null,"error":null,"field_group_variant":"State","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.state","suggest_explore":"users","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=18","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.state
@@ -4661,29 +4764,34 @@ interactions:
         INTERVAL; INTERVAL + DATE; DATETIME + INTERVAL; INTERVAL + DATETIME; INTERVAL
         + INTERVAL at [2:5]","params":"SELECT\n    users.state + 10  AS users_state\nFROM
         looker-private-demo.ecomm.users\n     AS users\nWHERE (1 = 2)\nGROUP BY\n    1\nORDER
-        BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":2,"column":5}}],"drill_menu_build_time":0.054762,"has_subtotals":false}}}'
+        BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":2,"column":5}}],"drill_menu_build_time":0.056837,"has_subtotals":false}},"c21bc687c577b710653c5dea7c37b2bc":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"c21bc687c577b710653c5dea7c37b2bc","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:56:21+00:00","aggregate_table_used_info":null,"runtime":"0.595","added_params":{"query_timezone":"America/New_York","sorts":["users.last_name"]},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":false,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_WToU6CXiRsas2Kgs4ucnXfewk_Be"},"sql":"SELECT\n    users.last_name  AS
+        users_last_name\nFROM looker-private-demo.ecomm.users\n     AS users\nWHERE
+        (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
+        Last Name","label_from_parameter":null,"label_short":"Last Name","map_layer":null,"name":"users.last_name","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users","view_label":"Users","dynamic":false,"week_start_day":"monday","original_view":"users","dimension_group":null,"error":null,"field_group_variant":"Last
+        Name","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.last_name","suggest_explore":"users","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=38","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.last_name
+        ","sql_case":null,"filters":null,"times_used":0,"sorted":{"sort_index":0,"desc":false}}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users","label":"Users","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.038654,"has_subtotals":false}}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '8153'
+      - '10669'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:36 GMT
+      - Tue, 05 Apr 2022 13:56:21 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 313d8dee8dd59eec
+      - 967ab9f6d41dd448
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 313d8dee8dd59eec
+      - 967ab9f6d41dd448
       X-B3-TraceId:
-      - 62475b1084cba214313d8dee8dd59eec
+      - 624c4a855afaab9e967ab9f6d41dd448
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4697,7 +4805,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -4711,20 +4819,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:37 GMT
+      - Tue, 05 Apr 2022 13:56:22 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 4eb5e2d476ecc688
+      - 6a3b6c37b4595891
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 4eb5e2d476ecc688
+      - 6a3b6c37b4595891
       X-B3-TraceId:
-      - 62475b114b8921e84eb5e2d476ecc688
+      - 624c4a8608b871706a3b6c37b4595891
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4736,7 +4844,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_f
   response:
@@ -4746,19 +4854,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:05:37 GMT
+      - Tue, 05 Apr 2022 13:56:22 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 2489b59ee61337a5
+      - 5fc93e55d7dd4980
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2489b59ee61337a5
+      - 5fc93e55d7dd4980
       X-B3-TraceId:
-      - 62475b110d66b9512489b59ee61337a5
+      - 624c4a86cec427c65fc93e55d7dd4980
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4772,7 +4880,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -4786,20 +4894,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:38 GMT
+      - Tue, 05 Apr 2022 13:56:23 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - fb7cbc2ee60f79d5
+      - 7fbb2763111f5b3f
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - fb7cbc2ee60f79d5
+      - 7fbb2763111f5b3f
       X-B3-TraceId:
-      - 62475b1273add398fb7cbc2ee60f79d5
+      - 624c4a86dc6bc7f87fbb2763111f5b3f
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4811,7 +4919,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_g
   response:
@@ -4821,19 +4929,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:05:38 GMT
+      - Tue, 05 Apr 2022 13:56:23 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 56eb7545f00d8618
+      - 7205f1c3fa7c1bee
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 56eb7545f00d8618
+      - 7205f1c3fa7c1bee
       X-B3-TraceId:
-      - 62475b1231a5e42156eb7545f00d8618
+      - 624c4a87299b37f87205f1c3fa7c1bee
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4847,7 +4955,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -4861,20 +4969,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:39 GMT
+      - Tue, 05 Apr 2022 13:56:24 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 1221b15c44e49ed4
+      - 9d57ccbea7456479
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 1221b15c44e49ed4
+      - 9d57ccbea7456479
       X-B3-TraceId:
-      - 62475b12846ac4b41221b15c44e49ed4
+      - 624c4a875b58021a9d57ccbea7456479
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4888,7 +4996,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -4902,19 +5010,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:39 GMT
+      - Tue, 05 Apr 2022 13:56:24 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 38d14f331130632b
+      - c1acedf7697a95e9
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 38d14f331130632b
+      - c1acedf7697a95e9
       X-B3-TraceId:
-      - 62475b137772c69b38d14f331130632b
+      - 624c4a886e1992f4c1acedf7697a95e9
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4928,7 +5036,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -4942,19 +5050,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:39 GMT
+      - Tue, 05 Apr 2022 13:56:24 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - aa65beb74d8f80e5
+      - c39cd4e03519f7c6
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - aa65beb74d8f80e5
+      - c39cd4e03519f7c6
       X-B3-TraceId:
-      - 62475b13b40f3b1eaa65beb74d8f80e5
+      - 624c4a889b1183dfc39cd4e03519f7c6
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4964,7 +5072,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -4978,19 +5086,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:39 GMT
+      - Tue, 05 Apr 2022 13:56:24 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 98ac091c83a2100a
+      - a636e2c8d02e9ed2
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 98ac091c83a2100a
+      - a636e2c8d02e9ed2
       X-B3-TraceId:
-      - 62475b1388df1b7c98ac091c83a2100a
+      - 624c4a88e5dcf6f1a636e2c8d02e9ed2
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5000,7 +5108,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -5014,20 +5122,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:39 GMT
+      - Tue, 05 Apr 2022 13:56:24 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 8f6a2efbd2f5dd56
+      - 3f597c8d01b7904f
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 8f6a2efbd2f5dd56
+      - 3f597c8d01b7904f
       X-B3-TraceId:
-      - 62475b13cf3931338f6a2efbd2f5dd56
+      - 624c4a8881c6c2d43f597c8d01b7904f
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5041,7 +5149,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -5055,20 +5163,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:40 GMT
+      - Tue, 05 Apr 2022 13:56:25 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 0097ee6148ae7b2f
+      - 85502f1c52fd6143
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 0097ee6148ae7b2f
+      - 85502f1c52fd6143
       X-B3-TraceId:
-      - 62475b13ff3330a80097ee6148ae7b2f
+      - 624c4a88400b8ea485502f1c52fd6143
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5082,7 +5190,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -5096,20 +5204,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:42 GMT
+      - Tue, 05 Apr 2022 13:56:27 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 4b6ad44db812138e
+      - b0b7d7fb3e7c264b
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 4b6ad44db812138e
+      - b0b7d7fb3e7c264b
       X-B3-TraceId:
-      - 62475b1479451c874b6ad44db812138e
+      - 624c4a89013efd92b0b7d7fb3e7c264b
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5119,7 +5227,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:27 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 5fa8f9fb734d4808
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 5fa8f9fb734d4808
+      X-B3-TraceId:
+      - 624c4a8b223fd6105fa8f9fb734d4808
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -5133,19 +5277,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:42 GMT
+      - Tue, 05 Apr 2022 13:56:27 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 2b5b475dbb596cff
+      - 13ffdc46b4dbfd2c
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2b5b475dbb596cff
+      - 13ffdc46b4dbfd2c
       X-B3-TraceId:
-      - 62475b160ac5f90d2b5b475dbb596cff
+      - 624c4a8b108f9c9013ffdc46b4dbfd2c
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5155,7 +5299,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -5169,20 +5313,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:42 GMT
+      - Tue, 05 Apr 2022 13:56:27 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 85ce631586b53323
+      - 2f4b098f2b4bebc9
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 85ce631586b53323
+      - 2f4b098f2b4bebc9
       X-B3-TraceId:
-      - 62475b16ba7e720185ce631586b53323
+      - 624c4a8b5c016a162f4b098f2b4bebc9
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:27 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 9e847ed11347f390
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 9e847ed11347f390
+      X-B3-TraceId:
+      - 624c4a8bbc1388cc9e847ed11347f390
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5192,7 +5376,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:27 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 662909c844659078
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 662909c844659078
+      X-B3-TraceId:
+      - 624c4a8b2cac0435662909c844659078
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:27 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 8e121d348d64c3f0
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 8e121d348d64c3f0
+      X-B3-TraceId:
+      - 624c4a8b06b1a75d8e121d348d64c3f0
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:27 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - e34ebabb247a8252
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - e34ebabb247a8252
+      X-B3-TraceId:
+      - 624c4a8bd8c306cee34ebabb247a8252
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:27 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 1c6b366c815239c6
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 1c6b366c815239c6
+      X-B3-TraceId:
+      - 624c4a8b5c57b1e21c6b366c815239c6
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:27 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 1eaf002ed47feca7
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 1eaf002ed47feca7
+      X-B3-TraceId:
+      - 624c4a8bff44fb5a1eaf002ed47feca7
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_i"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_i","remote":"origin","remote_name":"tmp_spectacles_i","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:28 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 69538464bc14197f
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 69538464bc14197f
+      X-B3-TraceId:
+      - 624c4a8bcc03c69b69538464bc14197f
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_i", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_i","remote":"origin","remote_name":"tmp_spectacles_i","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:56:28 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 638d7cdc93530058
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 638d7cdc93530058
+      X-B3-TraceId:
+      - 624c4a8c17c66941638d7cdc93530058
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -5241,320 +5693,12 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:05:42 GMT
+      - Tue, 05 Apr 2022 13:56:28 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
-- request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:42 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 1c9d6126cc0b4be4
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 1c9d6126cc0b4be4
-      X-B3-TraceId:
-      - 62475b164e8cd3f41c9d6126cc0b4be4
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:42 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 70f0fcfdcc0ecdf9
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 70f0fcfdcc0ecdf9
-      X-B3-TraceId:
-      - 62475b16850f2dbd70f0fcfdcc0ecdf9
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:42 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - f15321e379563b5c
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - f15321e379563b5c
-      X-B3-TraceId:
-      - 62475b16f79ac641f15321e379563b5c
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:42 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 958c6da9aa3fbab8
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 958c6da9aa3fbab8
-      X-B3-TraceId:
-      - 62475b16a31bad9e958c6da9aa3fbab8
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:42 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 8b0ebf42e16537bd
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 8b0ebf42e16537bd
-      X-B3-TraceId:
-      - 62475b1673609c918b0ebf42e16537bd
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:43 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 02afdf1b530b987d
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 02afdf1b530b987d
-      X-B3-TraceId:
-      - 62475b176855b16c02afdf1b530b987d
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_i"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_i","remote":"origin","remote_name":"tmp_spectacles_i","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:43 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - d60f58890ba514df
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - d60f58890ba514df
-      X-B3-TraceId:
-      - 62475b17418a2bd8d60f58890ba514df
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_i", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_i","remote":"origin","remote_name":"tmp_spectacles_i","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:44 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 9707b02bfd08bab4
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 9707b02bfd08bab4
-      X-B3-TraceId:
-      - 62475b17479cc3689707b02bfd08bab4
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
 - request:
     body: '{"model": "eye_exam", "view": "users", "fields": ["users.state"], "limit":
       0, "filter_expression": "1=2"}'
@@ -5564,7 +5708,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -5578,19 +5722,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:44 GMT
+      - Tue, 05 Apr 2022 13:56:29 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 34041ee95f5a65c5
+      - 0cc637cdcd7c8628
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 34041ee95f5a65c5
+      - 0cc637cdcd7c8628
       X-B3-TraceId:
-      - 62475b18a7e6931234041ee95f5a65c5
+      - 624c4a8dee426e230cc637cdcd7c8628
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5600,7 +5744,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/1909/run/sql
   response:
@@ -5615,19 +5759,19 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:05:44 GMT
+      - Tue, 05 Apr 2022 13:56:29 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - bda30b066432b120
+      - 3b4b197d4e870d97
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - bda30b066432b120
+      - 3b4b197d4e870d97
       X-B3-TraceId:
-      - 62475b189d0eac9ebda30b066432b120
+      - 624c4a8d03c37f393b4b197d4e870d97
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5641,7 +5785,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -5655,20 +5799,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:45 GMT
+      - Tue, 05 Apr 2022 13:56:30 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 22efea34375df8b1
+      - 4fa89dc1e6079448
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 22efea34375df8b1
+      - 4fa89dc1e6079448
       X-B3-TraceId:
-      - 62475b1818b1fb1822efea34375df8b1
+      - 624c4a8dbb37f83f4fa89dc1e6079448
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5680,7 +5824,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_h
   response:
@@ -5690,19 +5834,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:05:46 GMT
+      - Tue, 05 Apr 2022 13:56:31 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 09e3bc4a6a01625c
+      - 3ac4140de603116b
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 09e3bc4a6a01625c
+      - 3ac4140de603116b
       X-B3-TraceId:
-      - 62475b1954a93b3209e3bc4a6a01625c
+      - 624c4a8e7579a7ed3ac4140de603116b
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5716,7 +5860,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -5730,20 +5874,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:47 GMT
+      - Tue, 05 Apr 2022 13:56:32 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 60ce15fb241d5d84
+      - 3cf639a528a148cc
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 60ce15fb241d5d84
+      - 3cf639a528a148cc
       X-B3-TraceId:
-      - 62475b1a7df80d1660ce15fb241d5d84
+      - 624c4a8f7e6b3a103cf639a528a148cc
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5755,7 +5899,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_i
   response:
@@ -5765,19 +5909,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:05:47 GMT
+      - Tue, 05 Apr 2022 13:56:32 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 784647375f305ab6
+      - 52b6efc5bac327ae
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 784647375f305ab6
+      - 52b6efc5bac327ae
       X-B3-TraceId:
-      - 62475b1bac6d412d784647375f305ab6
+      - 624c4a90e602537a52b6efc5bac327ae
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5791,7 +5935,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -5805,20 +5949,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:47 GMT
+      - Tue, 05 Apr 2022 13:56:32 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 6ce6081e76c74808
+      - 2957602b3d54dd74
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6ce6081e76c74808
+      - 2957602b3d54dd74
       X-B3-TraceId:
-      - 62475b1b3791fa9b6ce6081e76c74808
+      - 624c4a90278e654d2957602b3d54dd74
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5832,7 +5976,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -5846,19 +5990,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:47 GMT
+      - Tue, 05 Apr 2022 13:56:32 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 02fab6b3ed484cab
+      - 36eab5dcd4fb8f7d
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 02fab6b3ed484cab
+      - 36eab5dcd4fb8f7d
       X-B3-TraceId:
-      - 62475b1b6e62d13d02fab6b3ed484cab
+      - 624c4a90aca00ae136eab5dcd4fb8f7d
       X-Content-Type-Options:
       - nosniff
     status:

--- a/tests/cassettes/test_runner/test_incremental_sql_with_diff_explores_and_valid_sql_should_not_error.yaml
+++ b/tests/cassettes/test_runner/test_incremental_sql_with_diff_explores_and_valid_sql_should_not_error.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -17,19 +17,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:40 GMT
+      - Tue, 05 Apr 2022 13:57:17 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 27720221377dda83
+      - e9a4abd6960e9cab
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 27720221377dda83
+      - e9a4abd6960e9cab
       X-B3-TraceId:
-      - 62475a24d9c8e25b27720221377dda83
+      - 624c4abd420f9fc1e9a4abd6960e9cab
       X-Content-Type-Options:
       - nosniff
     status:
@@ -39,7 +39,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -53,56 +53,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:40 GMT
+      - Tue, 05 Apr 2022 13:57:17 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 6be137fdc4852558
+      - 56458831908b2fa0
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6be137fdc4852558
+      - 56458831908b2fa0
       X-B3-TraceId:
-      - 62475a24d9105b486be137fdc4852558
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
-  response:
-    body:
-      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '147'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:01:40 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 4bcda433a7bf071d
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 4bcda433a7bf071d
-      X-B3-TraceId:
-      - 62475a24ae5095e64bcda433a7bf071d
+      - 624c4abd9a0fde2d56458831908b2fa0
       X-Content-Type-Options:
       - nosniff
     status:
@@ -116,7 +80,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -130,19 +94,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:40 GMT
+      - Tue, 05 Apr 2022 13:57:17 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - c02da471e2e27baf
+      - 9ef2bcbf75ac05b2
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - c02da471e2e27baf
+      - 9ef2bcbf75ac05b2
       X-B3-TraceId:
-      - 62475a24a16d4e88c02da471e2e27baf
+      - 624c4abd6ea5c2b49ef2bcbf75ac05b2
       X-Content-Type-Options:
       - nosniff
     status:
@@ -152,7 +116,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -166,19 +130,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:40 GMT
+      - Tue, 05 Apr 2022 13:57:17 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f5878607c1ea1f8a
+      - f271cb5602bbfbc5
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f5878607c1ea1f8a
+      - f271cb5602bbfbc5
       X-B3-TraceId:
-      - 62475a24895be48af5878607c1ea1f8a
+      - 624c4abd1f57f2e3f271cb5602bbfbc5
       X-Content-Type-Options:
       - nosniff
     status:
@@ -188,34 +152,34 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest-fail-lookml","remote":"origin","remote_name":"pytest-fail-lookml","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648842609,"ref":"067426a7d80ca00cdd982b2373ae8757756ff799","remote_ref":"067426a7d80ca00cdd982b2373ae8757756ff799","can":{}}'
+      string: '{"name":"pytest-incremental-invalid-equal","remote":"origin","remote_name":"pytest-incremental-invalid-equal","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648842827,"ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","remote_ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","can":{}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '387'
+      - '415'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:40 GMT
+      - Tue, 05 Apr 2022 13:57:17 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f4d72dd62532ab15
+      - 897a1d48b1e1633b
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f4d72dd62532ab15
+      - 897a1d48b1e1633b
       X-B3-TraceId:
-      - 62475a24e0e641b3f4d72dd62532ab15
+      - 624c4abdc7c6348b897a1d48b1e1633b
       X-Content-Type-Options:
       - nosniff
     status:
@@ -229,12 +193,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648842609,"ref":"067426a7d80ca00cdd982b2373ae8757756ff799","remote_ref":null,"can":{}}'
+      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648842827,"ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","remote_ref":null,"can":{}}'
     headers:
       Connection:
       - keep-alive
@@ -243,20 +207,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:41 GMT
+      - Tue, 05 Apr 2022 13:57:18 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - cf8fb22ea58997c6
+      - 1e7e8a5cbd4177f5
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - cf8fb22ea58997c6
+      - 1e7e8a5cbd4177f5
       X-B3-TraceId:
-      - 62475a24f7596615cf8fb22ea58997c6
+      - 624c4abdb9462c1e1e7e8a5cbd4177f5
       X-Content-Type-Options:
       - nosniff
     status:
@@ -270,12 +234,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648842609,"ref":"067426a7d80ca00cdd982b2373ae8757756ff799","remote_ref":null,"can":{}}'
+      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648842827,"ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","remote_ref":null,"can":{}}'
     headers:
       Connection:
       - keep-alive
@@ -284,20 +248,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:43 GMT
+      - Tue, 05 Apr 2022 13:57:20 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - a4c142f9d9006faa
+      - e5aec0bf7f46f1b6
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a4c142f9d9006faa
+      - e5aec0bf7f46f1b6
       X-B3-TraceId:
-      - 62475a2552edc68ba4c142f9d9006faa
+      - 624c4abe8862d0b0e5aec0bf7f46f1b6
       X-Content-Type-Options:
       - nosniff
     status:
@@ -307,7 +271,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:20 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - ba736410744a1248
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - ba736410744a1248
+      X-B3-TraceId:
+      - 624c4ac0c5e2aa06ba736410744a1248
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -321,19 +321,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:43 GMT
+      - Tue, 05 Apr 2022 13:57:20 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 082bb8b4aa16810d
+      - 371d8d1d0bb476b2
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 082bb8b4aa16810d
+      - 371d8d1d0bb476b2
       X-B3-TraceId:
-      - 62475a278e246a63082bb8b4aa16810d
+      - 624c4ac02e48088d371d8d1d0bb476b2
       X-Content-Type-Options:
       - nosniff
     status:
@@ -343,7 +343,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -357,20 +357,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:43 GMT
+      - Tue, 05 Apr 2022 13:57:20 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - df409f101e537bcc
+      - 87c35b929d661377
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - df409f101e537bcc
+      - 87c35b929d661377
       X-B3-TraceId:
-      - 62475a27725cdb25df409f101e537bcc
+      - 624c4ac067e8d1dd87c35b929d661377
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:20 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - b12d90f5dff996a5
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - b12d90f5dff996a5
+      X-B3-TraceId:
+      - 624c4ac00cb112d5b12d90f5dff996a5
       X-Content-Type-Options:
       - nosniff
     status:
@@ -380,7 +420,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:20 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - a36f4a4255d8b054
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - a36f4a4255d8b054
+      X-B3-TraceId:
+      - 624c4ac05f21badca36f4a4255d8b054
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:20 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 8c4fd294e58fe990
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 8c4fd294e58fe990
+      X-B3-TraceId:
+      - 624c4ac03dd973a08c4fd294e58fe990
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:20 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 578db890af42f2ee
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 578db890af42f2ee
+      X-B3-TraceId:
+      - 624c4ac0e4b466c3578db890af42f2ee
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:20 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 097799d9ae660a4e
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 097799d9ae660a4e
+      X-B3-TraceId:
+      - 624c4ac04365cb93097799d9ae660a4e
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:20 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 77944214860fc6a6
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 77944214860fc6a6
+      X-B3-TraceId:
+      - 624c4ac098500b9c77944214860fc6a6
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_b"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:21 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 92929b7da915dbb6
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 92929b7da915dbb6
+      X-B3-TraceId:
+      - 624c4ac04c28a58d92929b7da915dbb6
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_b", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:21 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 3d4b932c6e90f18a
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 3d4b932c6e90f18a
+      X-B3-TraceId:
+      - 624c4ac1821812253d4b932c6e90f18a
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -429,325 +737,17 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:01:43 GMT
+      - Tue, 05 Apr 2022 13:57:22 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:01:43 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - e7ab55baa903d425
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - e7ab55baa903d425
-      X-B3-TraceId:
-      - 62475a276c935f9ce7ab55baa903d425
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:01:43 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - fbfc832bd2803fab
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - fbfc832bd2803fab
-      X-B3-TraceId:
-      - 62475a27daef8329fbfc832bd2803fab
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:01:43 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - f03e5906e0601b09
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - f03e5906e0601b09
-      X-B3-TraceId:
-      - 62475a2773c09a5df03e5906e0601b09
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:01:43 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - fe550241d9e203e7
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - fe550241d9e203e7
-      X-B3-TraceId:
-      - 62475a27609fe8acfe550241d9e203e7
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:01:43 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 05818d99c25967a0
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 05818d99c25967a0
-      X-B3-TraceId:
-      - 62475a2775c7588005818d99c25967a0
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:01:43 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 3c3f7565b70617ef
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 3c3f7565b70617ef
-      X-B3-TraceId:
-      - 62475a27bb7dfb303c3f7565b70617ef
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_b"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:01:44 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 7ac1d6a79c052ab7
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 7ac1d6a79c052ab7
-      X-B3-TraceId:
-      - 62475a272a72a5527ac1d6a79c052ab7
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_b", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:01:44 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 692ad4118b6486db
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 692ad4118b6486db
-      X-B3-TraceId:
-      - 62475a28c7e47f12692ad4118b6486db
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models?fields=name%2Cproject_name%2Cexplores
   response:
@@ -831,20 +831,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:45 GMT
+      - Tue, 05 Apr 2022 13:57:22 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - decdbcf6383f7d67
+      - 4fa252307d57f0f8
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - decdbcf6383f7d67
+      - 4fa252307d57f0f8
       X-B3-TraceId:
-      - 62475a28cae4cbafdecdbcf6383f7d67
+      - 624c4ac2c07c29e04fa252307d57f0f8
       X-Content-Type-Options:
       - nosniff
     status:
@@ -854,7 +854,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users?fields=fields
   response:
@@ -885,20 +885,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:45 GMT
+      - Tue, 05 Apr 2022 13:57:23 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 2b8c85f587ce675c
+      - ff6467a8d1211799
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2b8c85f587ce675c
+      - ff6467a8d1211799
       X-B3-TraceId:
-      - 62475a2938062da02b8c85f587ce675c
+      - 624c4ac3d9bfa1d8ff6467a8d1211799
       X-Content-Type-Options:
       - nosniff
     status:
@@ -908,7 +908,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users__fail?fields=fields
   response:
@@ -944,20 +944,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:46 GMT
+      - Tue, 05 Apr 2022 13:57:23 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 8c11a5f82d9e2a17
+      - 8ed939b6ef766ca5
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 8c11a5f82d9e2a17
+      - 8ed939b6ef766ca5
       X-B3-TraceId:
-      - 62475a29c21b2f408c11a5f82d9e2a17
+      - 624c4ac3a779c4688ed939b6ef766ca5
       X-Content-Type-Options:
       - nosniff
     status:
@@ -973,7 +973,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -987,19 +987,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:46 GMT
+      - Tue, 05 Apr 2022 13:57:23 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - df188d876fe8c6b7
+      - b631f6f0818ef596
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - df188d876fe8c6b7
+      - b631f6f0818ef596
       X-B3-TraceId:
-      - 62475a2a67525f24df188d876fe8c6b7
+      - 624c4ac371979544b631f6f0818ef596
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1009,7 +1009,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/2216/run/sql
   response:
@@ -1027,19 +1027,19 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:01:46 GMT
+      - Tue, 05 Apr 2022 13:57:23 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - c2160464575a84d0
+      - a90ab5250b5cc9a3
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - c2160464575a84d0
+      - a90ab5250b5cc9a3
       X-B3-TraceId:
-      - 62475a2a6eab3e14c2160464575a84d0
+      - 624c4ac31d0a063aa90ab5250b5cc9a3
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1055,7 +1055,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -1069,19 +1069,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:46 GMT
+      - Tue, 05 Apr 2022 13:57:23 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - cb24f215f50baec6
+      - 10d3f671a510714a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - cb24f215f50baec6
+      - 10d3f671a510714a
       X-B3-TraceId:
-      - 62475a2a78f1df0ccb24f215f50baec6
+      - 624c4ac314a088e610d3f671a510714a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1091,7 +1091,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/1944/run/sql
   response:
@@ -1109,60 +1109,60 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:01:46 GMT
+      - Tue, 05 Apr 2022 13:57:23 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 996f28faecea32cc
+      - ded3a5267fd4275d
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 996f28faecea32cc
+      - ded3a5267fd4275d
       X-B3-TraceId:
-      - 62475a2ad1ab88e1996f28faecea32cc
+      - 624c4ac3969a0108ded3a5267fd4275d
       X-Content-Type-Options:
       - nosniff
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "pytest-fail-lookml"}'
+    body: '{"name": "pytest-incremental-invalid-equal"}'
     headers:
       Content-Length:
-      - '30'
+      - '44'
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest-fail-lookml","remote":"origin","remote_name":"pytest-fail-lookml","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648842609,"ref":"067426a7d80ca00cdd982b2373ae8757756ff799","remote_ref":"067426a7d80ca00cdd982b2373ae8757756ff799","can":{}}'
+      string: '{"name":"pytest-incremental-invalid-equal","remote":"origin","remote_name":"pytest-incremental-invalid-equal","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648842827,"ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","remote_ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","can":{}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '387'
+      - '415'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:47 GMT
+      - Tue, 05 Apr 2022 13:57:24 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 0616d4bf6a9c914b
+      - 973a9f601a4b2194
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 0616d4bf6a9c914b
+      - 973a9f601a4b2194
       X-B3-TraceId:
-      - 62475a2a2160263c0616d4bf6a9c914b
+      - 624c4ac3c0bbe865973a9f601a4b2194
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1174,7 +1174,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_a
   response:
@@ -1184,19 +1184,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:01:48 GMT
+      - Tue, 05 Apr 2022 13:57:25 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - c1f27e94aaf8dc6e
+      - ac631973c0d04769
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - c1f27e94aaf8dc6e
+      - ac631973c0d04769
       X-B3-TraceId:
-      - 62475a2b2a35b33dc1f27e94aaf8dc6e
+      - 624c4ac4cd719880ac631973c0d04769
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1210,7 +1210,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -1224,20 +1224,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:48 GMT
+      - Tue, 05 Apr 2022 13:57:26 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - adc6ee6fdc3974c5
+      - ff41a88d07ae14a1
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - adc6ee6fdc3974c5
+      - ff41a88d07ae14a1
       X-B3-TraceId:
-      - 62475a2c743ebc7fadc6ee6fdc3974c5
+      - 624c4ac525d7757dff41a88d07ae14a1
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1249,7 +1249,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_b
   response:
@@ -1259,19 +1259,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:01:49 GMT
+      - Tue, 05 Apr 2022 13:57:26 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - e9efdcf2cd7ee088
+      - 61b1ea894eb1566b
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - e9efdcf2cd7ee088
+      - 61b1ea894eb1566b
       X-B3-TraceId:
-      - 62475a2d25b7c420e9efdcf2cd7ee088
+      - 624c4ac61523f08361b1ea894eb1566b
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1285,7 +1285,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -1299,20 +1299,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:49 GMT
+      - Tue, 05 Apr 2022 13:57:27 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 63e22ac9687a6b7c
+      - 2198c8a29e5a2e82
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 63e22ac9687a6b7c
+      - 2198c8a29e5a2e82
       X-B3-TraceId:
-      - 62475a2d9d8c2d1e63e22ac9687a6b7c
+      - 624c4ac6d26853182198c8a29e5a2e82
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1326,7 +1326,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1340,19 +1340,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:49 GMT
+      - Tue, 05 Apr 2022 13:57:27 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - a70a0b047ef931ad
+      - 627297dd8792e7bf
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a70a0b047ef931ad
+      - 627297dd8792e7bf
       X-B3-TraceId:
-      - 62475a2dc6e1c12ba70a0b047ef931ad
+      - 624c4ac7e308f5dd627297dd8792e7bf
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1366,7 +1366,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1380,19 +1380,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:49 GMT
+      - Tue, 05 Apr 2022 13:57:27 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 39d0d3d11a9f760e
+      - 93a513503754a39e
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 39d0d3d11a9f760e
+      - 93a513503754a39e
       X-B3-TraceId:
-      - 62475a2dd49c5aef39d0d3d11a9f760e
+      - 624c4ac7513b9ad793a513503754a39e
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1402,7 +1402,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1416,19 +1416,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:49 GMT
+      - Tue, 05 Apr 2022 13:57:27 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f365d9767a85c244
+      - 3260ec3ffdf24343
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f365d9767a85c244
+      - 3260ec3ffdf24343
       X-B3-TraceId:
-      - 62475a2d832dc9aef365d9767a85c244
+      - 624c4ac78f021f023260ec3ffdf24343
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1438,34 +1438,34 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest-fail-lookml","remote":"origin","remote_name":"pytest-fail-lookml","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648842609,"ref":"067426a7d80ca00cdd982b2373ae8757756ff799","remote_ref":"067426a7d80ca00cdd982b2373ae8757756ff799","can":{}}'
+      string: '{"name":"pytest-incremental-invalid-equal","remote":"origin","remote_name":"pytest-incremental-invalid-equal","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648842827,"ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","remote_ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","can":{}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '387'
+      - '415'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:50 GMT
+      - Tue, 05 Apr 2022 13:57:27 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f73edadbf364491e
+      - 8f6746bbaa9b74a4
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f73edadbf364491e
+      - 8f6746bbaa9b74a4
       X-B3-TraceId:
-      - 62475a2d3f514f05f73edadbf364491e
+      - 624c4ac72e53c3178f6746bbaa9b74a4
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1479,12 +1479,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"tmp_spectacles_c","remote":"origin","remote_name":"tmp_spectacles_c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648842609,"ref":"067426a7d80ca00cdd982b2373ae8757756ff799","remote_ref":null,"can":{}}'
+      string: '{"name":"tmp_spectacles_c","remote":"origin","remote_name":"tmp_spectacles_c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648842827,"ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","remote_ref":null,"can":{}}'
     headers:
       Connection:
       - keep-alive
@@ -1493,20 +1493,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:50 GMT
+      - Tue, 05 Apr 2022 13:57:27 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - a579159a760c9587
+      - de448a7090a1b9e6
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a579159a760c9587
+      - de448a7090a1b9e6
       X-B3-TraceId:
-      - 62475a2eecd94793a579159a760c9587
+      - 624c4ac7c974c6ebde448a7090a1b9e6
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1520,12 +1520,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"tmp_spectacles_c","remote":"origin","remote_name":"tmp_spectacles_c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648842609,"ref":"067426a7d80ca00cdd982b2373ae8757756ff799","remote_ref":null,"can":{}}'
+      string: '{"name":"tmp_spectacles_c","remote":"origin","remote_name":"tmp_spectacles_c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648842827,"ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","remote_ref":null,"can":{}}'
     headers:
       Connection:
       - keep-alive
@@ -1534,20 +1534,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:52 GMT
+      - Tue, 05 Apr 2022 13:57:29 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 36e85de4b610ed21
+      - f99667e016e03df4
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 36e85de4b610ed21
+      - f99667e016e03df4
       X-B3-TraceId:
-      - 62475a2e0a97c6d436e85de4b610ed21
+      - 624c4ac78b211a99f99667e016e03df4
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1557,7 +1557,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:29 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - ea8393f3dc877609
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - ea8393f3dc877609
+      X-B3-TraceId:
+      - 624c4ac9986b71f4ea8393f3dc877609
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1571,19 +1607,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:52 GMT
+      - Tue, 05 Apr 2022 13:57:29 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 2390574b73dcfe4e
+      - e09912df86d7cd3c
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2390574b73dcfe4e
+      - e09912df86d7cd3c
       X-B3-TraceId:
-      - 62475a30e36da6032390574b73dcfe4e
+      - 624c4ac9f0becf83e09912df86d7cd3c
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1593,7 +1629,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -1607,20 +1643,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:52 GMT
+      - Tue, 05 Apr 2022 13:57:29 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 9618596ba87fd7d0
+      - 70773b3f526cdf39
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 9618596ba87fd7d0
+      - 70773b3f526cdf39
       X-B3-TraceId:
-      - 62475a30bdb4de409618596ba87fd7d0
+      - 624c4ac9f7577f4d70773b3f526cdf39
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:29 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - f902cdcebeb79310
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - f902cdcebeb79310
+      X-B3-TraceId:
+      - 624c4ac9fc9f7739f902cdcebeb79310
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1630,7 +1706,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:30 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 08fa5c41ad3d37cb
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 08fa5c41ad3d37cb
+      X-B3-TraceId:
+      - 624c4aca130dbe0b08fa5c41ad3d37cb
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:30 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 3b841a50e434d5c6
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 3b841a50e434d5c6
+      X-B3-TraceId:
+      - 624c4acab571624d3b841a50e434d5c6
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:30 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 7939e311d6d95664
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 7939e311d6d95664
+      X-B3-TraceId:
+      - 624c4aca356f21407939e311d6d95664
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:30 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - e71ae5c8942bc647
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - e71ae5c8942bc647
+      X-B3-TraceId:
+      - 624c4acaed04eba9e71ae5c8942bc647
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:30 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 23752f65fea9a3b2
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 23752f65fea9a3b2
+      X-B3-TraceId:
+      - 624c4acaf840f12e23752f65fea9a3b2
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_d"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_d","remote":"origin","remote_name":"tmp_spectacles_d","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:30 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - a0ffa3d2b4a93e6d
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - a0ffa3d2b4a93e6d
+      X-B3-TraceId:
+      - 624c4aca9a147896a0ffa3d2b4a93e6d
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_d", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_d","remote":"origin","remote_name":"tmp_spectacles_d","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:31 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - c8213d337cc15697
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - c8213d337cc15697
+      X-B3-TraceId:
+      - 624c4acaf0682c4fc8213d337cc15697
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -1679,325 +2023,17 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:01:52 GMT
+      - Tue, 05 Apr 2022 13:57:31 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:01:52 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - c2a92e07195f0448
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - c2a92e07195f0448
-      X-B3-TraceId:
-      - 62475a307cee3151c2a92e07195f0448
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:01:53 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 3fcffaf26f85ab43
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 3fcffaf26f85ab43
-      X-B3-TraceId:
-      - 62475a305abf6db43fcffaf26f85ab43
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:01:53 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 34bdc3a06624977f
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 34bdc3a06624977f
-      X-B3-TraceId:
-      - 62475a313fdb702134bdc3a06624977f
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:01:53 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 6883c75bb5039874
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 6883c75bb5039874
-      X-B3-TraceId:
-      - 62475a31480e02146883c75bb5039874
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:01:53 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - b90be9155176d637
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - b90be9155176d637
-      X-B3-TraceId:
-      - 62475a3167e3aa72b90be9155176d637
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:01:53 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 62a47829e64c72be
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 62a47829e64c72be
-      X-B3-TraceId:
-      - 62475a3106cfbebc62a47829e64c72be
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_d"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_d","remote":"origin","remote_name":"tmp_spectacles_d","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:01:53 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 25ed071375f6afbe
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 25ed071375f6afbe
-      X-B3-TraceId:
-      - 62475a3113dadfb425ed071375f6afbe
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_d", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_d","remote":"origin","remote_name":"tmp_spectacles_d","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:01:54 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - d120973e0c7b2798
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - d120973e0c7b2798
-      X-B3-TraceId:
-      - 62475a31731cfeadd120973e0c7b2798
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models?fields=name%2Cproject_name%2Cexplores
   response:
@@ -2081,20 +2117,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:55 GMT
+      - Tue, 05 Apr 2022 13:57:32 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 7a631b05cceedbd4
+      - 56a06bcd3a6c3fcc
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 7a631b05cceedbd4
+      - 56a06bcd3a6c3fcc
       X-B3-TraceId:
-      - 62475a3250f84ef87a631b05cceedbd4
+      - 624c4acb53e4243956a06bcd3a6c3fcc
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2104,7 +2140,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users?fields=fields
   response:
@@ -2135,20 +2171,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:55 GMT
+      - Tue, 05 Apr 2022 13:57:32 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 68d74bb30fc24b2d
+      - ae1f95a9f75daa1a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 68d74bb30fc24b2d
+      - ae1f95a9f75daa1a
       X-B3-TraceId:
-      - 62475a33870a481868d74bb30fc24b2d
+      - 624c4accaeb0cdabae1f95a9f75daa1a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2158,7 +2194,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users__fail?fields=fields
   response:
@@ -2194,20 +2230,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:55 GMT
+      - Tue, 05 Apr 2022 13:57:32 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 457ccb1e8d32447d
+      - 7d289a149339a3c7
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 457ccb1e8d32447d
+      - 7d289a149339a3c7
       X-B3-TraceId:
-      - 62475a338490ef67457ccb1e8d32447d
+      - 624c4acc5fb07d517d289a149339a3c7
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2223,7 +2259,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -2237,19 +2273,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:55 GMT
+      - Tue, 05 Apr 2022 13:57:32 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 1709df6ede3babcd
+      - 212b266dfee3327b
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 1709df6ede3babcd
+      - 212b266dfee3327b
       X-B3-TraceId:
-      - 62475a337b16d9dd1709df6ede3babcd
+      - 624c4acc55b16331212b266dfee3327b
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2259,7 +2295,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/2216/run/sql
   response:
@@ -2276,19 +2312,19 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:01:55 GMT
+      - Tue, 05 Apr 2022 13:57:32 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - ba85fb7d31563c78
+      - 847721d33ae229bd
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - ba85fb7d31563c78
+      - 847721d33ae229bd
       X-B3-TraceId:
-      - 62475a33c27b2184ba85fb7d31563c78
+      - 624c4acc25e44aee847721d33ae229bd
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2304,7 +2340,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -2318,19 +2354,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:55 GMT
+      - Tue, 05 Apr 2022 13:57:32 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 15f3eb9949cd4fdf
+      - d0395344b7929697
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 15f3eb9949cd4fdf
+      - d0395344b7929697
       X-B3-TraceId:
-      - 62475a33f3e2e32215f3eb9949cd4fdf
+      - 624c4acc611730dfd0395344b7929697
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2340,7 +2376,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/1944/run/sql
   response:
@@ -2358,60 +2394,60 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:01:56 GMT
+      - Tue, 05 Apr 2022 13:57:33 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 11b564651d7c8b6d
+      - 05be6dfadc22d061
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 11b564651d7c8b6d
+      - 05be6dfadc22d061
       X-B3-TraceId:
-      - 62475a33c142602f11b564651d7c8b6d
+      - 624c4acc37b6687505be6dfadc22d061
       X-Content-Type-Options:
       - nosniff
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "pytest-fail-lookml"}'
+    body: '{"name": "pytest-incremental-invalid-equal"}'
     headers:
       Content-Length:
-      - '30'
+      - '44'
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest-fail-lookml","remote":"origin","remote_name":"pytest-fail-lookml","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648842609,"ref":"067426a7d80ca00cdd982b2373ae8757756ff799","remote_ref":"067426a7d80ca00cdd982b2373ae8757756ff799","can":{}}'
+      string: '{"name":"pytest-incremental-invalid-equal","remote":"origin","remote_name":"pytest-incremental-invalid-equal","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648842827,"ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","remote_ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","can":{}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '387'
+      - '415'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:56 GMT
+      - Tue, 05 Apr 2022 13:57:33 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 342aff8548f7a9e9
+      - 36435ecf807f9f91
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 342aff8548f7a9e9
+      - 36435ecf807f9f91
       X-B3-TraceId:
-      - 62475a34e620a28b342aff8548f7a9e9
+      - 624c4acdb476c81136435ecf807f9f91
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2423,7 +2459,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_c
   response:
@@ -2433,19 +2469,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:01:57 GMT
+      - Tue, 05 Apr 2022 13:57:34 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 9005e0ca124f75e1
+      - daf2fe8bfe365d92
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 9005e0ca124f75e1
+      - daf2fe8bfe365d92
       X-B3-TraceId:
-      - 62475a34975168729005e0ca124f75e1
+      - 624c4acd8d2fceacdaf2fe8bfe365d92
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2459,7 +2495,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -2473,20 +2509,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:58 GMT
+      - Tue, 05 Apr 2022 13:57:35 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 0737cb0f46a7bc28
+      - 4dfb2c43b92591c9
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 0737cb0f46a7bc28
+      - 4dfb2c43b92591c9
       X-B3-TraceId:
-      - 62475a35acd973a00737cb0f46a7bc28
+      - 624c4ace68d922d44dfb2c43b92591c9
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2498,7 +2534,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_d
   response:
@@ -2508,19 +2544,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:01:58 GMT
+      - Tue, 05 Apr 2022 13:57:35 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 52fc4aa300b59515
+      - 210050d44058152f
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 52fc4aa300b59515
+      - 210050d44058152f
       X-B3-TraceId:
-      - 62475a36fc4c027352fc4aa300b59515
+      - 624c4acf8ab8eeab210050d44058152f
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2534,7 +2570,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -2548,20 +2584,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:59 GMT
+      - Tue, 05 Apr 2022 13:57:36 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 5ded6b1f03bac73c
+      - 1b07f16af9acb515
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 5ded6b1f03bac73c
+      - 1b07f16af9acb515
       X-B3-TraceId:
-      - 62475a361c13b8d65ded6b1f03bac73c
+      - 624c4acf9ae4607c1b07f16af9acb515
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2575,7 +2611,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -2589,19 +2625,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:59 GMT
+      - Tue, 05 Apr 2022 13:57:36 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 82adc1202f4494d8
+      - 44f7ee5b108d7c16
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 82adc1202f4494d8
+      - 44f7ee5b108d7c16
       X-B3-TraceId:
-      - 62475a3791e8a3b882adc1202f4494d8
+      - 624c4ad08b77c5f144f7ee5b108d7c16
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2615,7 +2651,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -2629,19 +2665,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:01:59 GMT
+      - Tue, 05 Apr 2022 13:57:36 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 78a99c427a66f0ec
+      - 9bd2d423ff6bed1e
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 78a99c427a66f0ec
+      - 9bd2d423ff6bed1e
       X-B3-TraceId:
-      - 62475a378c0ac80a78a99c427a66f0ec
+      - 624c4ad0b9f5d15c9bd2d423ff6bed1e
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2655,7 +2691,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -2669,20 +2705,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:00 GMT
+      - Tue, 05 Apr 2022 13:57:37 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - c52d2603b473b260
+      - 3c57b188031840b5
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - c52d2603b473b260
+      - 3c57b188031840b5
       X-B3-TraceId:
-      - 62475a372df80f75c52d2603b473b260
+      - 624c4ad05dd88ef93c57b188031840b5
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2694,7 +2730,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/reset_to_remote
   response:
@@ -2704,19 +2740,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:02:01 GMT
+      - Tue, 05 Apr 2022 13:57:37 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 3838135c2887f1f0
+      - cf564807fae1583a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 3838135c2887f1f0
+      - cf564807fae1583a
       X-B3-TraceId:
-      - 62475a38d7857ca33838135c2887f1f0
+      - 624c4ad1f1e02398cf564807fae1583a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2726,7 +2762,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:38 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 3ed47a52671c702b
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 3ed47a52671c702b
+      X-B3-TraceId:
+      - 624c4ad19d54ec853ed47a52671c702b
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -2740,19 +2812,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:01 GMT
+      - Tue, 05 Apr 2022 13:57:38 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f7bb56f974bcc3db
+      - 8d7355306e6d901b
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f7bb56f974bcc3db
+      - 8d7355306e6d901b
       X-B3-TraceId:
-      - 62475a391d694495f7bb56f974bcc3db
+      - 624c4ad2e4616a1b8d7355306e6d901b
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2762,7 +2834,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -2776,20 +2848,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:01 GMT
+      - Tue, 05 Apr 2022 13:57:38 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - a38e87a54a2aadc6
+      - 8c304e19cdd7e48c
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a38e87a54a2aadc6
+      - 8c304e19cdd7e48c
       X-B3-TraceId:
-      - 62475a39d74f63d7a38e87a54a2aadc6
+      - 624c4ad2c47bb9dd8c304e19cdd7e48c
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:38 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 9b6f5109e1b4b41c
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 9b6f5109e1b4b41c
+      X-B3-TraceId:
+      - 624c4ad2a39114fc9b6f5109e1b4b41c
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2799,7 +2911,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:38 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 66bfdbd4cc055a4e
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 66bfdbd4cc055a4e
+      X-B3-TraceId:
+      - 624c4ad27ba3cbe566bfdbd4cc055a4e
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:38 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 8b5bfe5d1fad7035
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 8b5bfe5d1fad7035
+      X-B3-TraceId:
+      - 624c4ad2beb093588b5bfe5d1fad7035
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:38 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 31423fe46f1c96fd
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 31423fe46f1c96fd
+      X-B3-TraceId:
+      - 624c4ad23a63c7ec31423fe46f1c96fd
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:38 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 2f27d605de143c9d
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 2f27d605de143c9d
+      X-B3-TraceId:
+      - 624c4ad27657dc462f27d605de143c9d
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:38 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - d36a9819dadb9082
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - d36a9819dadb9082
+      X-B3-TraceId:
+      - 624c4ad2dea58595d36a9819dadb9082
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_e"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_e","remote":"origin","remote_name":"tmp_spectacles_e","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:38 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 4f0ac6590a07628b
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 4f0ac6590a07628b
+      X-B3-TraceId:
+      - 624c4ad28617fc934f0ac6590a07628b
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_e", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_e","remote":"origin","remote_name":"tmp_spectacles_e","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:39 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 79b96a43b888e738
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 79b96a43b888e738
+      X-B3-TraceId:
+      - 624c4ad3b5cc9bff79b96a43b888e738
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -2848,320 +3228,12 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:02:01 GMT
+      - Tue, 05 Apr 2022 13:57:39 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
-- request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:01 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - fc536f90203c6d40
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - fc536f90203c6d40
-      X-B3-TraceId:
-      - 62475a39c2037f1afc536f90203c6d40
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:01 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - d3babdf7465e0771
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - d3babdf7465e0771
-      X-B3-TraceId:
-      - 62475a39f637b3a3d3babdf7465e0771
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:01 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 4ddb7fd353b525ef
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 4ddb7fd353b525ef
-      X-B3-TraceId:
-      - 62475a39cd59e04b4ddb7fd353b525ef
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:01 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 86aea886f1fb6bc6
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 86aea886f1fb6bc6
-      X-B3-TraceId:
-      - 62475a395116996686aea886f1fb6bc6
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:01 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 225ab35190c1ad73
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 225ab35190c1ad73
-      X-B3-TraceId:
-      - 62475a39fa2a9fb8225ab35190c1ad73
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:02 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - ccc8ccbae9aa0f54
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - ccc8ccbae9aa0f54
-      X-B3-TraceId:
-      - 62475a395ff7488fccc8ccbae9aa0f54
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_e"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_e","remote":"origin","remote_name":"tmp_spectacles_e","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:02 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 2d6589b38a8c464e
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 2d6589b38a8c464e
-      X-B3-TraceId:
-      - 62475a3a065d5a1a2d6589b38a8c464e
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_e", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_e","remote":"origin","remote_name":"tmp_spectacles_e","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:02 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 898a71e74379422f
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 898a71e74379422f
-      X-B3-TraceId:
-      - 62475a3a870a4f35898a71e74379422f
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
 - request:
     body: '{"query_id": 2216, "result_format": "json_detail"}'
     headers:
@@ -3170,12 +3242,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"bdd83579a52da8f86655b930ce721fe2"}'
+      string: '{"id":"ce2d0fcb6635d37d6a84756e1f0641ca"}'
     headers:
       Connection:
       - keep-alive
@@ -3184,19 +3256,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:03 GMT
+      - Tue, 05 Apr 2022 13:57:40 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 090818a66593b76e
+      - 852e3226c0e7ae9a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 090818a66593b76e
+      - 852e3226c0e7ae9a
       X-B3-TraceId:
-      - 62475a3b68b35852090818a66593b76e
+      - 624c4ad3148c9615852e3226c0e7ae9a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3206,12 +3278,12 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=bdd83579a52da8f86655b930ce721fe2
+    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=ce2d0fcb6635d37d6a84756e1f0641ca
   response:
     body:
-      string: '{"bdd83579a52da8f86655b930ce721fe2":{"status":"added"}}'
+      string: '{"ce2d0fcb6635d37d6a84756e1f0641ca":{"status":"added"}}'
     headers:
       Connection:
       - keep-alive
@@ -3220,19 +3292,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:03 GMT
+      - Tue, 05 Apr 2022 13:57:40 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 10d4305a48746947
+      - 7435ce4bd47f3c46
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 10d4305a48746947
+      - 7435ce4bd47f3c46
       X-B3-TraceId:
-      - 62475a3b8959879910d4305a48746947
+      - 624c4ad4960ef3f77435ce4bd47f3c46
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3242,12 +3314,12 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=bdd83579a52da8f86655b930ce721fe2
+    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=ce2d0fcb6635d37d6a84756e1f0641ca
   response:
     body:
-      string: '{"bdd83579a52da8f86655b930ce721fe2":{"status":"running"}}'
+      string: '{"ce2d0fcb6635d37d6a84756e1f0641ca":{"status":"running"}}'
     headers:
       Connection:
       - keep-alive
@@ -3256,19 +3328,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:04 GMT
+      - Tue, 05 Apr 2022 13:57:40 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 31b7a1d9d5b797aa
+      - 27c454bd1305e0b5
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 31b7a1d9d5b797aa
+      - 27c454bd1305e0b5
       X-B3-TraceId:
-      - 62475a3c12e6ecc031b7a1d9d5b797aa
+      - 624c4ad4d107a13727c454bd1305e0b5
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3278,12 +3350,12 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=bdd83579a52da8f86655b930ce721fe2
+    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=ce2d0fcb6635d37d6a84756e1f0641ca
   response:
     body:
-      string: '{"bdd83579a52da8f86655b930ce721fe2":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"bdd83579a52da8f86655b930ce721fe2","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:02:04+00:00","aggregate_table_used_info":null,"runtime":"0.708","added_params":{"query_timezone":"America/New_York","sorts":["users.city"]},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":true,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_9hG2X3KwyV0xJplNKdfeMr5wmI_S"},"sql":"SELECT\n    users.city  AS
+      string: '{"ce2d0fcb6635d37d6a84756e1f0641ca":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"ce2d0fcb6635d37d6a84756e1f0641ca","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:57:40+00:00","aggregate_table_used_info":null,"runtime":"0.645","added_params":{"query_timezone":"America/New_York","sorts":["users.city"]},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":false,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_wyYYi9z7qiljwNK_I_J4gwhLyhHK"},"sql":"SELECT\n    users.city  AS
         users_city,\n    users.email  AS users_email,\n    users.first_name  AS users_first_name,\n    users.id
         + 10  AS users_id,\n    users.last_name  AS users_last_name,\n    users.state  AS
         users_state\nFROM looker-private-demo.ecomm.users\n     AS users\nWHERE (1
@@ -3301,29 +3373,29 @@ interactions:
         Name","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.last_name","suggest_explore":"users","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=38","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.last_name
         ","sql_case":null,"filters":null,"times_used":0},{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
         State","label_from_parameter":null,"label_short":"State","map_layer":{"url":"/data/us_states.topo-402e425f99.json","name":"us_states","feature_key":"usa","property_key":null,"property_label_key":null,"projection":"albersUsa","format":"","extents_json_url":null,"max_zoom_level":null,"min_zoom_level":null},"name":"users.state","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users","view_label":"Users","dynamic":false,"week_start_day":"monday","original_view":"users","dimension_group":null,"error":null,"field_group_variant":"State","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.state","suggest_explore":"users","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=18","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.state
-        ","sql_case":null,"filters":null,"times_used":0}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users","label":"Users","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.06826700000000001,"has_subtotals":false}}}'
+        ","sql_case":null,"filters":null,"times_used":0}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users","label":"Users","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.06631200000000001,"has_subtotals":false}}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '9245'
+      - '9246'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:04 GMT
+      - Tue, 05 Apr 2022 13:57:41 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 544d8cde48716162
+      - 88aab2cf5a0e65e2
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 544d8cde48716162
+      - 88aab2cf5a0e65e2
       X-B3-TraceId:
-      - 62475a3ca29e1d06544d8cde48716162
+      - 624c4ad566ee5ecc88aab2cf5a0e65e2
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3337,7 +3409,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3351,20 +3423,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:06 GMT
+      - Tue, 05 Apr 2022 13:57:42 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 434703b72e7c1564
+      - ad37414580868180
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 434703b72e7c1564
+      - ad37414580868180
       X-B3-TraceId:
-      - 62475a3d25d39672434703b72e7c1564
+      - 624c4ad565531e5ead37414580868180
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3376,7 +3448,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_e
   response:
@@ -3386,19 +3458,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:02:06 GMT
+      - Tue, 05 Apr 2022 13:57:42 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - c654ffd3be23aa92
+      - a637056acb0d2386
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - c654ffd3be23aa92
+      - a637056acb0d2386
       X-B3-TraceId:
-      - 62475a3e34900656c654ffd3be23aa92
+      - 624c4ad6e797ac96a637056acb0d2386
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3412,7 +3484,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3426,20 +3498,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:06 GMT
+      - Tue, 05 Apr 2022 13:57:43 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 102324945ebbf41a
+      - 410e929dd0af2b46
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 102324945ebbf41a
+      - 410e929dd0af2b46
       X-B3-TraceId:
-      - 62475a3e5c11af16102324945ebbf41a
+      - 624c4ad6fe34d098410e929dd0af2b46
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3453,7 +3525,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3467,19 +3539,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:06 GMT
+      - Tue, 05 Apr 2022 13:57:43 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - cbe2c905fbf49e8d
+      - be5f516a674f4fca
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - cbe2c905fbf49e8d
+      - be5f516a674f4fca
       X-B3-TraceId:
-      - 62475a3eac5213f9cbe2c905fbf49e8d
+      - 624c4ad75b593034be5f516a674f4fca
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3493,7 +3565,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3507,19 +3579,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:06 GMT
+      - Tue, 05 Apr 2022 13:57:43 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - d09125ba757f5494
+      - aa63f69eaf7ded29
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - d09125ba757f5494
+      - aa63f69eaf7ded29
       X-B3-TraceId:
-      - 62475a3e380d7d24d09125ba757f5494
+      - 624c4ad7d5f2b263aa63f69eaf7ded29
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3529,7 +3601,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3543,19 +3615,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:07 GMT
+      - Tue, 05 Apr 2022 13:57:43 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 71378ff34f5e4e2d
+      - c6314be732f5dfe5
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 71378ff34f5e4e2d
+      - c6314be732f5dfe5
       X-B3-TraceId:
-      - 62475a3fb1bee4f271378ff34f5e4e2d
+      - 624c4ad7437cd9e8c6314be732f5dfe5
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3565,7 +3637,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -3579,20 +3651,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:07 GMT
+      - Tue, 05 Apr 2022 13:57:43 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 4f3f2e3a84115748
+      - b55ccf74cf4620e5
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 4f3f2e3a84115748
+      - b55ccf74cf4620e5
       X-B3-TraceId:
-      - 62475a3fae57a2734f3f2e3a84115748
+      - 624c4ad717d8a7eab55ccf74cf4620e5
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3606,7 +3678,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -3620,20 +3692,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:07 GMT
+      - Tue, 05 Apr 2022 13:57:44 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 2f373b451e9a3865
+      - 747bfa3269838b8a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2f373b451e9a3865
+      - 747bfa3269838b8a
       X-B3-TraceId:
-      - 62475a3fc5a068af2f373b451e9a3865
+      - 624c4ad7a0200a93747bfa3269838b8a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3647,7 +3719,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -3661,20 +3733,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:08 GMT
+      - Tue, 05 Apr 2022 13:57:44 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 98de73aca936be7d
+      - c5381f1c22803d30
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 98de73aca936be7d
+      - c5381f1c22803d30
       X-B3-TraceId:
-      - 62475a3f40c3659298de73aca936be7d
+      - 624c4ad8b5230640c5381f1c22803d30
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3684,7 +3756,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:44 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 0204fd7e32c58352
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 0204fd7e32c58352
+      X-B3-TraceId:
+      - 624c4ad8e4f879ae0204fd7e32c58352
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3698,19 +3806,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:08 GMT
+      - Tue, 05 Apr 2022 13:57:44 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 983e8310f31b7fc0
+      - e1516098d19001a4
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 983e8310f31b7fc0
+      - e1516098d19001a4
       X-B3-TraceId:
-      - 62475a405f5359f3983e8310f31b7fc0
+      - 624c4ad89a4f744ae1516098d19001a4
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3720,7 +3828,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3734,84 +3842,25 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:08 GMT
+      - Tue, 05 Apr 2022 13:57:44 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - a0d706954ef0c56b
+      - 3d768f990dbf3181
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a0d706954ef0c56b
+      - 3d768f990dbf3181
       X-B3-TraceId:
-      - 62475a4003996a2fa0d706954ef0c56b
+      - 624c4ad82e1cb6b73d768f990dbf3181
       X-Content-Type-Options:
       - nosniff
     status:
       code: 200
       message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
-  response:
-    body:
-      string: "<!DOCTYPE html>\n<html>\n<head>\n    <title>Looker Not Found (404)</title>\n
-        \   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600'
-        rel='stylesheet' type='text/css'>\n\n    <!-- @@@@@@@@@@@@@ FAVICONS @@@@@@@@@@@@@
-        -->\n\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"57x57\" href=\"https://wwwstatic-b.lookercdn.com/favicon/apple-touch-icon-57x57.png\"
-        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"114x114\" href=\"https://wwwstatic-c.lookercdn.com/favicon/apple-touch-icon-114x114.png\"
-        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"72x72\" href=\"https://wwwstatic-d.lookercdn.com/favicon/apple-touch-icon-72x72.png\"
-        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"144x144\" href=\"https://wwwstatic-a.lookercdn.com/favicon/apple-touch-icon-144x144.png\"
-        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"60x60\" href=\"https://wwwstatic-b.lookercdn.com/favicon/apple-touch-icon-60x60.png\"
-        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"120x120\" href=\"https://wwwstatic-c.lookercdn.com/favicon/apple-touch-icon-120x120.png\"
-        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"76x76\" href=\"https://wwwstatic-d.lookercdn.com/favicon/apple-touch-icon-76x76.png\"
-        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"152x152\" href=\"https://wwwstatic-a.lookercdn.com/favicon/apple-touch-icon-152x152.png\"
-        />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-b.lookercdn.com/favicon/favicon-196x196.png\"
-        sizes=\"196x196\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-c.lookercdn.com/favicon/favicon-96x96.png\"
-        sizes=\"96x96\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-d.lookercdn.com/favicon/favicon-32x32.png\"
-        sizes=\"32x32\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-a.lookercdn.com/favicon/favicon-16x16.png\"
-        sizes=\"16x16\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-b.lookercdn.com/favicon/favicon-128.png\"
-        sizes=\"128x128\" />\n    <meta name=\"application-name\" content=\"Looker\"/>\n
-        \   <meta name=\"msapplication-TileColor\" content=\"#FFFFFF\" />\n    <meta
-        name=\"msapplication-TileImage\" content=\"https://wwwstatic-c.lookercdn.com/favicon/mstile-144x144.png\"
-        />\n    <meta name=\"msapplication-square70x70logo\" content=\"https://wwwstatic-d.lookercdn.com/favicon/mstile-70x70.png\"
-        />\n    <meta name=\"msapplication-square150x150logo\" content=\"https://wwwstatic-a.lookercdn.com/favicon/mstile-150x150.png\"
-        />\n    <meta name=\"msapplication-wide310x150logo\" content=\"https://wwwstatic-b.lookercdn.com/favicon/mstile-310x150.png\"
-        />\n    <meta name=\"msapplication-square310x310logo\" content=\"https://wwwstatic-c.lookercdn.com/favicon/mstile-310x310.png\"
-        />\n\n    <style type=\"text/css\">\n        body {\n            background-color:
-        #2e343f;\n            color: white;\n            height: auto;\n            font-family:
-        Open Sans, Helvetica, Arial, sans-serif;\n        }\n        .message {\n
-        \           width: 100%;\n            max-width: 760px;\n            margin:
-        0 auto;\n            margin-top: 135px;\n            text-align: center;\n
-        \       }\n        h2, h3 {\n            font-weight: normal;\n        }\n
-        \       a {\n            color: white;\n        }\n    </style>\n</head>\n<body>\n\n
-        \   <div class=\"message\">\n\n        <img width=\"210\" height=\"84\" src=\"https://wwwstatic-a.lookercdn.com/logos/looker_all_white.svg\"
-        alt=\"Looker\">\n\n        <h1>Looker is unavailable.</h1>\n\n        <h2>If
-        you typed in a URL, double-check the spelling.</h2>\n        <h2>This may
-        also be due to a temporary condition such as an outage, <a href=\"https://docs.looker.com/relnotes/hosted-maintenance-hours\">scheduled
-        maintenance</a> or upgrade.</h2>\n        <br>\n        <h3>\n            If
-        this message persists or you have any concerns, <br> contact us from\n            <a
-        href=\"https://help.looker.com\">help.looker.com</a> and we'll respond promptly.\n
-        \       </h3>\n\n    </div>\n\n</body>\n</html>\n"
-    headers:
-      Connection:
-      - close
-      Content-Type:
-      - text/html
-      Date:
-      - Fri, 01 Apr 2022 20:02:08 GMT
-      Vary:
-      - Accept-Encoding
-    status:
-      code: 404
-      message: Not Found
 - request:
     body: '{"workspace_id": "production"}'
     headers:
@@ -3820,7 +3869,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3834,19 +3883,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:08 GMT
+      - Tue, 05 Apr 2022 13:57:44 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 61df77ae0ceb60e4
+      - 2bf813cfd309a091
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 61df77ae0ceb60e4
+      - 2bf813cfd309a091
       X-B3-TraceId:
-      - 62475a403126d2ce61df77ae0ceb60e4
+      - 624c4ad8da42c6212bf813cfd309a091
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3856,7 +3905,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3870,19 +3919,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:08 GMT
+      - Tue, 05 Apr 2022 13:57:45 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 72c3fdf42f461fb0
+      - 3a1c22be968499af
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 72c3fdf42f461fb0
+      - 3a1c22be968499af
       X-B3-TraceId:
-      - 62475a4077f9b40d72c3fdf42f461fb0
+      - 624c4ad974df0d4d3a1c22be968499af
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3892,7 +3941,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3906,20 +3955,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:08 GMT
+      - Tue, 05 Apr 2022 13:57:45 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 0a38b1e78ad56a48
+      - 74237ac140fa6ae3
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 0a38b1e78ad56a48
+      - 74237ac140fa6ae3
       X-B3-TraceId:
-      - 62475a40dbc191950a38b1e78ad56a48
+      - 624c4ad9f091136274237ac140fa6ae3
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3933,7 +3982,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3947,19 +3996,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:08 GMT
+      - Tue, 05 Apr 2022 13:57:45 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 906645296a1d09a3
+      - 79d076dca66c782a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 906645296a1d09a3
+      - 79d076dca66c782a
       X-B3-TraceId:
-      - 62475a409c83444f906645296a1d09a3
+      - 624c4ad95394f37279d076dca66c782a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3969,7 +4018,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3983,19 +4032,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:08 GMT
+      - Tue, 05 Apr 2022 13:57:45 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 7492007f825715dd
+      - cc383467dd7664ea
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 7492007f825715dd
+      - cc383467dd7664ea
       X-B3-TraceId:
-      - 62475a4055d0752b7492007f825715dd
+      - 624c4ad905ae177fcc383467dd7664ea
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4005,7 +4054,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -4019,20 +4068,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:08 GMT
+      - Tue, 05 Apr 2022 13:57:45 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 7eb9db1aa91fd909
+      - 809b085148231bfd
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 7eb9db1aa91fd909
+      - 809b085148231bfd
       X-B3-TraceId:
-      - 62475a40275f598a7eb9db1aa91fd909
+      - 624c4ad99af5e866809b085148231bfd
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4046,7 +4095,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -4060,20 +4109,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:09 GMT
+      - Tue, 05 Apr 2022 13:57:45 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 6d4c500e3d34ea1d
+      - a91bdcead3754d60
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6d4c500e3d34ea1d
+      - a91bdcead3754d60
       X-B3-TraceId:
-      - 62475a41d5d9b77e6d4c500e3d34ea1d
+      - 624c4ad9b9ddeb05a91bdcead3754d60
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4087,7 +4136,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -4101,291 +4150,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:09 GMT
+      - Tue, 05 Apr 2022 13:57:46 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - afb3b74875958b91
+      - 95111b0a289c4434
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - afb3b74875958b91
+      - 95111b0a289c4434
       X-B3-TraceId:
-      - 62475a41b5ab85baafb3b74875958b91
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "pytest-incremental-valid-diff"}'
-    headers:
-      Content-Length:
-      - '41'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
-  response:
-    body:
-      string: '{"name":"pytest-incremental-valid-diff","remote":"origin","remote_name":"pytest-incremental-valid-diff","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '409'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:10 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 41c7c73850360d32
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 41c7c73850360d32
-      X-B3-TraceId:
-      - 62475a420c1596ea41c7c73850360d32
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Content-Length:
-      - '0'
-      Cookie:
-      - looker.browser=9881689
-    method: DELETE
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_f
-  response:
-    body:
-      string: ''
-    headers:
-      Connection:
-      - keep-alive
-      Date:
-      - Fri, 01 Apr 2022 20:02:10 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Origin
-      X-B3-ParentSpanId:
-      - 91bd99b1d3e37777
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 91bd99b1d3e37777
-      X-B3-TraceId:
-      - 62475a427c9222f691bd99b1d3e37777
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: '{"name": "tmp_spectacles_5e52c0302c"}'
-    headers:
-      Content-Length:
-      - '37'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:11 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - faa483bd7752882f
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - faa483bd7752882f
-      X-B3-TraceId:
-      - 62475a42e7af393ffaa483bd7752882f
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Content-Length:
-      - '0'
-      Cookie:
-      - looker.browser=9881689
-    method: DELETE
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_g
-  response:
-    body:
-      string: ''
-    headers:
-      Connection:
-      - keep-alive
-      Date:
-      - Fri, 01 Apr 2022 20:02:11 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Origin
-      X-B3-ParentSpanId:
-      - 46a5f5b501bc7729
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 46a5f5b501bc7729
-      X-B3-TraceId:
-      - 62475a43b3b3531846a5f5b501bc7729
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: '{"name": "tmp_spectacles_5e52c0302c"}'
-    headers:
-      Content-Length:
-      - '37'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:12 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 9cd884cae0662235
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 9cd884cae0662235
-      X-B3-TraceId:
-      - 62475a4395c1fc699cd884cae0662235
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:12 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 42569839557aeacf
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 42569839557aeacf
-      X-B3-TraceId:
-      - 62475a449e90776a42569839557aeacf
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:12 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - cfa45014f0b8944c
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - cfa45014f0b8944c
-      X-B3-TraceId:
-      - 62475a44b5f291b6cfa45014f0b8944c
+      - 624c4ad9ea86ecf695111b0a289c4434
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4395,235 +4173,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:12 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 4419a66799bbcf6f
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 4419a66799bbcf6f
-      X-B3-TraceId:
-      - 62475a440a98517a4419a66799bbcf6f
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
-  response:
-    body:
-      string: '{"name":"pytest-incremental-valid-diff","remote":"origin","remote_name":"pytest-incremental-valid-diff","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '409'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:12 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - efffab1c184dc91b
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - efffab1c184dc91b
-      X-B3-TraceId:
-      - 62475a44c517140eefffab1c184dc91b
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_h"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_h","remote":"origin","remote_name":"tmp_spectacles_h","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:13 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - b3736f25187cebe6
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - b3736f25187cebe6
-      X-B3-TraceId:
-      - 62475a445c27dac7b3736f25187cebe6
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_h", "ref": "b0823dad6abb07bf26e468bf91e7c6531c758e32"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_h","remote":"origin","remote_name":"tmp_spectacles_h","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:15 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - c086fa2d1044e631
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - c086fa2d1044e631
-      X-B3-TraceId:
-      - 62475a45e304e462c086fa2d1044e631
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:15 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - a570af4983bf0a04
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - a570af4983bf0a04
-      X-B3-TraceId:
-      - 62475a479a1765fca570af4983bf0a04
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:15 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 11ed38fd19aeae63
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 11ed38fd19aeae63
-      X-B3-TraceId:
-      - 62475a47f00ccc6811ed38fd19aeae63
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -4672,320 +4222,12 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:02:15 GMT
+      - Tue, 05 Apr 2022 13:57:46 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
-- request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:15 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 7cae7247cdc1ce33
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 7cae7247cdc1ce33
-      X-B3-TraceId:
-      - 62475a47385c9d577cae7247cdc1ce33
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:15 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - d4dd36e558a2a13e
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - d4dd36e558a2a13e
-      X-B3-TraceId:
-      - 62475a47b1037d43d4dd36e558a2a13e
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:15 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - eacc484a2ce78e49
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - eacc484a2ce78e49
-      X-B3-TraceId:
-      - 62475a470d5c7357eacc484a2ce78e49
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:15 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 830d5adcba1d3441
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 830d5adcba1d3441
-      X-B3-TraceId:
-      - 62475a4794d71b15830d5adcba1d3441
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:15 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 94e907a6e0bff94b
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 94e907a6e0bff94b
-      X-B3-TraceId:
-      - 62475a47eeb3653394e907a6e0bff94b
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:15 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 6481a950d3dfec1a
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 6481a950d3dfec1a
-      X-B3-TraceId:
-      - 62475a4738652d4b6481a950d3dfec1a
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_i"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_i","remote":"origin","remote_name":"tmp_spectacles_i","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:16 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - c188e3221725dbbe
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - c188e3221725dbbe
-      X-B3-TraceId:
-      - 62475a48072769fdc188e3221725dbbe
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_i", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_i","remote":"origin","remote_name":"tmp_spectacles_i","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:02:16 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 887fb35217b8088c
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 887fb35217b8088c
-      X-B3-TraceId:
-      - 62475a48ff7b8544887fb35217b8088c
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
 - request:
     body: '{"name": "pytest-incremental-valid-diff"}'
     headers:
@@ -4994,7 +4236,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -5008,20 +4250,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:17 GMT
+      - Tue, 05 Apr 2022 13:57:47 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - a0675db16b82739a
+      - 8aaad7b4edcd270c
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a0675db16b82739a
+      - 8aaad7b4edcd270c
       X-B3-TraceId:
-      - 62475a4977a87dafa0675db16b82739a
+      - 624c4ada170b77038aaad7b4edcd270c
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5033,9 +4275,9 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_h
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_f
   response:
     body:
       string: ''
@@ -5043,19 +4285,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:02:18 GMT
+      - Tue, 05 Apr 2022 13:57:47 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 1ad769c5fcffe513
+      - b0748a6dfa0b969f
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 1ad769c5fcffe513
+      - b0748a6dfa0b969f
       X-B3-TraceId:
-      - 62475a4930638bdb1ad769c5fcffe513
+      - 624c4adbab15f4edb0748a6dfa0b969f
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5069,7 +4311,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -5083,20 +4325,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:19 GMT
+      - Tue, 05 Apr 2022 13:57:48 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - a29810ad6ae849a5
+      - ed4e2218098ec637
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a29810ad6ae849a5
+      - ed4e2218098ec637
       X-B3-TraceId:
-      - 62475a4a2fc7b021a29810ad6ae849a5
+      - 624c4adbc621cdd4ed4e2218098ec637
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5108,9 +4350,9 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_i
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_g
   response:
     body:
       string: ''
@@ -5118,19 +4360,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:02:19 GMT
+      - Tue, 05 Apr 2022 13:57:48 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 495a0105920b7dfe
+      - 32c68f856c14310b
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 495a0105920b7dfe
+      - 32c68f856c14310b
       X-B3-TraceId:
-      - 62475a4b31b1dbff495a0105920b7dfe
+      - 624c4adc28e45c8732c68f856c14310b
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5144,7 +4386,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -5158,20 +4400,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:20 GMT
+      - Tue, 05 Apr 2022 13:57:48 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 62ba5525dd3ac2e3
+      - 3aeb120476783c78
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 62ba5525dd3ac2e3
+      - 3aeb120476783c78
       X-B3-TraceId:
-      - 62475a4ba9f3353562ba5525dd3ac2e3
+      - 624c4adcd0882d653aeb120476783c78
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5185,7 +4427,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -5199,19 +4441,921 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:20 GMT
+      - Tue, 05 Apr 2022 13:57:48 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 7b4e01a6a037c240
+      - 647af9bf7c0acc2a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 7b4e01a6a037c240
+      - 647af9bf7c0acc2a
       X-B3-TraceId:
-      - 62475a4c1cd537197b4e01a6a037c240
+      - 624c4adcb5f6b207647af9bf7c0acc2a
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:49 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - accc89da16642d09
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - accc89da16642d09
+      X-B3-TraceId:
+      - 624c4adc0472f971accc89da16642d09
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:49 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 49e1cd7ccca61874
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 49e1cd7ccca61874
+      X-B3-TraceId:
+      - 624c4addbc8f5f6b49e1cd7ccca61874
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
+  response:
+    body:
+      string: '{"name":"pytest-incremental-valid-diff","remote":"origin","remote_name":"pytest-incremental-valid-diff","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '409'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:49 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 3c1cc917d03b6ca8
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 3c1cc917d03b6ca8
+      X-B3-TraceId:
+      - 624c4adda3ef16a03c1cc917d03b6ca8
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_h"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_h","remote":"origin","remote_name":"tmp_spectacles_h","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:49 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - cf7156d1fa135d19
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - cf7156d1fa135d19
+      X-B3-TraceId:
+      - 624c4addec53c34dcf7156d1fa135d19
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_h", "ref": "b0823dad6abb07bf26e468bf91e7c6531c758e32"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_h","remote":"origin","remote_name":"tmp_spectacles_h","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:51 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 6e3e5f7b86acffae
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 6e3e5f7b86acffae
+      X-B3-TraceId:
+      - 624c4add6449c52c6e3e5f7b86acffae
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:51 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - ec51dcad82feb3f5
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - ec51dcad82feb3f5
+      X-B3-TraceId:
+      - 624c4adf9376926cec51dcad82feb3f5
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:51 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 247456ecb794108b
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 247456ecb794108b
+      X-B3-TraceId:
+      - 624c4adf5c45be6f247456ecb794108b
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:51 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - ee989d03872763c7
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - ee989d03872763c7
+      X-B3-TraceId:
+      - 624c4adf3f71396aee989d03872763c7
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:51 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 6a4d2123af673583
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 6a4d2123af673583
+      X-B3-TraceId:
+      - 624c4adfb7ad90016a4d2123af673583
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:51 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - cca844c8943d447f
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - cca844c8943d447f
+      X-B3-TraceId:
+      - 624c4adf3c2bab03cca844c8943d447f
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:52 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 1eb9bd0c5aa05c5d
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 1eb9bd0c5aa05c5d
+      X-B3-TraceId:
+      - 624c4ae0fdab16651eb9bd0c5aa05c5d
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:52 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 3cda44da66d9dd23
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 3cda44da66d9dd23
+      X-B3-TraceId:
+      - 624c4ae098dba26f3cda44da66d9dd23
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:52 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 29dee437373c4b6c
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 29dee437373c4b6c
+      X-B3-TraceId:
+      - 624c4ae0ddf0325d29dee437373c4b6c
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:52 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - bb8c8f3590e247e0
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - bb8c8f3590e247e0
+      X-B3-TraceId:
+      - 624c4ae0d969654fbb8c8f3590e247e0
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_i"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_i","remote":"origin","remote_name":"tmp_spectacles_i","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:52 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - bb3063b0f528bf80
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - bb3063b0f528bf80
+      X-B3-TraceId:
+      - 624c4ae08cade18abb3063b0f528bf80
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_i", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_i","remote":"origin","remote_name":"tmp_spectacles_i","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:53 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - b8e854706d9046b2
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - b8e854706d9046b2
+      X-B3-TraceId:
+      - 624c4ae0fa259524b8e854706d9046b2
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html>\n<head>\n    <title>Looker Not Found (404)</title>\n
+        \   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600'
+        rel='stylesheet' type='text/css'>\n\n    <!-- @@@@@@@@@@@@@ FAVICONS @@@@@@@@@@@@@
+        -->\n\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"57x57\" href=\"https://wwwstatic-b.lookercdn.com/favicon/apple-touch-icon-57x57.png\"
+        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"114x114\" href=\"https://wwwstatic-c.lookercdn.com/favicon/apple-touch-icon-114x114.png\"
+        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"72x72\" href=\"https://wwwstatic-d.lookercdn.com/favicon/apple-touch-icon-72x72.png\"
+        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"144x144\" href=\"https://wwwstatic-a.lookercdn.com/favicon/apple-touch-icon-144x144.png\"
+        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"60x60\" href=\"https://wwwstatic-b.lookercdn.com/favicon/apple-touch-icon-60x60.png\"
+        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"120x120\" href=\"https://wwwstatic-c.lookercdn.com/favicon/apple-touch-icon-120x120.png\"
+        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"76x76\" href=\"https://wwwstatic-d.lookercdn.com/favicon/apple-touch-icon-76x76.png\"
+        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"152x152\" href=\"https://wwwstatic-a.lookercdn.com/favicon/apple-touch-icon-152x152.png\"
+        />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-b.lookercdn.com/favicon/favicon-196x196.png\"
+        sizes=\"196x196\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-c.lookercdn.com/favicon/favicon-96x96.png\"
+        sizes=\"96x96\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-d.lookercdn.com/favicon/favicon-32x32.png\"
+        sizes=\"32x32\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-a.lookercdn.com/favicon/favicon-16x16.png\"
+        sizes=\"16x16\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-b.lookercdn.com/favicon/favicon-128.png\"
+        sizes=\"128x128\" />\n    <meta name=\"application-name\" content=\"Looker\"/>\n
+        \   <meta name=\"msapplication-TileColor\" content=\"#FFFFFF\" />\n    <meta
+        name=\"msapplication-TileImage\" content=\"https://wwwstatic-c.lookercdn.com/favicon/mstile-144x144.png\"
+        />\n    <meta name=\"msapplication-square70x70logo\" content=\"https://wwwstatic-d.lookercdn.com/favicon/mstile-70x70.png\"
+        />\n    <meta name=\"msapplication-square150x150logo\" content=\"https://wwwstatic-a.lookercdn.com/favicon/mstile-150x150.png\"
+        />\n    <meta name=\"msapplication-wide310x150logo\" content=\"https://wwwstatic-b.lookercdn.com/favicon/mstile-310x150.png\"
+        />\n    <meta name=\"msapplication-square310x310logo\" content=\"https://wwwstatic-c.lookercdn.com/favicon/mstile-310x310.png\"
+        />\n\n    <style type=\"text/css\">\n        body {\n            background-color:
+        #2e343f;\n            color: white;\n            height: auto;\n            font-family:
+        Open Sans, Helvetica, Arial, sans-serif;\n        }\n        .message {\n
+        \           width: 100%;\n            max-width: 760px;\n            margin:
+        0 auto;\n            margin-top: 135px;\n            text-align: center;\n
+        \       }\n        h2, h3 {\n            font-weight: normal;\n        }\n
+        \       a {\n            color: white;\n        }\n    </style>\n</head>\n<body>\n\n
+        \   <div class=\"message\">\n\n        <img width=\"210\" height=\"84\" src=\"https://wwwstatic-a.lookercdn.com/logos/looker_all_white.svg\"
+        alt=\"Looker\">\n\n        <h1>Looker is unavailable.</h1>\n\n        <h2>If
+        you typed in a URL, double-check the spelling.</h2>\n        <h2>This may
+        also be due to a temporary condition such as an outage, <a href=\"https://docs.looker.com/relnotes/hosted-maintenance-hours\">scheduled
+        maintenance</a> or upgrade.</h2>\n        <br>\n        <h3>\n            If
+        this message persists or you have any concerns, <br> contact us from\n            <a
+        href=\"https://help.looker.com\">help.looker.com</a> and we'll respond promptly.\n
+        \       </h3>\n\n    </div>\n\n</body>\n</html>\n"
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - text/html
+      Date:
+      - Tue, 05 Apr 2022 13:57:53 GMT
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: '{"name": "pytest-incremental-valid-diff"}'
+    headers:
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
+  response:
+    body:
+      string: '{"name":"pytest-incremental-valid-diff","remote":"origin","remote_name":"pytest-incremental-valid-diff","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '409'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:54 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 8fd2504bde739f04
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 8fd2504bde739f04
+      X-B3-TraceId:
+      - 624c4ae1869867cf8fd2504bde739f04
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Content-Length:
+      - '0'
+      Cookie:
+      - looker.browser=39326198
+    method: DELETE
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_h
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 05 Apr 2022 13:57:55 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Origin
+      X-B3-ParentSpanId:
+      - 5dbb13eafdb22df7
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 5dbb13eafdb22df7
+      X-B3-TraceId:
+      - 624c4ae26f1080535dbb13eafdb22df7
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{"name": "tmp_spectacles_5e52c0302c"}'
+    headers:
+      Content-Length:
+      - '37'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:55 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 8ac8ca704c54e305
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 8ac8ca704c54e305
+      X-B3-TraceId:
+      - 624c4ae323c6b5158ac8ca704c54e305
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Content-Length:
+      - '0'
+      Cookie:
+      - looker.browser=39326198
+    method: DELETE
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_i
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 05 Apr 2022 13:57:55 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Origin
+      X-B3-ParentSpanId:
+      - ba5bb6e44fac0897
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - ba5bb6e44fac0897
+      X-B3-TraceId:
+      - 624c4ae37f9ccc53ba5bb6e44fac0897
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{"name": "tmp_spectacles_5e52c0302c"}'
+    headers:
+      Content-Length:
+      - '37'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:56 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 62fc9a23eda8a7bd
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 62fc9a23eda8a7bd
+      X-B3-TraceId:
+      - 624c4ae351d2b6a462fc9a23eda8a7bd
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:56 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 91e7cd211cac238f
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 91e7cd211cac238f
+      X-B3-TraceId:
+      - 624c4ae44b23befe91e7cd211cac238f
       X-Content-Type-Options:
       - nosniff
     status:

--- a/tests/cassettes/test_runner/test_incremental_sql_with_equal_explores_should_not_error.yaml
+++ b/tests/cassettes/test_runner/test_incremental_sql_with_equal_explores_should_not_error.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -17,19 +17,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:26 GMT
+      - Tue, 05 Apr 2022 13:57:56 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 67e5d3c40a3d7358
+      - a0113ee867997231
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 67e5d3c40a3d7358
+      - a0113ee867997231
       X-B3-TraceId:
-      - 62475aca8597d3bd67e5d3c40a3d7358
+      - 624c4ae43ebae813a0113ee867997231
       X-Content-Type-Options:
       - nosniff
     status:
@@ -39,7 +39,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -53,56 +53,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:26 GMT
+      - Tue, 05 Apr 2022 13:57:56 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f86645372fa0acdd
+      - 2c5e5d1b4a41d641
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f86645372fa0acdd
+      - 2c5e5d1b4a41d641
       X-B3-TraceId:
-      - 62475acaa5fa0928f86645372fa0acdd
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
-  response:
-    body:
-      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '147'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:26 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - f62183a59b93fc9b
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - f62183a59b93fc9b
-      X-B3-TraceId:
-      - 62475acad1539338f62183a59b93fc9b
+      - 624c4ae4c57a11412c5e5d1b4a41d641
       X-Content-Type-Options:
       - nosniff
     status:
@@ -116,7 +80,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -130,19 +94,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:27 GMT
+      - Tue, 05 Apr 2022 13:57:56 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 6ec7c6beb54557d2
+      - eec387e0f0e08f20
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6ec7c6beb54557d2
+      - eec387e0f0e08f20
       X-B3-TraceId:
-      - 62475aca343cfe796ec7c6beb54557d2
+      - 624c4ae45d273f5deec387e0f0e08f20
       X-Content-Type-Options:
       - nosniff
     status:
@@ -152,7 +116,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -166,19 +130,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:27 GMT
+      - Tue, 05 Apr 2022 13:57:56 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 30d0931a477f0255
+      - 9c2e1f21c76191f7
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 30d0931a477f0255
+      - 9c2e1f21c76191f7
       X-B3-TraceId:
-      - 62475acb982daab230d0931a477f0255
+      - 624c4ae4223fe7439c2e1f21c76191f7
       X-Content-Type-Options:
       - nosniff
     status:
@@ -188,34 +152,34 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest-incremental-invalid-equal","remote":"origin","remote_name":"pytest-incremental-invalid-equal","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648842827,"ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","remote_ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","can":{}}'
+      string: '{"name":"pytest-incremental-valid-diff","remote":"origin","remote_name":"pytest-incremental-valid-diff","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","can":{}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '415'
+      - '409'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:27 GMT
+      - Tue, 05 Apr 2022 13:57:57 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 927edf727a4df6cc
+      - 7acd292e99bd0800
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 927edf727a4df6cc
+      - 7acd292e99bd0800
       X-B3-TraceId:
-      - 62475acb7df7d133927edf727a4df6cc
+      - 624c4ae4edce400e7acd292e99bd0800
       X-Content-Type-Options:
       - nosniff
     status:
@@ -229,12 +193,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648842827,"ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","remote_ref":null,"can":{}}'
+      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":null,"can":{}}'
     headers:
       Connection:
       - keep-alive
@@ -243,20 +207,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:27 GMT
+      - Tue, 05 Apr 2022 13:57:57 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - ae15bd38d5013832
+      - c255f3a3c05a38b8
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - ae15bd38d5013832
+      - c255f3a3c05a38b8
       X-B3-TraceId:
-      - 62475acbf0743b07ae15bd38d5013832
+      - 624c4ae5c60d9220c255f3a3c05a38b8
       X-Content-Type-Options:
       - nosniff
     status:
@@ -270,12 +234,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648842827,"ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","remote_ref":null,"can":{}}'
+      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":null,"can":{}}'
     headers:
       Connection:
       - keep-alive
@@ -284,20 +248,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:29 GMT
+      - Tue, 05 Apr 2022 13:57:59 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f5f6d371495cf140
+      - 92768bd41a705c2f
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f5f6d371495cf140
+      - 92768bd41a705c2f
       X-B3-TraceId:
-      - 62475acb4ac255daf5f6d371495cf140
+      - 624c4ae56af2655992768bd41a705c2f
       X-Content-Type-Options:
       - nosniff
     status:
@@ -307,7 +271,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:59 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 482e69e16f1ecb50
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 482e69e16f1ecb50
+      X-B3-TraceId:
+      - 624c4ae75e00b9b8482e69e16f1ecb50
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -321,19 +321,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:29 GMT
+      - Tue, 05 Apr 2022 13:57:59 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 03d8eaef376da4ca
+      - 7e65bdffebb66af8
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 03d8eaef376da4ca
+      - 7e65bdffebb66af8
       X-B3-TraceId:
-      - 62475acd3e3aaef703d8eaef376da4ca
+      - 624c4ae763795a567e65bdffebb66af8
       X-Content-Type-Options:
       - nosniff
     status:
@@ -343,7 +343,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -357,20 +357,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:29 GMT
+      - Tue, 05 Apr 2022 13:57:59 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - edd173464dc38192
+      - 96a2209664718944
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - edd173464dc38192
+      - 96a2209664718944
       X-B3-TraceId:
-      - 62475acdc0beb302edd173464dc38192
+      - 624c4ae77096f26c96a2209664718944
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:59 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - ac972374aa0a744d
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - ac972374aa0a744d
+      X-B3-TraceId:
+      - 624c4ae7b94f17c6ac972374aa0a744d
       X-Content-Type-Options:
       - nosniff
     status:
@@ -380,7 +420,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:59 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - fe842f015127a949
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - fe842f015127a949
+      X-B3-TraceId:
+      - 624c4ae714bd8596fe842f015127a949
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:59 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 0c7f6642de5a7bf2
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 0c7f6642de5a7bf2
+      X-B3-TraceId:
+      - 624c4ae7668820cd0c7f6642de5a7bf2
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:57:59 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - b106aae5692ec01f
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - b106aae5692ec01f
+      X-B3-TraceId:
+      - 624c4ae70d359f7ab106aae5692ec01f
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:00 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 1d3918ea38ce1fda
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 1d3918ea38ce1fda
+      X-B3-TraceId:
+      - 624c4ae8558d36d01d3918ea38ce1fda
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:00 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 2d5cfe29e6fa157d
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 2d5cfe29e6fa157d
+      X-B3-TraceId:
+      - 624c4ae8be282d9f2d5cfe29e6fa157d
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_b"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:00 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 4a6656c3681ac486
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 4a6656c3681ac486
+      X-B3-TraceId:
+      - 624c4ae8549fb8b64a6656c3681ac486
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_b", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:01 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - eeaa0dd540f5732f
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - eeaa0dd540f5732f
+      X-B3-TraceId:
+      - 624c4ae856f9dbdceeaa0dd540f5732f
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -429,325 +737,17 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:04:29 GMT
+      - Tue, 05 Apr 2022 13:58:01 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:29 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 590da7801bdc9124
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 590da7801bdc9124
-      X-B3-TraceId:
-      - 62475acde4c869fd590da7801bdc9124
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:29 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 3952609ce1c2e969
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 3952609ce1c2e969
-      X-B3-TraceId:
-      - 62475acd1e829d823952609ce1c2e969
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:30 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 33a863d5da24fa99
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 33a863d5da24fa99
-      X-B3-TraceId:
-      - 62475acdce425b2d33a863d5da24fa99
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:30 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 773e6bbfab24afe5
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 773e6bbfab24afe5
-      X-B3-TraceId:
-      - 62475ace90d15b3d773e6bbfab24afe5
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:30 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 57fcc5f5a90e2d2a
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 57fcc5f5a90e2d2a
-      X-B3-TraceId:
-      - 62475ace508c541557fcc5f5a90e2d2a
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:30 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 1c5d6ee054ff4c2a
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 1c5d6ee054ff4c2a
-      X-B3-TraceId:
-      - 62475acea6dd1d051c5d6ee054ff4c2a
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_b"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:30 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 2d76b4fae201e70f
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 2d76b4fae201e70f
-      X-B3-TraceId:
-      - 62475ace45ff46ce2d76b4fae201e70f
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_b", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:31 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 7d37612e93fc9dee
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 7d37612e93fc9dee
-      X-B3-TraceId:
-      - 62475acec2400ade7d37612e93fc9dee
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models?fields=name%2Cproject_name%2Cexplores
   response:
@@ -831,20 +831,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:32 GMT
+      - Tue, 05 Apr 2022 13:58:02 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 6982db56b23e0907
+      - 06e3dad43db93abc
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6982db56b23e0907
+      - 06e3dad43db93abc
       X-B3-TraceId:
-      - 62475acf8e6dacc76982db56b23e0907
+      - 624c4ae9b15818f406e3dad43db93abc
       X-Content-Type-Options:
       - nosniff
     status:
@@ -854,7 +854,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users?fields=fields
   response:
@@ -885,20 +885,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:32 GMT
+      - Tue, 05 Apr 2022 13:58:02 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 669121f86e8014e2
+      - d9a36628154d0113
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 669121f86e8014e2
+      - d9a36628154d0113
       X-B3-TraceId:
-      - 62475ad069aea545669121f86e8014e2
+      - 624c4aea6b35de5bd9a36628154d0113
       X-Content-Type-Options:
       - nosniff
     status:
@@ -908,7 +908,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users__fail?fields=fields
   response:
@@ -944,20 +944,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:32 GMT
+      - Tue, 05 Apr 2022 13:58:02 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - bf1bed97fedb01c2
+      - 8df191eaa41cb335
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - bf1bed97fedb01c2
+      - 8df191eaa41cb335
       X-B3-TraceId:
-      - 62475ad0b7677d07bf1bed97fedb01c2
+      - 624c4aea96f5ca0f8df191eaa41cb335
       X-Content-Type-Options:
       - nosniff
     status:
@@ -973,7 +973,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -987,19 +987,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:32 GMT
+      - Tue, 05 Apr 2022 13:58:02 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 00749d20b070fd2e
+      - 6db07d6aabf0535c
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 00749d20b070fd2e
+      - 6db07d6aabf0535c
       X-B3-TraceId:
-      - 62475ad0491539c200749d20b070fd2e
+      - 624c4aea133101976db07d6aabf0535c
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1009,7 +1009,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/2216/run/sql
   response:
@@ -1026,19 +1026,19 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:04:32 GMT
+      - Tue, 05 Apr 2022 13:58:02 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - bda592154b6555e9
+      - c088df7df7a847e9
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - bda592154b6555e9
+      - c088df7df7a847e9
       X-B3-TraceId:
-      - 62475ad0772b7a08bda592154b6555e9
+      - 624c4aeaa1d41303c088df7df7a847e9
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1054,7 +1054,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -1068,19 +1068,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:32 GMT
+      - Tue, 05 Apr 2022 13:58:02 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 1d35c796342879ab
+      - c50387962bcecc2f
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 1d35c796342879ab
+      - c50387962bcecc2f
       X-B3-TraceId:
-      - 62475ad0bea8648e1d35c796342879ab
+      - 624c4aea8a5f418ac50387962bcecc2f
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1090,7 +1090,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/1944/run/sql
   response:
@@ -1108,60 +1108,60 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:04:33 GMT
+      - Tue, 05 Apr 2022 13:58:03 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 72b34deb7406045a
+      - 9b269abb842d8c25
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 72b34deb7406045a
+      - 9b269abb842d8c25
       X-B3-TraceId:
-      - 62475ad0dc8d857b72b34deb7406045a
+      - 624c4aea216f5e339b269abb842d8c25
       X-Content-Type-Options:
       - nosniff
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "pytest-incremental-invalid-equal"}'
+    body: '{"name": "pytest-incremental-valid-diff"}'
     headers:
       Content-Length:
-      - '44'
+      - '41'
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest-incremental-invalid-equal","remote":"origin","remote_name":"pytest-incremental-invalid-equal","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648842827,"ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","remote_ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","can":{}}'
+      string: '{"name":"pytest-incremental-valid-diff","remote":"origin","remote_name":"pytest-incremental-valid-diff","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","can":{}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '415'
+      - '409'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:33 GMT
+      - Tue, 05 Apr 2022 13:58:03 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 90fbc499c1101c1a
+      - d48fc306d48939fb
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 90fbc499c1101c1a
+      - d48fc306d48939fb
       X-B3-TraceId:
-      - 62475ad1744c22ac90fbc499c1101c1a
+      - 624c4aebb90c86acd48fc306d48939fb
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1173,7 +1173,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_a
   response:
@@ -1183,19 +1183,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:04:34 GMT
+      - Tue, 05 Apr 2022 13:58:04 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 50ce3384349426e2
+      - 831cc0d4da325ccf
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 50ce3384349426e2
+      - 831cc0d4da325ccf
       X-B3-TraceId:
-      - 62475ad1aeafeec550ce3384349426e2
+      - 624c4aeb79006dd2831cc0d4da325ccf
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1209,7 +1209,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -1223,20 +1223,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:35 GMT
+      - Tue, 05 Apr 2022 13:58:05 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 5298a407c32f6c0c
+      - 45831a4afdd066a1
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 5298a407c32f6c0c
+      - 45831a4afdd066a1
       X-B3-TraceId:
-      - 62475ad22a7836905298a407c32f6c0c
+      - 624c4aecfc89a41e45831a4afdd066a1
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1248,7 +1248,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_b
   response:
@@ -1258,19 +1258,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:04:35 GMT
+      - Tue, 05 Apr 2022 13:58:05 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 43601cb3d75ca3fb
+      - f36a6b7621a7b1ea
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 43601cb3d75ca3fb
+      - f36a6b7621a7b1ea
       X-B3-TraceId:
-      - 62475ad3d3891aa443601cb3d75ca3fb
+      - 624c4aed4995c84ff36a6b7621a7b1ea
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1284,7 +1284,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -1298,20 +1298,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:36 GMT
+      - Tue, 05 Apr 2022 13:58:06 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 8c62796f20c6eb6c
+      - 1e6d79b55bbf3ec6
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 8c62796f20c6eb6c
+      - 1e6d79b55bbf3ec6
       X-B3-TraceId:
-      - 62475ad375e7849e8c62796f20c6eb6c
+      - 624c4aed3e2a0a341e6d79b55bbf3ec6
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1325,7 +1325,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1339,19 +1339,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:36 GMT
+      - Tue, 05 Apr 2022 13:58:06 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 56105527c2c7429c
+      - 807292487d1af984
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 56105527c2c7429c
+      - 807292487d1af984
       X-B3-TraceId:
-      - 62475ad4c3fefb2b56105527c2c7429c
+      - 624c4aee93fe2a30807292487d1af984
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1365,7 +1365,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1379,19 +1379,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:36 GMT
+      - Tue, 05 Apr 2022 13:58:06 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 6234a15e93bcb65a
+      - 71614c0970f93b5b
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6234a15e93bcb65a
+      - 71614c0970f93b5b
       X-B3-TraceId:
-      - 62475ad4071948516234a15e93bcb65a
+      - 624c4aee2f85d45971614c0970f93b5b
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1401,7 +1401,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1415,19 +1415,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:36 GMT
+      - Tue, 05 Apr 2022 13:58:06 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 1604ad9bed644379
+      - effdb4b87d31ab4b
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 1604ad9bed644379
+      - effdb4b87d31ab4b
       X-B3-TraceId:
-      - 62475ad4924212ca1604ad9bed644379
+      - 624c4aee1ca05163effdb4b87d31ab4b
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1437,34 +1437,34 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest-incremental-invalid-equal","remote":"origin","remote_name":"pytest-incremental-invalid-equal","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648842827,"ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","remote_ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","can":{}}'
+      string: '{"name":"pytest-incremental-valid-diff","remote":"origin","remote_name":"pytest-incremental-valid-diff","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","can":{}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '415'
+      - '409'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:36 GMT
+      - Tue, 05 Apr 2022 13:58:06 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f072a17d960989d0
+      - 2dde65fd37eb3e0b
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f072a17d960989d0
+      - 2dde65fd37eb3e0b
       X-B3-TraceId:
-      - 62475ad4f967b146f072a17d960989d0
+      - 624c4aee59e8ee8a2dde65fd37eb3e0b
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1478,12 +1478,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"tmp_spectacles_c","remote":"origin","remote_name":"tmp_spectacles_c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648842827,"ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","remote_ref":null,"can":{}}'
+      string: '{"name":"tmp_spectacles_c","remote":"origin","remote_name":"tmp_spectacles_c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":null,"can":{}}'
     headers:
       Connection:
       - keep-alive
@@ -1492,20 +1492,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:36 GMT
+      - Tue, 05 Apr 2022 13:58:06 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f2fe4cd96c33f612
+      - 6174255ff91dc72e
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f2fe4cd96c33f612
+      - 6174255ff91dc72e
       X-B3-TraceId:
-      - 62475ad4308424fdf2fe4cd96c33f612
+      - 624c4aee7722668a6174255ff91dc72e
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1519,12 +1519,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"tmp_spectacles_c","remote":"origin","remote_name":"tmp_spectacles_c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648842827,"ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","remote_ref":null,"can":{}}'
+      string: '{"name":"tmp_spectacles_c","remote":"origin","remote_name":"tmp_spectacles_c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":null,"can":{}}'
     headers:
       Connection:
       - keep-alive
@@ -1533,20 +1533,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:38 GMT
+      - Tue, 05 Apr 2022 13:58:08 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 7354715f8cf29cbd
+      - 8023bf24b5283012
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 7354715f8cf29cbd
+      - 8023bf24b5283012
       X-B3-TraceId:
-      - 62475ad404f750b37354715f8cf29cbd
+      - 624c4aeedc041d7d8023bf24b5283012
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1556,7 +1556,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:08 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - e6a8a482f0b22601
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - e6a8a482f0b22601
+      X-B3-TraceId:
+      - 624c4af0933a2389e6a8a482f0b22601
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1570,19 +1606,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:38 GMT
+      - Tue, 05 Apr 2022 13:58:08 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 8f545582de4c5583
+      - 47380a14999c1511
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 8f545582de4c5583
+      - 47380a14999c1511
       X-B3-TraceId:
-      - 62475ad6de1dc14b8f545582de4c5583
+      - 624c4af00a6fbcd147380a14999c1511
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1592,7 +1628,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -1606,20 +1642,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:38 GMT
+      - Tue, 05 Apr 2022 13:58:08 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 33eee00175e27867
+      - 6f6fe92cd3a038bd
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 33eee00175e27867
+      - 6f6fe92cd3a038bd
       X-B3-TraceId:
-      - 62475ad6afdd599833eee00175e27867
+      - 624c4af0d5e96c546f6fe92cd3a038bd
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:09 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - b5f009521ef6ad8d
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - b5f009521ef6ad8d
+      X-B3-TraceId:
+      - 624c4af1a88c1eefb5f009521ef6ad8d
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1629,7 +1705,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:09 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 6ed2b14bd329061f
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 6ed2b14bd329061f
+      X-B3-TraceId:
+      - 624c4af16731f4886ed2b14bd329061f
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:09 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 8b870a7774458aa7
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 8b870a7774458aa7
+      X-B3-TraceId:
+      - 624c4af116d932bc8b870a7774458aa7
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:09 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 9cb11d8cfa608f92
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 9cb11d8cfa608f92
+      X-B3-TraceId:
+      - 624c4af1ed9c80e49cb11d8cfa608f92
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:09 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 762afae9b7f73e05
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 762afae9b7f73e05
+      X-B3-TraceId:
+      - 624c4af1a4c8bdfa762afae9b7f73e05
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:09 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - e2b1cca706d685ee
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - e2b1cca706d685ee
+      X-B3-TraceId:
+      - 624c4af1c872767fe2b1cca706d685ee
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_d"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_d","remote":"origin","remote_name":"tmp_spectacles_d","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:09 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 7cd21ebac2904fa4
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 7cd21ebac2904fa4
+      X-B3-TraceId:
+      - 624c4af1a306d17e7cd21ebac2904fa4
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_d", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_d","remote":"origin","remote_name":"tmp_spectacles_d","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:10 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - a54142356bbf58b2
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - a54142356bbf58b2
+      X-B3-TraceId:
+      - 624c4af1bea9d6bea54142356bbf58b2
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -1678,325 +2022,17 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:04:39 GMT
+      - Tue, 05 Apr 2022 13:58:10 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:39 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 7f8cfc32b4a2145f
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 7f8cfc32b4a2145f
-      X-B3-TraceId:
-      - 62475ad7e1cb9f3f7f8cfc32b4a2145f
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:39 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 69a9a9726885895e
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 69a9a9726885895e
-      X-B3-TraceId:
-      - 62475ad74aac5bc069a9a9726885895e
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:39 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 7b39c65f1beea1d4
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 7b39c65f1beea1d4
-      X-B3-TraceId:
-      - 62475ad7d554e3577b39c65f1beea1d4
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:39 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 87c0d709cee5db2b
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 87c0d709cee5db2b
-      X-B3-TraceId:
-      - 62475ad79b8e445e87c0d709cee5db2b
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:39 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 206143508752633a
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 206143508752633a
-      X-B3-TraceId:
-      - 62475ad769d3ad3e206143508752633a
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:39 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 111fa21a1c27e609
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 111fa21a1c27e609
-      X-B3-TraceId:
-      - 62475ad7ebf46675111fa21a1c27e609
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_d"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_d","remote":"origin","remote_name":"tmp_spectacles_d","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:39 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - e84e6780e0bc5a05
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - e84e6780e0bc5a05
-      X-B3-TraceId:
-      - 62475ad7506c2501e84e6780e0bc5a05
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_d", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_d","remote":"origin","remote_name":"tmp_spectacles_d","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:40 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 80917120e5d35687
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 80917120e5d35687
-      X-B3-TraceId:
-      - 62475ad8b0cdf62580917120e5d35687
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models?fields=name%2Cproject_name%2Cexplores
   response:
@@ -2080,20 +2116,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:41 GMT
+      - Tue, 05 Apr 2022 13:58:11 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 51afa0289e2b3a63
+      - 90ee10f513635e58
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 51afa0289e2b3a63
+      - 90ee10f513635e58
       X-B3-TraceId:
-      - 62475ad801d90aed51afa0289e2b3a63
+      - 624c4af22eb6e39a90ee10f513635e58
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2103,7 +2139,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users?fields=fields
   response:
@@ -2134,20 +2170,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:41 GMT
+      - Tue, 05 Apr 2022 13:58:11 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 2fa3220cca2f05f0
+      - 1571f45c5a5e3154
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2fa3220cca2f05f0
+      - 1571f45c5a5e3154
       X-B3-TraceId:
-      - 62475ad943fd241e2fa3220cca2f05f0
+      - 624c4af3011e26631571f45c5a5e3154
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2157,7 +2193,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users__fail?fields=fields
   response:
@@ -2193,20 +2229,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:41 GMT
+      - Tue, 05 Apr 2022 13:58:11 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 878bd0d177769f0e
+      - 9bca6c4e3217519a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 878bd0d177769f0e
+      - 9bca6c4e3217519a
       X-B3-TraceId:
-      - 62475ad9cb446d32878bd0d177769f0e
+      - 624c4af3c306a75b9bca6c4e3217519a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2222,7 +2258,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -2236,19 +2272,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:41 GMT
+      - Tue, 05 Apr 2022 13:58:11 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 3c5756f02871a050
+      - 09e1f9ac73e83d67
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 3c5756f02871a050
+      - 09e1f9ac73e83d67
       X-B3-TraceId:
-      - 62475ad954666ee43c5756f02871a050
+      - 624c4af3a89070ae09e1f9ac73e83d67
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2258,7 +2294,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/2216/run/sql
   response:
@@ -2275,19 +2311,19 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:04:42 GMT
+      - Tue, 05 Apr 2022 13:58:11 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 3e778bbb27df9073
+      - 29eec4d75c3d8164
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 3e778bbb27df9073
+      - 29eec4d75c3d8164
       X-B3-TraceId:
-      - 62475ad9b1c4a7cd3e778bbb27df9073
+      - 624c4af31285790029eec4d75c3d8164
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2303,7 +2339,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -2317,19 +2353,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:42 GMT
+      - Tue, 05 Apr 2022 13:58:12 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 91a73fe82944e9b9
+      - 929f63c25d6baff1
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 91a73fe82944e9b9
+      - 929f63c25d6baff1
       X-B3-TraceId:
-      - 62475ada04b7aab591a73fe82944e9b9
+      - 624c4af390f6e3b5929f63c25d6baff1
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2339,7 +2375,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/queries/1944/run/sql
   response:
@@ -2357,60 +2393,60 @@ interactions:
       Content-Type:
       - application/sql
       Date:
-      - Fri, 01 Apr 2022 20:04:42 GMT
+      - Tue, 05 Apr 2022 13:58:12 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 116578b840bb5fd4
+      - 7be4c2c3c04d97b3
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 116578b840bb5fd4
+      - 7be4c2c3c04d97b3
       X-B3-TraceId:
-      - 62475ada8e272d44116578b840bb5fd4
+      - 624c4af49bc538c17be4c2c3c04d97b3
       X-Content-Type-Options:
       - nosniff
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "pytest-incremental-invalid-equal"}'
+    body: '{"name": "pytest-incremental-valid-diff"}'
     headers:
       Content-Length:
-      - '44'
+      - '41'
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest-incremental-invalid-equal","remote":"origin","remote_name":"pytest-incremental-invalid-equal","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648842827,"ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","remote_ref":"f6fded2b439e4b28d54056fd8d0620da3decc546","can":{}}'
+      string: '{"name":"pytest-incremental-valid-diff","remote":"origin","remote_name":"pytest-incremental-valid-diff","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832098,"ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","remote_ref":"01d3dbcde86812672aa807fb524ab9643c9126b3","can":{}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '415'
+      - '409'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:43 GMT
+      - Tue, 05 Apr 2022 13:58:12 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 3650ac8bed663233
+      - 4a4b3d2f67cf59f6
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 3650ac8bed663233
+      - 4a4b3d2f67cf59f6
       X-B3-TraceId:
-      - 62475ada4667a5c83650ac8bed663233
+      - 624c4af4a5ab9ade4a4b3d2f67cf59f6
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2422,7 +2458,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_c
   response:
@@ -2432,19 +2468,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:04:43 GMT
+      - Tue, 05 Apr 2022 13:58:13 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - cf60d139a456ba9a
+      - 94974458f7f7c8b5
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - cf60d139a456ba9a
+      - 94974458f7f7c8b5
       X-B3-TraceId:
-      - 62475adb5b571c6fcf60d139a456ba9a
+      - 624c4af5876e40e394974458f7f7c8b5
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2458,7 +2494,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -2472,20 +2508,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:44 GMT
+      - Tue, 05 Apr 2022 13:58:14 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 31e25d2317961130
+      - 7cedd506f22c8919
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 31e25d2317961130
+      - 7cedd506f22c8919
       X-B3-TraceId:
-      - 62475adbe30aefe831e25d2317961130
+      - 624c4af5f0885f037cedd506f22c8919
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2497,7 +2533,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_d
   response:
@@ -2507,19 +2543,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:04:44 GMT
+      - Tue, 05 Apr 2022 13:58:14 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 0f9e9f9df1c36ef6
+      - a388b4bb3e24d3b8
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 0f9e9f9df1c36ef6
+      - a388b4bb3e24d3b8
       X-B3-TraceId:
-      - 62475adcf7b076ce0f9e9f9df1c36ef6
+      - 624c4af6f67055a0a388b4bb3e24d3b8
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2533,7 +2569,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -2547,20 +2583,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:45 GMT
+      - Tue, 05 Apr 2022 13:58:15 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 161a58046d07de50
+      - 7f5dc50f8c0f79aa
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 161a58046d07de50
+      - 7f5dc50f8c0f79aa
       X-B3-TraceId:
-      - 62475adc31891adf161a58046d07de50
+      - 624c4af6f81eff5e7f5dc50f8c0f79aa
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2574,7 +2610,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -2588,19 +2624,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:45 GMT
+      - Tue, 05 Apr 2022 13:58:15 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 5a0b1feaa41be096
+      - 6fd5ef850ed2213f
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 5a0b1feaa41be096
+      - 6fd5ef850ed2213f
       X-B3-TraceId:
-      - 62475addacaf59995a0b1feaa41be096
+      - 624c4af724aebf5f6fd5ef850ed2213f
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2614,7 +2650,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -2628,19 +2664,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:45 GMT
+      - Tue, 05 Apr 2022 13:58:15 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f308aa84bceb0de5
+      - 4ed68358dd288cd7
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f308aa84bceb0de5
+      - 4ed68358dd288cd7
       X-B3-TraceId:
-      - 62475addeaeab873f308aa84bceb0de5
+      - 624c4af72dbb89114ed68358dd288cd7
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2654,12 +2690,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
     body:
-      string: '{"name":"pytest-incremental-equal","remote":"origin","remote_name":"pytest-incremental-equal","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":3,"behind_count":2,"commit_at":1648832027,"ref":"741aeac4101451fc6985b88fe20e567479848ac2","remote_ref":"742b118d314d2478a215aa02016c09e173deec7e","can":{}}'
+      string: '{"name":"pytest-incremental-equal","remote":"origin","remote_name":"pytest-incremental-equal","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":"742b118d314d2478a215aa02016c09e173deec7e","can":{}}'
     headers:
       Connection:
       - keep-alive
@@ -2668,20 +2704,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:46 GMT
+      - Tue, 05 Apr 2022 13:58:16 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - d55d13cc8e140cb4
+      - a9334e267fcb2743
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - d55d13cc8e140cb4
+      - a9334e267fcb2743
       X-B3-TraceId:
-      - 62475add0f654ac8d55d13cc8e140cb4
+      - 624c4af7877e5300a9334e267fcb2743
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2693,7 +2729,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/reset_to_remote
   response:
@@ -2703,19 +2739,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:04:47 GMT
+      - Tue, 05 Apr 2022 13:58:17 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 9f373e2de3f749f0
+      - 66374191f936fe11
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 9f373e2de3f749f0
+      - 66374191f936fe11
       X-B3-TraceId:
-      - 62475adee81763299f373e2de3f749f0
+      - 624c4af8d9d1860466374191f936fe11
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2725,7 +2761,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:17 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 3fb3942686be52ef
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 3fb3942686be52ef
+      X-B3-TraceId:
+      - 624c4af9fd90d1fa3fb3942686be52ef
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -2739,19 +2811,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:47 GMT
+      - Tue, 05 Apr 2022 13:58:17 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - c0a2251eb383afaa
+      - 82b97255d5073e8b
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - c0a2251eb383afaa
+      - 82b97255d5073e8b
       X-B3-TraceId:
-      - 62475adf4eb64a83c0a2251eb383afaa
+      - 624c4af9237ba6ef82b97255d5073e8b
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2761,7 +2833,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -2775,84 +2847,25 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:47 GMT
+      - Tue, 05 Apr 2022 13:58:17 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 9b4b4efbae280b11
+      - 19118d9d88054190
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 9b4b4efbae280b11
+      - 19118d9d88054190
       X-B3-TraceId:
-      - 62475adf40e1429a9b4b4efbae280b11
+      - 624c4af9f188d1fb19118d9d88054190
       X-Content-Type-Options:
       - nosniff
     status:
       code: 200
       message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
-  response:
-    body:
-      string: "<!DOCTYPE html>\n<html>\n<head>\n    <title>Looker Not Found (404)</title>\n
-        \   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600'
-        rel='stylesheet' type='text/css'>\n\n    <!-- @@@@@@@@@@@@@ FAVICONS @@@@@@@@@@@@@
-        -->\n\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"57x57\" href=\"https://wwwstatic-b.lookercdn.com/favicon/apple-touch-icon-57x57.png\"
-        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"114x114\" href=\"https://wwwstatic-c.lookercdn.com/favicon/apple-touch-icon-114x114.png\"
-        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"72x72\" href=\"https://wwwstatic-d.lookercdn.com/favicon/apple-touch-icon-72x72.png\"
-        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"144x144\" href=\"https://wwwstatic-a.lookercdn.com/favicon/apple-touch-icon-144x144.png\"
-        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"60x60\" href=\"https://wwwstatic-b.lookercdn.com/favicon/apple-touch-icon-60x60.png\"
-        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"120x120\" href=\"https://wwwstatic-c.lookercdn.com/favicon/apple-touch-icon-120x120.png\"
-        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"76x76\" href=\"https://wwwstatic-d.lookercdn.com/favicon/apple-touch-icon-76x76.png\"
-        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"152x152\" href=\"https://wwwstatic-a.lookercdn.com/favicon/apple-touch-icon-152x152.png\"
-        />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-b.lookercdn.com/favicon/favicon-196x196.png\"
-        sizes=\"196x196\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-c.lookercdn.com/favicon/favicon-96x96.png\"
-        sizes=\"96x96\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-d.lookercdn.com/favicon/favicon-32x32.png\"
-        sizes=\"32x32\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-a.lookercdn.com/favicon/favicon-16x16.png\"
-        sizes=\"16x16\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-b.lookercdn.com/favicon/favicon-128.png\"
-        sizes=\"128x128\" />\n    <meta name=\"application-name\" content=\"Looker\"/>\n
-        \   <meta name=\"msapplication-TileColor\" content=\"#FFFFFF\" />\n    <meta
-        name=\"msapplication-TileImage\" content=\"https://wwwstatic-c.lookercdn.com/favicon/mstile-144x144.png\"
-        />\n    <meta name=\"msapplication-square70x70logo\" content=\"https://wwwstatic-d.lookercdn.com/favicon/mstile-70x70.png\"
-        />\n    <meta name=\"msapplication-square150x150logo\" content=\"https://wwwstatic-a.lookercdn.com/favicon/mstile-150x150.png\"
-        />\n    <meta name=\"msapplication-wide310x150logo\" content=\"https://wwwstatic-b.lookercdn.com/favicon/mstile-310x150.png\"
-        />\n    <meta name=\"msapplication-square310x310logo\" content=\"https://wwwstatic-c.lookercdn.com/favicon/mstile-310x310.png\"
-        />\n\n    <style type=\"text/css\">\n        body {\n            background-color:
-        #2e343f;\n            color: white;\n            height: auto;\n            font-family:
-        Open Sans, Helvetica, Arial, sans-serif;\n        }\n        .message {\n
-        \           width: 100%;\n            max-width: 760px;\n            margin:
-        0 auto;\n            margin-top: 135px;\n            text-align: center;\n
-        \       }\n        h2, h3 {\n            font-weight: normal;\n        }\n
-        \       a {\n            color: white;\n        }\n    </style>\n</head>\n<body>\n\n
-        \   <div class=\"message\">\n\n        <img width=\"210\" height=\"84\" src=\"https://wwwstatic-a.lookercdn.com/logos/looker_all_white.svg\"
-        alt=\"Looker\">\n\n        <h1>Looker is unavailable.</h1>\n\n        <h2>If
-        you typed in a URL, double-check the spelling.</h2>\n        <h2>This may
-        also be due to a temporary condition such as an outage, <a href=\"https://docs.looker.com/relnotes/hosted-maintenance-hours\">scheduled
-        maintenance</a> or upgrade.</h2>\n        <br>\n        <h3>\n            If
-        this message persists or you have any concerns, <br> contact us from\n            <a
-        href=\"https://help.looker.com\">help.looker.com</a> and we'll respond promptly.\n
-        \       </h3>\n\n    </div>\n\n</body>\n</html>\n"
-    headers:
-      Connection:
-      - close
-      Content-Type:
-      - text/html
-      Date:
-      - Fri, 01 Apr 2022 20:04:47 GMT
-      Vary:
-      - Accept-Encoding
-    status:
-      code: 404
-      message: Not Found
 - request:
     body: '{"workspace_id": "production"}'
     headers:
@@ -2861,7 +2874,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -2875,19 +2888,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:47 GMT
+      - Tue, 05 Apr 2022 13:58:17 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 503c18a8fa26976d
+      - 8fab7eb56c9de440
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 503c18a8fa26976d
+      - 8fab7eb56c9de440
       X-B3-TraceId:
-      - 62475adf2f6c26ba503c18a8fa26976d
+      - 624c4af90c6bdb978fab7eb56c9de440
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2897,7 +2910,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -2911,19 +2924,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:47 GMT
+      - Tue, 05 Apr 2022 13:58:17 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 0fa0e0278b344bd6
+      - 2a1f0f6ef126f219
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 0fa0e0278b344bd6
+      - 2a1f0f6ef126f219
       X-B3-TraceId:
-      - 62475adfac800d2e0fa0e0278b344bd6
+      - 624c4af9ea102dcb2a1f0f6ef126f219
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2933,7 +2946,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -2947,20 +2960,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:47 GMT
+      - Tue, 05 Apr 2022 13:58:17 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 7f500885e949d7d3
+      - 49c8de65db635585
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 7f500885e949d7d3
+      - 49c8de65db635585
       X-B3-TraceId:
-      - 62475adf9b4967d07f500885e949d7d3
+      - 624c4af9d3ca6be049c8de65db635585
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2974,7 +2987,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -2988,19 +3001,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:47 GMT
+      - Tue, 05 Apr 2022 13:58:17 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - d2236bbe346625f6
+      - 19bb36b6e70f635d
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - d2236bbe346625f6
+      - 19bb36b6e70f635d
       X-B3-TraceId:
-      - 62475adfdf501e4bd2236bbe346625f6
+      - 624c4af9b1fb82ca19bb36b6e70f635d
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3010,7 +3023,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3024,19 +3037,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:47 GMT
+      - Tue, 05 Apr 2022 13:58:17 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - c432a35db4a669ee
+      - 88ce6e599a861a40
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - c432a35db4a669ee
+      - 88ce6e599a861a40
       X-B3-TraceId:
-      - 62475adf52c52fa2c432a35db4a669ee
+      - 624c4af9b54722ca88ce6e599a861a40
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3046,7 +3059,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3060,20 +3073,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:48 GMT
+      - Tue, 05 Apr 2022 13:58:17 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - c98a67ac01116b75
+      - 9ffcf6f6956f6942
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - c98a67ac01116b75
+      - 9ffcf6f6956f6942
       X-B3-TraceId:
-      - 62475adff5102290c98a67ac01116b75
+      - 624c4af9f352a57f9ffcf6f6956f6942
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3087,7 +3100,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3101,20 +3114,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:48 GMT
+      - Tue, 05 Apr 2022 13:58:18 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 79cd1df18da17e72
+      - 80c5a65dc7fd36b9
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 79cd1df18da17e72
+      - 80c5a65dc7fd36b9
       X-B3-TraceId:
-      - 62475ae05be9b38d79cd1df18da17e72
+      - 624c4af94fa5aabd80c5a65dc7fd36b9
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3128,7 +3141,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3142,25 +3155,84 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:48 GMT
+      - Tue, 05 Apr 2022 13:58:18 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 2068b38f3762024e
+      - 729a7d317903cf28
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2068b38f3762024e
+      - 729a7d317903cf28
       X-B3-TraceId:
-      - 62475ae003f2f8022068b38f3762024e
+      - 624c4afa92087b9a729a7d317903cf28
       X-Content-Type-Options:
       - nosniff
     status:
       code: 200
       message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html>\n<head>\n    <title>Looker Not Found (404)</title>\n
+        \   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600'
+        rel='stylesheet' type='text/css'>\n\n    <!-- @@@@@@@@@@@@@ FAVICONS @@@@@@@@@@@@@
+        -->\n\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"57x57\" href=\"https://wwwstatic-b.lookercdn.com/favicon/apple-touch-icon-57x57.png\"
+        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"114x114\" href=\"https://wwwstatic-c.lookercdn.com/favicon/apple-touch-icon-114x114.png\"
+        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"72x72\" href=\"https://wwwstatic-d.lookercdn.com/favicon/apple-touch-icon-72x72.png\"
+        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"144x144\" href=\"https://wwwstatic-a.lookercdn.com/favicon/apple-touch-icon-144x144.png\"
+        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"60x60\" href=\"https://wwwstatic-b.lookercdn.com/favicon/apple-touch-icon-60x60.png\"
+        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"120x120\" href=\"https://wwwstatic-c.lookercdn.com/favicon/apple-touch-icon-120x120.png\"
+        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"76x76\" href=\"https://wwwstatic-d.lookercdn.com/favicon/apple-touch-icon-76x76.png\"
+        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"152x152\" href=\"https://wwwstatic-a.lookercdn.com/favicon/apple-touch-icon-152x152.png\"
+        />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-b.lookercdn.com/favicon/favicon-196x196.png\"
+        sizes=\"196x196\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-c.lookercdn.com/favicon/favicon-96x96.png\"
+        sizes=\"96x96\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-d.lookercdn.com/favicon/favicon-32x32.png\"
+        sizes=\"32x32\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-a.lookercdn.com/favicon/favicon-16x16.png\"
+        sizes=\"16x16\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-b.lookercdn.com/favicon/favicon-128.png\"
+        sizes=\"128x128\" />\n    <meta name=\"application-name\" content=\"Looker\"/>\n
+        \   <meta name=\"msapplication-TileColor\" content=\"#FFFFFF\" />\n    <meta
+        name=\"msapplication-TileImage\" content=\"https://wwwstatic-c.lookercdn.com/favicon/mstile-144x144.png\"
+        />\n    <meta name=\"msapplication-square70x70logo\" content=\"https://wwwstatic-d.lookercdn.com/favicon/mstile-70x70.png\"
+        />\n    <meta name=\"msapplication-square150x150logo\" content=\"https://wwwstatic-a.lookercdn.com/favicon/mstile-150x150.png\"
+        />\n    <meta name=\"msapplication-wide310x150logo\" content=\"https://wwwstatic-b.lookercdn.com/favicon/mstile-310x150.png\"
+        />\n    <meta name=\"msapplication-square310x310logo\" content=\"https://wwwstatic-c.lookercdn.com/favicon/mstile-310x310.png\"
+        />\n\n    <style type=\"text/css\">\n        body {\n            background-color:
+        #2e343f;\n            color: white;\n            height: auto;\n            font-family:
+        Open Sans, Helvetica, Arial, sans-serif;\n        }\n        .message {\n
+        \           width: 100%;\n            max-width: 760px;\n            margin:
+        0 auto;\n            margin-top: 135px;\n            text-align: center;\n
+        \       }\n        h2, h3 {\n            font-weight: normal;\n        }\n
+        \       a {\n            color: white;\n        }\n    </style>\n</head>\n<body>\n\n
+        \   <div class=\"message\">\n\n        <img width=\"210\" height=\"84\" src=\"https://wwwstatic-a.lookercdn.com/logos/looker_all_white.svg\"
+        alt=\"Looker\">\n\n        <h1>Looker is unavailable.</h1>\n\n        <h2>If
+        you typed in a URL, double-check the spelling.</h2>\n        <h2>This may
+        also be due to a temporary condition such as an outage, <a href=\"https://docs.looker.com/relnotes/hosted-maintenance-hours\">scheduled
+        maintenance</a> or upgrade.</h2>\n        <br>\n        <h3>\n            If
+        this message persists or you have any concerns, <br> contact us from\n            <a
+        href=\"https://help.looker.com\">help.looker.com</a> and we'll respond promptly.\n
+        \       </h3>\n\n    </div>\n\n</body>\n</html>\n"
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - text/html
+      Date:
+      - Tue, 05 Apr 2022 13:58:18 GMT
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 404
+      message: Not Found
 - request:
     body: '{"name": "tmp_spectacles_5e52c0302c"}'
     headers:
@@ -3169,7 +3241,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3183,20 +3255,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:49 GMT
+      - Tue, 05 Apr 2022 13:58:19 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - e6f91e64d8b340ac
+      - e11d25ceed7b2fca
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - e6f91e64d8b340ac
+      - e11d25ceed7b2fca
       X-B3-TraceId:
-      - 62475ae13fbf4f74e6f91e64d8b340ac
+      - 624c4afbaeb3272ee11d25ceed7b2fca
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3208,7 +3280,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_e
   response:
@@ -3218,19 +3290,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:04:50 GMT
+      - Tue, 05 Apr 2022 13:58:20 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - dc24ca0b98cf777b
+      - 271c807348af175b
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - dc24ca0b98cf777b
+      - 271c807348af175b
       X-B3-TraceId:
-      - 62475ae1e6769323dc24ca0b98cf777b
+      - 624c4afb83b862f9271c807348af175b
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3244,7 +3316,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3258,20 +3330,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:50 GMT
+      - Tue, 05 Apr 2022 13:58:20 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 7a75eafe6f7bdcff
+      - a5a31cd6abf70c4a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 7a75eafe6f7bdcff
+      - a5a31cd6abf70c4a
       X-B3-TraceId:
-      - 62475ae26ea5f2607a75eafe6f7bdcff
+      - 624c4afc1c059f61a5a31cd6abf70c4a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3285,7 +3357,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3299,19 +3371,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:50 GMT
+      - Tue, 05 Apr 2022 13:58:20 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 554259f858cad435
+      - 02157c3ecb4f11d4
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 554259f858cad435
+      - 02157c3ecb4f11d4
       X-B3-TraceId:
-      - 62475ae2479884f5554259f858cad435
+      - 624c4afcdb47aeb602157c3ecb4f11d4
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3325,7 +3397,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3339,19 +3411,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:50 GMT
+      - Tue, 05 Apr 2022 13:58:20 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - af02f3b9c0e2869d
+      - 20ce88606e4dd216
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - af02f3b9c0e2869d
+      - 20ce88606e4dd216
       X-B3-TraceId:
-      - 62475ae27391ea1faf02f3b9c0e2869d
+      - 624c4afcbabb687120ce88606e4dd216
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3361,7 +3433,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3375,19 +3447,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:50 GMT
+      - Tue, 05 Apr 2022 13:58:20 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 675ec97e7cbdb586
+      - f78c881ebbb2ba63
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 675ec97e7cbdb586
+      - f78c881ebbb2ba63
       X-B3-TraceId:
-      - 62475ae2b55dc74f675ec97e7cbdb586
+      - 624c4afc68320f44f78c881ebbb2ba63
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3397,7 +3469,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -3411,20 +3483,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:50 GMT
+      - Tue, 05 Apr 2022 13:58:20 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 418ccd98e55e1644
+      - 537a785cb5b318c5
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 418ccd98e55e1644
+      - 537a785cb5b318c5
       X-B3-TraceId:
-      - 62475ae2d5d6dc90418ccd98e55e1644
+      - 624c4afc98e006bf537a785cb5b318c5
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3438,7 +3510,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -3452,20 +3524,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:51 GMT
+      - Tue, 05 Apr 2022 13:58:21 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - e6419199c723780c
+      - 4ccb185f41af3892
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - e6419199c723780c
+      - 4ccb185f41af3892
       X-B3-TraceId:
-      - 62475ae337557435e6419199c723780c
+      - 624c4afd292f2b594ccb185f41af3892
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3479,7 +3551,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -3493,20 +3565,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:51 GMT
+      - Tue, 05 Apr 2022 13:58:21 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 992ed7bcb63de854
+      - 8ef6edab5c495711
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 992ed7bcb63de854
+      - 8ef6edab5c495711
       X-B3-TraceId:
-      - 62475ae3f9ea3c0d992ed7bcb63de854
+      - 624c4afd19982a388ef6edab5c495711
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3516,7 +3588,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:22 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 1e3486bd0fd7ec73
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 1e3486bd0fd7ec73
+      X-B3-TraceId:
+      - 624c4afec8951f0c1e3486bd0fd7ec73
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3530,19 +3638,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:52 GMT
+      - Tue, 05 Apr 2022 13:58:22 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 1120f6b86746c4c1
+      - 11ecdd864ca83e47
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 1120f6b86746c4c1
+      - 11ecdd864ca83e47
       X-B3-TraceId:
-      - 62475ae3083d66371120f6b86746c4c1
+      - 624c4afe8e0d38e311ecdd864ca83e47
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3552,7 +3660,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3566,84 +3674,25 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:52 GMT
+      - Tue, 05 Apr 2022 13:58:22 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 48b1d5d5367b88c1
+      - 4043057ecc23f154
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 48b1d5d5367b88c1
+      - 4043057ecc23f154
       X-B3-TraceId:
-      - 62475ae4bba6874648b1d5d5367b88c1
+      - 624c4afea8c9949d4043057ecc23f154
       X-Content-Type-Options:
       - nosniff
     status:
       code: 200
       message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
-  response:
-    body:
-      string: "<!DOCTYPE html>\n<html>\n<head>\n    <title>Looker Not Found (404)</title>\n
-        \   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600'
-        rel='stylesheet' type='text/css'>\n\n    <!-- @@@@@@@@@@@@@ FAVICONS @@@@@@@@@@@@@
-        -->\n\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"57x57\" href=\"https://wwwstatic-b.lookercdn.com/favicon/apple-touch-icon-57x57.png\"
-        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"114x114\" href=\"https://wwwstatic-c.lookercdn.com/favicon/apple-touch-icon-114x114.png\"
-        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"72x72\" href=\"https://wwwstatic-d.lookercdn.com/favicon/apple-touch-icon-72x72.png\"
-        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"144x144\" href=\"https://wwwstatic-a.lookercdn.com/favicon/apple-touch-icon-144x144.png\"
-        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"60x60\" href=\"https://wwwstatic-b.lookercdn.com/favicon/apple-touch-icon-60x60.png\"
-        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"120x120\" href=\"https://wwwstatic-c.lookercdn.com/favicon/apple-touch-icon-120x120.png\"
-        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"76x76\" href=\"https://wwwstatic-d.lookercdn.com/favicon/apple-touch-icon-76x76.png\"
-        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"152x152\" href=\"https://wwwstatic-a.lookercdn.com/favicon/apple-touch-icon-152x152.png\"
-        />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-b.lookercdn.com/favicon/favicon-196x196.png\"
-        sizes=\"196x196\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-c.lookercdn.com/favicon/favicon-96x96.png\"
-        sizes=\"96x96\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-d.lookercdn.com/favicon/favicon-32x32.png\"
-        sizes=\"32x32\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-a.lookercdn.com/favicon/favicon-16x16.png\"
-        sizes=\"16x16\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-b.lookercdn.com/favicon/favicon-128.png\"
-        sizes=\"128x128\" />\n    <meta name=\"application-name\" content=\"Looker\"/>\n
-        \   <meta name=\"msapplication-TileColor\" content=\"#FFFFFF\" />\n    <meta
-        name=\"msapplication-TileImage\" content=\"https://wwwstatic-c.lookercdn.com/favicon/mstile-144x144.png\"
-        />\n    <meta name=\"msapplication-square70x70logo\" content=\"https://wwwstatic-d.lookercdn.com/favicon/mstile-70x70.png\"
-        />\n    <meta name=\"msapplication-square150x150logo\" content=\"https://wwwstatic-a.lookercdn.com/favicon/mstile-150x150.png\"
-        />\n    <meta name=\"msapplication-wide310x150logo\" content=\"https://wwwstatic-b.lookercdn.com/favicon/mstile-310x150.png\"
-        />\n    <meta name=\"msapplication-square310x310logo\" content=\"https://wwwstatic-c.lookercdn.com/favicon/mstile-310x310.png\"
-        />\n\n    <style type=\"text/css\">\n        body {\n            background-color:
-        #2e343f;\n            color: white;\n            height: auto;\n            font-family:
-        Open Sans, Helvetica, Arial, sans-serif;\n        }\n        .message {\n
-        \           width: 100%;\n            max-width: 760px;\n            margin:
-        0 auto;\n            margin-top: 135px;\n            text-align: center;\n
-        \       }\n        h2, h3 {\n            font-weight: normal;\n        }\n
-        \       a {\n            color: white;\n        }\n    </style>\n</head>\n<body>\n\n
-        \   <div class=\"message\">\n\n        <img width=\"210\" height=\"84\" src=\"https://wwwstatic-a.lookercdn.com/logos/looker_all_white.svg\"
-        alt=\"Looker\">\n\n        <h1>Looker is unavailable.</h1>\n\n        <h2>If
-        you typed in a URL, double-check the spelling.</h2>\n        <h2>This may
-        also be due to a temporary condition such as an outage, <a href=\"https://docs.looker.com/relnotes/hosted-maintenance-hours\">scheduled
-        maintenance</a> or upgrade.</h2>\n        <br>\n        <h3>\n            If
-        this message persists or you have any concerns, <br> contact us from\n            <a
-        href=\"https://help.looker.com\">help.looker.com</a> and we'll respond promptly.\n
-        \       </h3>\n\n    </div>\n\n</body>\n</html>\n"
-    headers:
-      Connection:
-      - close
-      Content-Type:
-      - text/html
-      Date:
-      - Fri, 01 Apr 2022 20:04:52 GMT
-      Vary:
-      - Accept-Encoding
-    status:
-      code: 404
-      message: Not Found
 - request:
     body: '{"workspace_id": "production"}'
     headers:
@@ -3652,7 +3701,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3666,19 +3715,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:52 GMT
+      - Tue, 05 Apr 2022 13:58:22 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - d2e0db11e6f26677
+      - 8e644f74fe7e0dc3
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - d2e0db11e6f26677
+      - 8e644f74fe7e0dc3
       X-B3-TraceId:
-      - 62475ae4ea561fc2d2e0db11e6f26677
+      - 624c4afe7a3dc54c8e644f74fe7e0dc3
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3688,7 +3737,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3702,19 +3751,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:52 GMT
+      - Tue, 05 Apr 2022 13:58:22 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - e010af0aea6614b5
+      - bf85a75c31fcc397
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - e010af0aea6614b5
+      - bf85a75c31fcc397
       X-B3-TraceId:
-      - 62475ae470cbec2de010af0aea6614b5
+      - 624c4afe9f699d24bf85a75c31fcc397
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3724,7 +3773,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3738,20 +3787,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:52 GMT
+      - Tue, 05 Apr 2022 13:58:22 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 0dddf07f0ffadb35
+      - 82b44f0fd306257e
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 0dddf07f0ffadb35
+      - 82b44f0fd306257e
       X-B3-TraceId:
-      - 62475ae48965c17e0dddf07f0ffadb35
+      - 624c4afeeab8223a82b44f0fd306257e
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3765,7 +3814,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3779,19 +3828,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:52 GMT
+      - Tue, 05 Apr 2022 13:58:22 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - b43c04f3e77f9ba0
+      - 8af6235f855e4683
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - b43c04f3e77f9ba0
+      - 8af6235f855e4683
       X-B3-TraceId:
-      - 62475ae47e91cbddb43c04f3e77f9ba0
+      - 624c4afe68ad24358af6235f855e4683
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3801,7 +3850,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3815,19 +3864,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:52 GMT
+      - Tue, 05 Apr 2022 13:58:22 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 492aa902473dc38b
+      - 458439d295e8360d
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 492aa902473dc38b
+      - 458439d295e8360d
       X-B3-TraceId:
-      - 62475ae417bc164c492aa902473dc38b
+      - 624c4afe1155c35f458439d295e8360d
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3837,7 +3886,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3851,20 +3900,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:52 GMT
+      - Tue, 05 Apr 2022 13:58:22 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 30a8106427e38315
+      - 547ded87871f24eb
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 30a8106427e38315
+      - 547ded87871f24eb
       X-B3-TraceId:
-      - 62475ae43d265da530a8106427e38315
+      - 624c4afef875e20f547ded87871f24eb
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3878,7 +3927,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3892,20 +3941,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:53 GMT
+      - Tue, 05 Apr 2022 13:58:23 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 2d182d524bc5f61a
+      - 6814c646408bb8a7
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2d182d524bc5f61a
+      - 6814c646408bb8a7
       X-B3-TraceId:
-      - 62475ae431833b032d182d524bc5f61a
+      - 624c4afed14c00726814c646408bb8a7
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3919,7 +3968,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3933,291 +3982,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:53 GMT
+      - Tue, 05 Apr 2022 13:58:23 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 849ba19ca9a9d4f5
+      - af791633a5320f98
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 849ba19ca9a9d4f5
+      - af791633a5320f98
       X-B3-TraceId:
-      - 62475ae5dc1c5f76849ba19ca9a9d4f5
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "pytest-incremental-equal"}'
-    headers:
-      Content-Length:
-      - '36'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
-  response:
-    body:
-      string: '{"name":"pytest-incremental-equal","remote":"origin","remote_name":"pytest-incremental-equal","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":"742b118d314d2478a215aa02016c09e173deec7e","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '399'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:54 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - c571e806d8e9df94
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - c571e806d8e9df94
-      X-B3-TraceId:
-      - 62475ae5d528f7a9c571e806d8e9df94
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Content-Length:
-      - '0'
-      Cookie:
-      - looker.browser=9881689
-    method: DELETE
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_f
-  response:
-    body:
-      string: ''
-    headers:
-      Connection:
-      - keep-alive
-      Date:
-      - Fri, 01 Apr 2022 20:04:54 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Origin
-      X-B3-ParentSpanId:
-      - e764b6221c0b17c4
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - e764b6221c0b17c4
-      X-B3-TraceId:
-      - 62475ae6541b5e5de764b6221c0b17c4
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: '{"name": "tmp_spectacles_5e52c0302c"}'
-    headers:
-      Content-Length:
-      - '37'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:55 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 66fc0a8a73c03f8f
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 66fc0a8a73c03f8f
-      X-B3-TraceId:
-      - 62475ae6ccab789066fc0a8a73c03f8f
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Content-Length:
-      - '0'
-      Cookie:
-      - looker.browser=9881689
-    method: DELETE
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_g
-  response:
-    body:
-      string: ''
-    headers:
-      Connection:
-      - keep-alive
-      Date:
-      - Fri, 01 Apr 2022 20:04:55 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Origin
-      X-B3-ParentSpanId:
-      - ba32ebafaa5412bb
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - ba32ebafaa5412bb
-      X-B3-TraceId:
-      - 62475ae7afff69d1ba32ebafaa5412bb
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: '{"name": "tmp_spectacles_5e52c0302c"}'
-    headers:
-      Content-Length:
-      - '37'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:56 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 18f2a123d9d2b1d1
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 18f2a123d9d2b1d1
-      X-B3-TraceId:
-      - 62475ae75a091f7e18f2a123d9d2b1d1
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:56 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 4684b916b53d567d
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 4684b916b53d567d
-      X-B3-TraceId:
-      - 62475ae87ccb1f3e4684b916b53d567d
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:56 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 036e146fc8d05444
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 036e146fc8d05444
-      X-B3-TraceId:
-      - 62475ae89cb36a5d036e146fc8d05444
+      - 624c4aff2c3bf6a2af791633a5320f98
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4227,235 +4005,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:56 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 4d28ba9f13805261
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 4d28ba9f13805261
-      X-B3-TraceId:
-      - 62475ae891c1de704d28ba9f13805261
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
-  response:
-    body:
-      string: '{"name":"pytest-incremental-equal","remote":"origin","remote_name":"pytest-incremental-equal","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":"742b118d314d2478a215aa02016c09e173deec7e","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '399'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:56 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - f32c5b12f035779f
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - f32c5b12f035779f
-      X-B3-TraceId:
-      - 62475ae830b0265df32c5b12f035779f
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_h"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_h","remote":"origin","remote_name":"tmp_spectacles_h","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:57 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - a54e49c6e484b552
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - a54e49c6e484b552
-      X-B3-TraceId:
-      - 62475ae8cdc4f84ca54e49c6e484b552
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_h", "ref": "b0823dad6abb07bf26e468bf91e7c6531c758e32"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_h","remote":"origin","remote_name":"tmp_spectacles_h","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:59 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 9e197b49eda3ceb5
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 9e197b49eda3ceb5
-      X-B3-TraceId:
-      - 62475ae98a0951299e197b49eda3ceb5
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:59 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 04bb7fe484d743ce
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 04bb7fe484d743ce
-      X-B3-TraceId:
-      - 62475aebd38cff7004bb7fe484d743ce
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:59 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 4851c8e3de4a1cd7
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 4851c8e3de4a1cd7
-      X-B3-TraceId:
-      - 62475aeb1c0011d34851c8e3de4a1cd7
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -4504,320 +4054,12 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:04:59 GMT
+      - Tue, 05 Apr 2022 13:58:23 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
-- request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:59 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 88ae148d9d199dda
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 88ae148d9d199dda
-      X-B3-TraceId:
-      - 62475aeb6e46604288ae148d9d199dda
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:59 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 97e099b2f51484cf
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 97e099b2f51484cf
-      X-B3-TraceId:
-      - 62475aeb0bb4972a97e099b2f51484cf
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:59 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - a63b76f9da06b4fa
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - a63b76f9da06b4fa
-      X-B3-TraceId:
-      - 62475aeb0125b440a63b76f9da06b4fa
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:59 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 04e166cefd842689
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 04e166cefd842689
-      X-B3-TraceId:
-      - 62475aeb0c69c17204e166cefd842689
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:59 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - b9fef699eae4fec2
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - b9fef699eae4fec2
-      X-B3-TraceId:
-      - 62475aebd10021ddb9fef699eae4fec2
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:04:59 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - a916c14937bd4b39
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - a916c14937bd4b39
-      X-B3-TraceId:
-      - 62475aebefd17fb9a916c14937bd4b39
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_i"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_i","remote":"origin","remote_name":"tmp_spectacles_i","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:00 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 98280d9c10ace5b5
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 98280d9c10ace5b5
-      X-B3-TraceId:
-      - 62475aeb5da6146998280d9c10ace5b5
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_i", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_i","remote":"origin","remote_name":"tmp_spectacles_i","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:05:00 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - b70d7065bd6b6f6d
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - b70d7065bd6b6f6d
-      X-B3-TraceId:
-      - 62475aeceb05790ab70d7065bd6b6f6d
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
 - request:
     body: '{"name": "pytest-incremental-equal"}'
     headers:
@@ -4826,7 +4068,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -4840,20 +4082,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:01 GMT
+      - Tue, 05 Apr 2022 13:58:24 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 5224118af4d52668
+      - 2ade5cdbde699ce9
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 5224118af4d52668
+      - 2ade5cdbde699ce9
       X-B3-TraceId:
-      - 62475aedbd0d642a5224118af4d52668
+      - 624c4affaa94f6f82ade5cdbde699ce9
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4865,9 +4107,9 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_h
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_f
   response:
     body:
       string: ''
@@ -4875,19 +4117,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:05:02 GMT
+      - Tue, 05 Apr 2022 13:58:24 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 165d1984b0d91373
+      - da16afb066a9b826
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 165d1984b0d91373
+      - da16afb066a9b826
       X-B3-TraceId:
-      - 62475aede77a2c5a165d1984b0d91373
+      - 624c4b007dc82364da16afb066a9b826
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4901,7 +4143,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -4915,20 +4157,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:03 GMT
+      - Tue, 05 Apr 2022 13:58:25 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - cd03303868ea114f
+      - fc405597ebd53b20
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - cd03303868ea114f
+      - fc405597ebd53b20
       X-B3-TraceId:
-      - 62475aee17d58b1ccd03303868ea114f
+      - 624c4b00015af895fc405597ebd53b20
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4940,9 +4182,9 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_i
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_g
   response:
     body:
       string: ''
@@ -4950,19 +4192,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:05:03 GMT
+      - Tue, 05 Apr 2022 13:58:25 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 2b7a13e271fed281
+      - 84582240bf42ee38
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2b7a13e271fed281
+      - 84582240bf42ee38
       X-B3-TraceId:
-      - 62475aefdec1fd432b7a13e271fed281
+      - 624c4b012037cf9184582240bf42ee38
       X-Content-Type-Options:
       - nosniff
     status:
@@ -4976,7 +4218,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -4990,20 +4232,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:04 GMT
+      - Tue, 05 Apr 2022 13:58:26 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f4c0bc7c86c5f94b
+      - ad98a7a84d59ad30
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f4c0bc7c86c5f94b
+      - ad98a7a84d59ad30
       X-B3-TraceId:
-      - 62475aefd9665955f4c0bc7c86c5f94b
+      - 624c4b01633af344ad98a7a84d59ad30
       X-Content-Type-Options:
       - nosniff
     status:
@@ -5017,7 +4259,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -5031,19 +4273,921 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:05:04 GMT
+      - Tue, 05 Apr 2022 13:58:26 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 23f411c90655fd3e
+      - 02a7699f4af211c3
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 23f411c90655fd3e
+      - 02a7699f4af211c3
       X-B3-TraceId:
-      - 62475af0ebf1d07a23f411c90655fd3e
+      - 624c4b02d56de6ae02a7699f4af211c3
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:26 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 98f6e3d4befc0453
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 98f6e3d4befc0453
+      X-B3-TraceId:
+      - 624c4b02c7be2f9798f6e3d4befc0453
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:26 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 1f17d7bd8fb64e99
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 1f17d7bd8fb64e99
+      X-B3-TraceId:
+      - 624c4b02c892b6171f17d7bd8fb64e99
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
+  response:
+    body:
+      string: '{"name":"pytest-incremental-equal","remote":"origin","remote_name":"pytest-incremental-equal","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":"742b118d314d2478a215aa02016c09e173deec7e","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '399'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:26 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 80bece43f62eda4b
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 80bece43f62eda4b
+      X-B3-TraceId:
+      - 624c4b02fcc9384f80bece43f62eda4b
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_h"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_h","remote":"origin","remote_name":"tmp_spectacles_h","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:27 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - ec869ee4f8b9126a
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - ec869ee4f8b9126a
+      X-B3-TraceId:
+      - 624c4b026d1febe5ec869ee4f8b9126a
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_h", "ref": "b0823dad6abb07bf26e468bf91e7c6531c758e32"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_h","remote":"origin","remote_name":"tmp_spectacles_h","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:28 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 0c18e33e68a5dd14
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 0c18e33e68a5dd14
+      X-B3-TraceId:
+      - 624c4b033f6fdbd00c18e33e68a5dd14
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:29 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 64d8288e59116aa2
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 64d8288e59116aa2
+      X-B3-TraceId:
+      - 624c4b045925bdf064d8288e59116aa2
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:29 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 25a0e97477cbe4ed
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 25a0e97477cbe4ed
+      X-B3-TraceId:
+      - 624c4b0518702ba425a0e97477cbe4ed
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:29 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 4c7a545c244a3800
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 4c7a545c244a3800
+      X-B3-TraceId:
+      - 624c4b056ead6a134c7a545c244a3800
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:29 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 6039a305429c7ac3
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 6039a305429c7ac3
+      X-B3-TraceId:
+      - 624c4b05df665f9b6039a305429c7ac3
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:29 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 5456460fcfc897f4
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 5456460fcfc897f4
+      X-B3-TraceId:
+      - 624c4b05b81b66e55456460fcfc897f4
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:29 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - b30fa2016ddadd9e
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - b30fa2016ddadd9e
+      X-B3-TraceId:
+      - 624c4b05bf36af99b30fa2016ddadd9e
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:29 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 659844e5ff18bd7d
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 659844e5ff18bd7d
+      X-B3-TraceId:
+      - 624c4b05d46c6046659844e5ff18bd7d
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:29 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 3bffca36225566d0
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 3bffca36225566d0
+      X-B3-TraceId:
+      - 624c4b05b9b99cc53bffca36225566d0
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:29 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 540d968ca9d94a95
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 540d968ca9d94a95
+      X-B3-TraceId:
+      - 624c4b05cd3cec8c540d968ca9d94a95
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_i"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_i","remote":"origin","remote_name":"tmp_spectacles_i","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:30 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 7be6775ff832d596
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 7be6775ff832d596
+      X-B3-TraceId:
+      - 624c4b0543a2cc347be6775ff832d596
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_i", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_i","remote":"origin","remote_name":"tmp_spectacles_i","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:30 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 5b917e269e23f038
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 5b917e269e23f038
+      X-B3-TraceId:
+      - 624c4b069995e96a5b917e269e23f038
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html>\n<head>\n    <title>Looker Not Found (404)</title>\n
+        \   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600'
+        rel='stylesheet' type='text/css'>\n\n    <!-- @@@@@@@@@@@@@ FAVICONS @@@@@@@@@@@@@
+        -->\n\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"57x57\" href=\"https://wwwstatic-b.lookercdn.com/favicon/apple-touch-icon-57x57.png\"
+        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"114x114\" href=\"https://wwwstatic-c.lookercdn.com/favicon/apple-touch-icon-114x114.png\"
+        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"72x72\" href=\"https://wwwstatic-d.lookercdn.com/favicon/apple-touch-icon-72x72.png\"
+        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"144x144\" href=\"https://wwwstatic-a.lookercdn.com/favicon/apple-touch-icon-144x144.png\"
+        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"60x60\" href=\"https://wwwstatic-b.lookercdn.com/favicon/apple-touch-icon-60x60.png\"
+        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"120x120\" href=\"https://wwwstatic-c.lookercdn.com/favicon/apple-touch-icon-120x120.png\"
+        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"76x76\" href=\"https://wwwstatic-d.lookercdn.com/favicon/apple-touch-icon-76x76.png\"
+        />\n    <link rel=\"apple-touch-icon-precomposed\" sizes=\"152x152\" href=\"https://wwwstatic-a.lookercdn.com/favicon/apple-touch-icon-152x152.png\"
+        />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-b.lookercdn.com/favicon/favicon-196x196.png\"
+        sizes=\"196x196\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-c.lookercdn.com/favicon/favicon-96x96.png\"
+        sizes=\"96x96\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-d.lookercdn.com/favicon/favicon-32x32.png\"
+        sizes=\"32x32\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-a.lookercdn.com/favicon/favicon-16x16.png\"
+        sizes=\"16x16\" />\n    <link rel=\"icon\" type=\"image/png\" href=\"https://wwwstatic-b.lookercdn.com/favicon/favicon-128.png\"
+        sizes=\"128x128\" />\n    <meta name=\"application-name\" content=\"Looker\"/>\n
+        \   <meta name=\"msapplication-TileColor\" content=\"#FFFFFF\" />\n    <meta
+        name=\"msapplication-TileImage\" content=\"https://wwwstatic-c.lookercdn.com/favicon/mstile-144x144.png\"
+        />\n    <meta name=\"msapplication-square70x70logo\" content=\"https://wwwstatic-d.lookercdn.com/favicon/mstile-70x70.png\"
+        />\n    <meta name=\"msapplication-square150x150logo\" content=\"https://wwwstatic-a.lookercdn.com/favicon/mstile-150x150.png\"
+        />\n    <meta name=\"msapplication-wide310x150logo\" content=\"https://wwwstatic-b.lookercdn.com/favicon/mstile-310x150.png\"
+        />\n    <meta name=\"msapplication-square310x310logo\" content=\"https://wwwstatic-c.lookercdn.com/favicon/mstile-310x310.png\"
+        />\n\n    <style type=\"text/css\">\n        body {\n            background-color:
+        #2e343f;\n            color: white;\n            height: auto;\n            font-family:
+        Open Sans, Helvetica, Arial, sans-serif;\n        }\n        .message {\n
+        \           width: 100%;\n            max-width: 760px;\n            margin:
+        0 auto;\n            margin-top: 135px;\n            text-align: center;\n
+        \       }\n        h2, h3 {\n            font-weight: normal;\n        }\n
+        \       a {\n            color: white;\n        }\n    </style>\n</head>\n<body>\n\n
+        \   <div class=\"message\">\n\n        <img width=\"210\" height=\"84\" src=\"https://wwwstatic-a.lookercdn.com/logos/looker_all_white.svg\"
+        alt=\"Looker\">\n\n        <h1>Looker is unavailable.</h1>\n\n        <h2>If
+        you typed in a URL, double-check the spelling.</h2>\n        <h2>This may
+        also be due to a temporary condition such as an outage, <a href=\"https://docs.looker.com/relnotes/hosted-maintenance-hours\">scheduled
+        maintenance</a> or upgrade.</h2>\n        <br>\n        <h3>\n            If
+        this message persists or you have any concerns, <br> contact us from\n            <a
+        href=\"https://help.looker.com\">help.looker.com</a> and we'll respond promptly.\n
+        \       </h3>\n\n    </div>\n\n</body>\n</html>\n"
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - text/html
+      Date:
+      - Tue, 05 Apr 2022 13:58:30 GMT
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: '{"name": "pytest-incremental-equal"}'
+    headers:
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
+  response:
+    body:
+      string: '{"name":"pytest-incremental-equal","remote":"origin","remote_name":"pytest-incremental-equal","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":false,"ahead_count":0,"behind_count":0,"commit_at":1648832027,"ref":"742b118d314d2478a215aa02016c09e173deec7e","remote_ref":"742b118d314d2478a215aa02016c09e173deec7e","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '399'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:31 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 0ce6161bf51c8287
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 0ce6161bf51c8287
+      X-B3-TraceId:
+      - 624c4b063c22cf3d0ce6161bf51c8287
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Content-Length:
+      - '0'
+      Cookie:
+      - looker.browser=39326198
+    method: DELETE
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch/tmp_spectacles_h
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 05 Apr 2022 13:58:32 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Origin
+      X-B3-ParentSpanId:
+      - 5bc98cd455a543f0
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 5bc98cd455a543f0
+      X-B3-TraceId:
+      - 624c4b0767102b815bc98cd455a543f0
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{"name": "tmp_spectacles_5e52c0302c"}'
+    headers:
+      Content-Length:
+      - '37'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:33 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - b9155aca82da722e
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - b9155aca82da722e
+      X-B3-TraceId:
+      - 624c4b0872d98a69b9155aca82da722e
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Content-Length:
+      - '0'
+      Cookie:
+      - looker.browser=39326198
+    method: DELETE
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_i
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 05 Apr 2022 13:58:33 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Origin
+      X-B3-ParentSpanId:
+      - 28bf42bc60a5578a
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 28bf42bc60a5578a
+      X-B3-TraceId:
+      - 624c4b09c856cc7328bf42bc60a5578a
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{"name": "tmp_spectacles_5e52c0302c"}'
+    headers:
+      Content-Length:
+      - '37'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:33 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 6a68d268169ca6ae
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 6a68d268169ca6ae
+      X-B3-TraceId:
+      - 624c4b0990d843a46a68d268169ca6ae
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:33 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 046493d0f28837d8
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 046493d0f28837d8
+      X-B3-TraceId:
+      - 624c4b099fb9c8c6046493d0f28837d8
       X-Content-Type-Options:
       - nosniff
     status:

--- a/tests/cassettes/test_runner/test_validate_content_should_work.yaml
+++ b/tests/cassettes/test_runner/test_validate_content_should_work.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -17,19 +17,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:25 GMT
+      - Tue, 05 Apr 2022 13:58:38 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - a14a7c19b2ff98dc
+      - 7f94b23b9d19d1bb
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a14a7c19b2ff98dc
+      - 7f94b23b9d19d1bb
       X-B3-TraceId:
-      - 62475ac95352e7f8a14a7c19b2ff98dc
+      - 624c4b0e718b19607f94b23b9d19d1bb
       X-Content-Type-Options:
       - nosniff
     status:
@@ -39,7 +39,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -53,20 +53,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:25 GMT
+      - Tue, 05 Apr 2022 13:58:38 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - d73928a13689d5e2
+      - 4bf4ad5252de4b40
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - d73928a13689d5e2
+      - 4bf4ad5252de4b40
       X-B3-TraceId:
-      - 62475ac9a395b166d73928a13689d5e2
+      - 624c4b0ed71e59b64bf4ad5252de4b40
       X-Content-Type-Options:
       - nosniff
     status:
@@ -76,7 +76,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
   response:
@@ -90,19 +90,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:25 GMT
+      - Tue, 05 Apr 2022 13:58:38 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 86e980e0a971c866
+      - 4469740fffd17e43
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 86e980e0a971c866
+      - 4469740fffd17e43
       X-B3-TraceId:
-      - 62475ac99324d22386e980e0a971c866
+      - 624c4b0ef3327e874469740fffd17e43
       X-Content-Type-Options:
       - nosniff
     status:
@@ -112,7 +112,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models?fields=name%2Cproject_name%2Cexplores
   response:
@@ -196,20 +196,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:25 GMT
+      - Tue, 05 Apr 2022 13:58:39 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 734b8115a09132ba
+      - adb6e620bb3ec902
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 734b8115a09132ba
+      - adb6e620bb3ec902
       X-B3-TraceId:
-      - 62475ac9fbaabe3f734b8115a09132ba
+      - 624c4b0e89eab4d1adb6e620bb3ec902
       X-Content-Type-Options:
       - nosniff
     status:
@@ -219,7 +219,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/content_validation
   response:
@@ -263,7 +263,7 @@ interactions:
         Analytics Overview","space":{"name":"Looker eCommerce","id":47},"folder":{"name":"Looker
         eCommerce","id":47},"id":24},"dashboard_element":{"body_text":null,"dashboard_id":24,"id":203,"look_id":null,"note_display":"below","note_state":"expanded","note_text":"","note_text_as_html":"","query_id":null,"subtitle_text":null,"title":"Total
         Profit","title_hidden":false,"title_text":null,"type":"vis","rich_content_json":null},"dashboard_filter":null,"scheduled_plan":null,"alert":null,"lookml_dashboard":null,"lookml_dashboard_element":null,"errors":[{"message":"Unknown
-        field \"orders.total_profit_k\".","field_name":"orders.total_profit_k","model_name":"thelook_partner","explore_name":"order_items","removable":true}],"id":9}],"computation_time":0.999569,"total_looks_validated":31,"total_dashboard_elements_validated":167,"total_dashboard_filters_validated":29,"total_scheduled_plans_validated":9,"total_alerts_validated":0,"total_explores_validated":26}'
+        field \"orders.total_profit_k\".","field_name":"orders.total_profit_k","model_name":"thelook_partner","explore_name":"order_items","removable":true}],"id":9}],"computation_time":1.035665,"total_looks_validated":31,"total_dashboard_elements_validated":167,"total_dashboard_filters_validated":29,"total_scheduled_plans_validated":9,"total_alerts_validated":0,"total_explores_validated":26}'
     headers:
       Connection:
       - keep-alive
@@ -272,20 +272,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:04:26 GMT
+      - Tue, 05 Apr 2022 13:58:40 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 26048247eaae6119
+      - 3d7c82720eba46c3
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 26048247eaae6119
+      - 3d7c82720eba46c3
       X-B3-TraceId:
-      - 62475ac92fe8447226048247eaae6119
+      - 624c4b0fa7f68a473d7c82720eba46c3
       X-Content-Type-Options:
       - nosniff
     status:

--- a/tests/cassettes/test_runner/test_validate_data_tests_should_work.yaml
+++ b/tests/cassettes/test_runner/test_validate_data_tests_should_work.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -17,19 +17,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:20 GMT
+      - Tue, 05 Apr 2022 13:58:34 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 50003758274029d0
+      - 004f9bf6ecb8bda7
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 50003758274029d0
+      - 004f9bf6ecb8bda7
       X-B3-TraceId:
-      - 62475a4ccbb89afc50003758274029d0
+      - 624c4b0a9cf1ea84004f9bf6ecb8bda7
       X-Content-Type-Options:
       - nosniff
     status:
@@ -39,7 +39,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -53,20 +53,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:20 GMT
+      - Tue, 05 Apr 2022 13:58:34 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 857a6246eef841a8
+      - 3dbabaddaf4f01da
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 857a6246eef841a8
+      - 3dbabaddaf4f01da
       X-B3-TraceId:
-      - 62475a4c64a8dace857a6246eef841a8
+      - 624c4b0ac9a6dd533dbabaddaf4f01da
       X-Content-Type-Options:
       - nosniff
     status:
@@ -76,7 +76,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
   response:
@@ -90,19 +90,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:20 GMT
+      - Tue, 05 Apr 2022 13:58:34 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 46af47190513f914
+      - d2ca97b8b479dd00
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 46af47190513f914
+      - d2ca97b8b479dd00
       X-B3-TraceId:
-      - 62475a4cce93695346af47190513f914
+      - 624c4b0abe9c31c8d2ca97b8b479dd00
       X-Content-Type-Options:
       - nosniff
     status:
@@ -112,7 +112,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models?fields=name%2Cproject_name%2Cexplores
   response:
@@ -196,20 +196,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:20 GMT
+      - Tue, 05 Apr 2022 13:58:34 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - faec8a31406f73e9
+      - be5887e0644597ae
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - faec8a31406f73e9
+      - be5887e0644597ae
       X-B3-TraceId:
-      - 62475a4cbd23d9fbfaec8a31406f73e9
+      - 624c4b0abdf961c5be5887e0644597ae
       X-Content-Type-Options:
       - nosniff
     status:
@@ -219,7 +219,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/lookml_tests
   response:
@@ -233,20 +233,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:20 GMT
+      - Tue, 05 Apr 2022 13:58:34 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - ceae84ce59238e3b
+      - 6544a89a2930c437
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - ceae84ce59238e3b
+      - 6544a89a2930c437
       X-B3-TraceId:
-      - 62475a4c08107963ceae84ce59238e3b
+      - 624c4b0ab01da6a16544a89a2930c437
       X-Content-Type-Options:
       - nosniff
     status:
@@ -256,7 +256,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/lookml_tests/run?model=eye_exam&test=users_age_should_be_in_expected_range
   response:
@@ -270,19 +270,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:21 GMT
+      - Tue, 05 Apr 2022 13:58:35 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 48c4808e502a7c0c
+      - 908b3c44081378c0
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 48c4808e502a7c0c
+      - 908b3c44081378c0
       X-B3-TraceId:
-      - 62475a4c193112b548c4808e502a7c0c
+      - 624c4b0ab1376df6908b3c44081378c0
       X-Content-Type-Options:
       - nosniff
     status:
@@ -292,7 +292,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/lookml_tests/run?model=eye_exam&test=users_name_should_be_in_caps
   response:
@@ -306,19 +306,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:21 GMT
+      - Tue, 05 Apr 2022 13:58:37 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 7b6692048a1793c0
+      - faa81c7aa386ba55
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 7b6692048a1793c0
+      - faa81c7aa386ba55
       X-B3-TraceId:
-      - 62475a4ddb99c08d7b6692048a1793c0
+      - 624c4b0b85d6798cfaa81c7aa386ba55
       X-Content-Type-Options:
       - nosniff
     status:
@@ -328,7 +328,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/lookml_tests/run?model=eye_exam&test=users__fail_age_should_be_in_expected_range
   response:
@@ -346,20 +346,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:21 GMT
+      - Tue, 05 Apr 2022 13:58:38 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - ee0c10f828bed1b9
+      - 213e605aa8c97384
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - ee0c10f828bed1b9
+      - 213e605aa8c97384
       X-B3-TraceId:
-      - 62475a4d49eeff51ee0c10f828bed1b9
+      - 624c4b0db19aea25213e605aa8c97384
       X-Content-Type-Options:
       - nosniff
     status:
@@ -369,7 +369,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/lookml_tests/run?model=eye_exam&test=users__fail_name_should_be_in_caps
   response:
@@ -385,20 +385,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:02:22 GMT
+      - Tue, 05 Apr 2022 13:58:38 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 6dcc3e769d54d606
+      - 43315101bd32c715
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6dcc3e769d54d606
+      - 43315101bd32c715
       X-B3-TraceId:
-      - 62475a4deaf9b2e96dcc3e769d54d606
+      - 624c4b0e1b76e88b43315101bd32c715
       X-Content-Type-Options:
       - nosniff
     status:

--- a/tests/cassettes/test_runner/test_validate_sql_should_work[False].yaml
+++ b/tests/cassettes/test_runner/test_validate_sql_should_work[False].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -17,19 +17,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:19 GMT
+      - Tue, 05 Apr 2022 13:58:40 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 84c66c68b53b2560
+      - 8a4e278caae32505
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 84c66c68b53b2560
+      - 8a4e278caae32505
       X-B3-TraceId:
-      - 62475a871fc3319484c66c68b53b2560
+      - 624c4b10a55d57138a4e278caae32505
       X-Content-Type-Options:
       - nosniff
     status:
@@ -39,7 +39,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -53,56 +53,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:19 GMT
+      - Tue, 05 Apr 2022 13:58:40 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - cb1d785c1ae7a788
+      - 56e90dbebf3e62b9
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - cb1d785c1ae7a788
+      - 56e90dbebf3e62b9
       X-B3-TraceId:
-      - 62475a87a8193367cb1d785c1ae7a788
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
-  response:
-    body:
-      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '147'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:19 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 369d48597fe279ee
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 369d48597fe279ee
-      X-B3-TraceId:
-      - 62475a8792e86dd6369d48597fe279ee
+      - 624c4b10a26ef12256e90dbebf3e62b9
       X-Content-Type-Options:
       - nosniff
     status:
@@ -116,7 +80,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -130,19 +94,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:20 GMT
+      - Tue, 05 Apr 2022 13:58:40 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f03a5aa5810ff119
+      - bcda68b49670d4ff
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f03a5aa5810ff119
+      - bcda68b49670d4ff
       X-B3-TraceId:
-      - 62475a880be31113f03a5aa5810ff119
+      - 624c4b1062938d6dbcda68b49670d4ff
       X-Content-Type-Options:
       - nosniff
     status:
@@ -156,7 +120,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -170,20 +134,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:20 GMT
+      - Tue, 05 Apr 2022 13:58:41 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - c34e059b3d6022ff
+      - b1674653b26692d8
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - c34e059b3d6022ff
+      - b1674653b26692d8
       X-B3-TraceId:
-      - 62475a883da5e476c34e059b3d6022ff
+      - 624c4b10db012a24b1674653b26692d8
       X-Content-Type-Options:
       - nosniff
     status:
@@ -195,7 +159,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/reset_to_remote
   response:
@@ -205,19 +169,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:03:21 GMT
+      - Tue, 05 Apr 2022 13:58:42 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 5d144802e3036dce
+      - 3868470a90f151ba
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 5d144802e3036dce
+      - 3868470a90f151ba
       X-B3-TraceId:
-      - 62475a8841f6119f5d144802e3036dce
+      - 624c4b1170a1296c3868470a90f151ba
       X-Content-Type-Options:
       - nosniff
     status:
@@ -227,7 +191,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:42 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 1d3ace27392b3a07
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 1d3ace27392b3a07
+      X-B3-TraceId:
+      - 624c4b1257baf1751d3ace27392b3a07
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -241,19 +241,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:21 GMT
+      - Tue, 05 Apr 2022 13:58:42 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - e9d5159f53ff743a
+      - 8bd3fd4f66c91bc3
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - e9d5159f53ff743a
+      - 8bd3fd4f66c91bc3
       X-B3-TraceId:
-      - 62475a89679536dde9d5159f53ff743a
+      - 624c4b12660a5ea18bd3fd4f66c91bc3
       X-Content-Type-Options:
       - nosniff
     status:
@@ -263,7 +263,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -277,20 +277,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:21 GMT
+      - Tue, 05 Apr 2022 13:58:42 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 58a36beb2a45ec45
+      - d66de296686eed54
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 58a36beb2a45ec45
+      - d66de296686eed54
       X-B3-TraceId:
-      - 62475a89430ad7d858a36beb2a45ec45
+      - 624c4b1233a633e6d66de296686eed54
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:42 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - e3a24b297338054d
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - e3a24b297338054d
+      X-B3-TraceId:
+      - 624c4b126450d41ae3a24b297338054d
       X-Content-Type-Options:
       - nosniff
     status:
@@ -300,7 +340,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:42 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - fb4db523a0c13259
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - fb4db523a0c13259
+      X-B3-TraceId:
+      - 624c4b121d27dbe2fb4db523a0c13259
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:42 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 5107e1403b79341f
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 5107e1403b79341f
+      X-B3-TraceId:
+      - 624c4b1202bd08d35107e1403b79341f
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:42 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 09d246d0e8fdfe2c
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 09d246d0e8fdfe2c
+      X-B3-TraceId:
+      - 624c4b1299768d6309d246d0e8fdfe2c
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:42 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 222b6442f4ac8017
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 222b6442f4ac8017
+      X-B3-TraceId:
+      - 624c4b120ef14334222b6442f4ac8017
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:42 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 0543db341d99566c
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 0543db341d99566c
+      X-B3-TraceId:
+      - 624c4b12d09bf77c0543db341d99566c
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_a"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:43 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 53945a5e44cb3d96
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 53945a5e44cb3d96
+      X-B3-TraceId:
+      - 624c4b12b3590ae553945a5e44cb3d96
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_a", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:43 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - a26bec5fe0a6d67d
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - a26bec5fe0a6d67d
+      X-B3-TraceId:
+      - 624c4b134192dd9aa26bec5fe0a6d67d
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -349,325 +657,17 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:03:21 GMT
+      - Tue, 05 Apr 2022 13:58:43 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:21 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 6bf8d8e18df268de
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 6bf8d8e18df268de
-      X-B3-TraceId:
-      - 62475a89e260c3166bf8d8e18df268de
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:21 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - b3250e07b6674cf6
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - b3250e07b6674cf6
-      X-B3-TraceId:
-      - 62475a89906346fcb3250e07b6674cf6
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:22 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - c16624d48fbe32b5
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - c16624d48fbe32b5
-      X-B3-TraceId:
-      - 62475a8a7c1a3afac16624d48fbe32b5
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:22 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - d4b7c09157f03f09
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - d4b7c09157f03f09
-      X-B3-TraceId:
-      - 62475a8aba3b2e6dd4b7c09157f03f09
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:22 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 8086efa7568c1373
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 8086efa7568c1373
-      X-B3-TraceId:
-      - 62475a8a871698378086efa7568c1373
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:22 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - decb8db5a34f2e4f
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - decb8db5a34f2e4f
-      X-B3-TraceId:
-      - 62475a8aedc00531decb8db5a34f2e4f
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_a"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:22 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 88d3e824b99a804e
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 88d3e824b99a804e
-      X-B3-TraceId:
-      - 62475a8a4521a7fe88d3e824b99a804e
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_a", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:23 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 84a9c0283f06c7e2
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 84a9c0283f06c7e2
-      X-B3-TraceId:
-      - 62475a8ace403a2484a9c0283f06c7e2
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models?fields=name%2Cproject_name%2Cexplores
   response:
@@ -751,20 +751,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:23 GMT
+      - Tue, 05 Apr 2022 13:58:44 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 9ba6562515426a55
+      - 5fe01bc2a89cd517
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 9ba6562515426a55
+      - 5fe01bc2a89cd517
       X-B3-TraceId:
-      - 62475a8b59657c199ba6562515426a55
+      - 624c4b13799cb41d5fe01bc2a89cd517
       X-Content-Type-Options:
       - nosniff
     status:
@@ -774,7 +774,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users?fields=fields
   response:
@@ -805,20 +805,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:24 GMT
+      - Tue, 05 Apr 2022 13:58:44 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - b1fa4fc4359ae402
+      - 27ca38e3e88f948b
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - b1fa4fc4359ae402
+      - 27ca38e3e88f948b
       X-B3-TraceId:
-      - 62475a8c669105a0b1fa4fc4359ae402
+      - 624c4b14fef3e8e727ca38e3e88f948b
       X-Content-Type-Options:
       - nosniff
     status:
@@ -828,7 +828,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users__fail?fields=fields
   response:
@@ -864,20 +864,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:24 GMT
+      - Tue, 05 Apr 2022 13:58:44 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - e32524196ca73372
+      - 79ec80cf0018f7eb
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - e32524196ca73372
+      - 79ec80cf0018f7eb
       X-B3-TraceId:
-      - 62475a8cc125f213e32524196ca73372
+      - 624c4b14d354db7779ec80cf0018f7eb
       X-Content-Type-Options:
       - nosniff
     status:
@@ -893,7 +893,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -907,19 +907,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:24 GMT
+      - Tue, 05 Apr 2022 13:58:44 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - d2027d383687bf71
+      - cddacfaf5d74e638
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - d2027d383687bf71
+      - cddacfaf5d74e638
       X-B3-TraceId:
-      - 62475a8ca636088ad2027d383687bf71
+      - 624c4b1499bfa5abcddacfaf5d74e638
       X-Content-Type-Options:
       - nosniff
     status:
@@ -935,7 +935,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -949,19 +949,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:24 GMT
+      - Tue, 05 Apr 2022 13:58:45 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - fb276cd745970271
+      - d44465303974da79
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - fb276cd745970271
+      - d44465303974da79
       X-B3-TraceId:
-      - 62475a8c582a6103fb276cd745970271
+      - 624c4b1576cc5074d44465303974da79
       X-Content-Type-Options:
       - nosniff
     status:
@@ -975,7 +975,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -989,20 +989,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:25 GMT
+      - Tue, 05 Apr 2022 13:58:45 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 66a5741825bfd8b1
+      - 51a648356868798d
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 66a5741825bfd8b1
+      - 51a648356868798d
       X-B3-TraceId:
-      - 62475a8c45da3aef66a5741825bfd8b1
+      - 624c4b15c0ca67b151a648356868798d
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1014,7 +1014,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_a
   response:
@@ -1024,19 +1024,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:03:25 GMT
+      - Tue, 05 Apr 2022 13:58:45 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 906bc3ea75bf4954
+      - a83d383386a85374
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 906bc3ea75bf4954
+      - a83d383386a85374
       X-B3-TraceId:
-      - 62475a8d744bff11906bc3ea75bf4954
+      - 624c4b15b27be6c6a83d383386a85374
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1050,7 +1050,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -1064,20 +1064,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:25 GMT
+      - Tue, 05 Apr 2022 13:58:46 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 7829b9a34bf1abd8
+      - a6d392e4192fa6a9
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 7829b9a34bf1abd8
+      - a6d392e4192fa6a9
       X-B3-TraceId:
-      - 62475a8d7d56525b7829b9a34bf1abd8
+      - 624c4b15c6b22015a6d392e4192fa6a9
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1091,7 +1091,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1105,19 +1105,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:25 GMT
+      - Tue, 05 Apr 2022 13:58:46 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 2ed094d8fc8f754b
+      - 2ae719de14f1a737
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2ed094d8fc8f754b
+      - 2ae719de14f1a737
       X-B3-TraceId:
-      - 62475a8d2e36847b2ed094d8fc8f754b
+      - 624c4b16c43209232ae719de14f1a737
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1131,7 +1131,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1145,19 +1145,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:26 GMT
+      - Tue, 05 Apr 2022 13:58:46 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 1832ee0668d0c3a7
+      - c1d009eaf8cbc462
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 1832ee0668d0c3a7
+      - c1d009eaf8cbc462
       X-B3-TraceId:
-      - 62475a8e582976f51832ee0668d0c3a7
+      - 624c4b16768701bbc1d009eaf8cbc462
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1171,7 +1171,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -1185,20 +1185,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:26 GMT
+      - Tue, 05 Apr 2022 13:58:47 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 0b152e80a1f9fa61
+      - 9ce20d22bde43543
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 0b152e80a1f9fa61
+      - 9ce20d22bde43543
       X-B3-TraceId:
-      - 62475a8eaffe6ce80b152e80a1f9fa61
+      - 624c4b165216d1029ce20d22bde43543
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1210,7 +1210,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/reset_to_remote
   response:
@@ -1220,19 +1220,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:03:27 GMT
+      - Tue, 05 Apr 2022 13:58:48 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 5ee71d766bc52cb7
+      - 8cc367dd1342b6bd
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 5ee71d766bc52cb7
+      - 8cc367dd1342b6bd
       X-B3-TraceId:
-      - 62475a8edb3f27a75ee71d766bc52cb7
+      - 624c4b17e57a80a28cc367dd1342b6bd
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1242,7 +1242,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:48 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 3dfc0611b25be5f4
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 3dfc0611b25be5f4
+      X-B3-TraceId:
+      - 624c4b18c408babd3dfc0611b25be5f4
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1256,19 +1292,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:27 GMT
+      - Tue, 05 Apr 2022 13:58:48 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 0660c73a36948803
+      - 3c693f41ad4da17b
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 0660c73a36948803
+      - 3c693f41ad4da17b
       X-B3-TraceId:
-      - 62475a8f9bcedc480660c73a36948803
+      - 624c4b18be4c8e3b3c693f41ad4da17b
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1278,7 +1314,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -1292,20 +1328,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:27 GMT
+      - Tue, 05 Apr 2022 13:58:48 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 0ba3b8aca9466f25
+      - '5415801603585258'
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 0ba3b8aca9466f25
+      - '5415801603585258'
       X-B3-TraceId:
-      - 62475a8fec5af91c0ba3b8aca9466f25
+      - 624c4b18b25c47695415801603585258
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:48 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 8b850fcd2986881e
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 8b850fcd2986881e
+      X-B3-TraceId:
+      - 624c4b182bbdf0be8b850fcd2986881e
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1315,7 +1391,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:48 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 5f50efa2736065d2
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 5f50efa2736065d2
+      X-B3-TraceId:
+      - 624c4b1809b2e2345f50efa2736065d2
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:48 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 1f14226c9f5a8588
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 1f14226c9f5a8588
+      X-B3-TraceId:
+      - 624c4b180bd17fa21f14226c9f5a8588
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:48 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - e9160f51b507de43
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - e9160f51b507de43
+      X-B3-TraceId:
+      - 624c4b1858507c59e9160f51b507de43
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:48 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 292d58a2fbf79b0a
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 292d58a2fbf79b0a
+      X-B3-TraceId:
+      - 624c4b18fcf3ea24292d58a2fbf79b0a
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:48 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - c15fa44cfc0b05f6
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - c15fa44cfc0b05f6
+      X-B3-TraceId:
+      - 624c4b187aff9b84c15fa44cfc0b05f6
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_b"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:49 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 150a4e9f46db6a0a
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 150a4e9f46db6a0a
+      X-B3-TraceId:
+      - 624c4b1835dbc0cb150a4e9f46db6a0a
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_b", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:49 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - ada07e568cbda396
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - ada07e568cbda396
+      X-B3-TraceId:
+      - 624c4b199e5026dfada07e568cbda396
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -1364,320 +1708,12 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:03:27 GMT
+      - Tue, 05 Apr 2022 13:58:50 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
-- request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:27 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 235a04afcd1f39a9
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 235a04afcd1f39a9
-      X-B3-TraceId:
-      - 62475a8fbcefceaa235a04afcd1f39a9
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:27 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - d806cebe735e6ccb
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - d806cebe735e6ccb
-      X-B3-TraceId:
-      - 62475a8f518b3a15d806cebe735e6ccb
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:28 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 9c1a41eea83787a9
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 9c1a41eea83787a9
-      X-B3-TraceId:
-      - 62475a90551b27e09c1a41eea83787a9
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:28 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - d43487a64b18b292
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - d43487a64b18b292
-      X-B3-TraceId:
-      - 62475a905b447d7cd43487a64b18b292
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:28 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - e71af61c58bc4ea3
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - e71af61c58bc4ea3
-      X-B3-TraceId:
-      - 62475a90d2fdba60e71af61c58bc4ea3
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:28 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 6c42c30f4467e210
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 6c42c30f4467e210
-      X-B3-TraceId:
-      - 62475a90d4e93c816c42c30f4467e210
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_b"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:28 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - cd100f0b45068c77
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - cd100f0b45068c77
-      X-B3-TraceId:
-      - 62475a9044db40c3cd100f0b45068c77
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_b", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:29 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - b0c414c4a8abc004
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - b0c414c4a8abc004
-      X-B3-TraceId:
-      - 62475a90b5447e19b0c414c4a8abc004
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
 - request:
     body: '{"query_id": 2216, "result_format": "json_detail"}'
     headers:
@@ -1686,12 +1722,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"0e0bbfcc4914874b823a562f2ad2b692"}'
+      string: '{"id":"2cd3996b16eb3f765b904b29fbdaf66a"}'
     headers:
       Connection:
       - keep-alive
@@ -1700,19 +1736,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:29 GMT
+      - Tue, 05 Apr 2022 13:58:50 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 8e55ca9d3cc718e9
+      - 85e137f4cae1cbbb
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 8e55ca9d3cc718e9
+      - 85e137f4cae1cbbb
       X-B3-TraceId:
-      - 62475a91453667a38e55ca9d3cc718e9
+      - 624c4b1aae71aec185e137f4cae1cbbb
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1726,12 +1762,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"1c70056c137afd61654cf62fb6acee46"}'
+      string: '{"id":"d4826f6fc53272f6a49ba698921e7c84"}'
     headers:
       Connection:
       - keep-alive
@@ -1740,19 +1776,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:29 GMT
+      - Tue, 05 Apr 2022 13:58:50 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 677a4c88d2df35c1
+      - 797f99e8fba0cc7d
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 677a4c88d2df35c1
+      - 797f99e8fba0cc7d
       X-B3-TraceId:
-      - 62475a9186cb739e677a4c88d2df35c1
+      - 624c4b1adfe55585797f99e8fba0cc7d
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1762,12 +1798,12 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=0e0bbfcc4914874b823a562f2ad2b692%2C1c70056c137afd61654cf62fb6acee46
+    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=2cd3996b16eb3f765b904b29fbdaf66a%2Cd4826f6fc53272f6a49ba698921e7c84
   response:
     body:
-      string: '{"0e0bbfcc4914874b823a562f2ad2b692":{"status":"running"},"1c70056c137afd61654cf62fb6acee46":{"status":"added"}}'
+      string: '{"2cd3996b16eb3f765b904b29fbdaf66a":{"status":"running"},"d4826f6fc53272f6a49ba698921e7c84":{"status":"added"}}'
     headers:
       Connection:
       - keep-alive
@@ -1776,19 +1812,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:29 GMT
+      - Tue, 05 Apr 2022 13:58:50 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 2e322dcb929fb32d
+      - 6636224f04ab804e
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2e322dcb929fb32d
+      - 6636224f04ab804e
       X-B3-TraceId:
-      - 62475a911204d21f2e322dcb929fb32d
+      - 624c4b1af580680a6636224f04ab804e
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1798,12 +1834,12 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=0e0bbfcc4914874b823a562f2ad2b692%2C1c70056c137afd61654cf62fb6acee46
+    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=2cd3996b16eb3f765b904b29fbdaf66a%2Cd4826f6fc53272f6a49ba698921e7c84
   response:
     body:
-      string: '{"0e0bbfcc4914874b823a562f2ad2b692":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"0e0bbfcc4914874b823a562f2ad2b692","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:03:30+00:00","aggregate_table_used_info":null,"runtime":"0.471","added_params":{"query_timezone":"America/New_York","sorts":["users.city"]},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":true,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_ukSHvLNpexoPL0CariK142mPBJRt"},"sql":"SELECT\n    users.city  AS
+      string: '{"2cd3996b16eb3f765b904b29fbdaf66a":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"2cd3996b16eb3f765b904b29fbdaf66a","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:58:51+00:00","aggregate_table_used_info":null,"runtime":"0.505","added_params":{"query_timezone":"America/New_York","sorts":["users.city"]},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":true,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_lksxWxVGjBfYoRJd4zKbQiIm1sJs"},"sql":"SELECT\n    users.city  AS
         users_city,\n    users.email  AS users_email,\n    users.first_name  AS users_first_name,\n    users.id  AS
         users_id,\n    users.last_name  AS users_last_name,\n    users.state  AS users_state\nFROM
         looker-private-demo.ecomm.users\n     AS users\nWHERE (1 = 2)\nORDER BY\n    1\nLIMIT
@@ -1821,7 +1857,7 @@ interactions:
         Name","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.last_name","suggest_explore":"users","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=38","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.last_name
         ","sql_case":null,"filters":null,"times_used":0},{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
         State","label_from_parameter":null,"label_short":"State","map_layer":{"url":"/data/us_states.topo-402e425f99.json","name":"us_states","feature_key":"usa","property_key":null,"property_label_key":null,"projection":"albersUsa","format":"","extents_json_url":null,"max_zoom_level":null,"min_zoom_level":null},"name":"users.state","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users","view_label":"Users","dynamic":false,"week_start_day":"monday","original_view":"users","dimension_group":null,"error":null,"field_group_variant":"State","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.state","suggest_explore":"users","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=18","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.state
-        ","sql_case":null,"filters":null,"times_used":0}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users","label":"Users","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.06622600000000001,"has_subtotals":false}},"1c70056c137afd61654cf62fb6acee46":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"1c70056c137afd61654cf62fb6acee46","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:03:30+00:00","aggregate_table_used_info":null,"runtime":"0.282","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.city"]},"forecast_result":null,"sql":"SELECT\n    users__fail.city  AS
+        ","sql_case":null,"filters":null,"times_used":0}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users","label":"Users","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.06656100000000001,"has_subtotals":false}},"d4826f6fc53272f6a49ba698921e7c84":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"d4826f6fc53272f6a49ba698921e7c84","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:58:50+00:00","aggregate_table_used_info":null,"runtime":"0.325","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.city"]},"forecast_result":null,"sql":"SELECT\n    users__fail.city  AS
         users__fail_city,\n    users__fail.email_address  AS users__fail_email,\n    users__fail.first  AS
         users__fail_first_name,\n    users__fail.id  AS users__fail_id,\n    users__fail.last  AS
         users__fail_last_name\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
@@ -1850,29 +1886,29 @@ interactions:
         users__fail_city,\n    users__fail.email_address  AS users__fail_email,\n    users__fail.first  AS
         users__fail_first_name,\n    users__fail.id  AS users__fail_id,\n    users__fail.last  AS
         users__fail_last_name\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
-        (1 = 2)\nORDER BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":3,"column":17}}],"drill_menu_build_time":0.037559999999999996,"has_subtotals":false}}}'
+        (1 = 2)\nORDER BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":3,"column":17}}],"drill_menu_build_time":0.039158,"has_subtotals":false}}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '17777'
+      - '17765'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:30 GMT
+      - Tue, 05 Apr 2022 13:58:51 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 9ea5dc6a3a4e4a30
+      - f15940058a1ccd6a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 9ea5dc6a3a4e4a30
+      - f15940058a1ccd6a
       X-B3-TraceId:
-      - 62475a9202efee0f9ea5dc6a3a4e4a30
+      - 624c4b1bc574f50ff15940058a1ccd6a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1886,7 +1922,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -1900,20 +1936,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:31 GMT
+      - Tue, 05 Apr 2022 13:58:52 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - d83fbbd737ba0308
+      - daedf0e2b175dfb2
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - d83fbbd737ba0308
+      - daedf0e2b175dfb2
       X-B3-TraceId:
-      - 62475a9322c13828d83fbbd737ba0308
+      - 624c4b1b58ee39e8daedf0e2b175dfb2
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1925,7 +1961,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_b
   response:
@@ -1935,19 +1971,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:03:31 GMT
+      - Tue, 05 Apr 2022 13:58:52 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 8f1e4b12033ad026
+      - 7645ae1702c5e106
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 8f1e4b12033ad026
+      - 7645ae1702c5e106
       X-B3-TraceId:
-      - 62475a93c2417ef68f1e4b12033ad026
+      - 624c4b1c168ac33c7645ae1702c5e106
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1961,7 +1997,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -1975,20 +2011,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:32 GMT
+      - Tue, 05 Apr 2022 13:58:53 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 6ec1f4e28e2e7c1f
+      - 59d942968da25418
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6ec1f4e28e2e7c1f
+      - 59d942968da25418
       X-B3-TraceId:
-      - 62475a93f317185a6ec1f4e28e2e7c1f
+      - 624c4b1cb3ebc2f459d942968da25418
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2002,7 +2038,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -2016,19 +2052,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:32 GMT
+      - Tue, 05 Apr 2022 13:58:53 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 2faaa1088adf09b4
+      - 903cbbb22073e120
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2faaa1088adf09b4
+      - 903cbbb22073e120
       X-B3-TraceId:
-      - 62475a94cba3a03d2faaa1088adf09b4
+      - 624c4b1d874f1a27903cbbb22073e120
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2042,7 +2078,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -2056,19 +2092,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:32 GMT
+      - Tue, 05 Apr 2022 13:58:53 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 2debd8c4eb707667
+      - c9ce36a9f6a43f88
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2debd8c4eb707667
+      - c9ce36a9f6a43f88
       X-B3-TraceId:
-      - 62475a94777fa5422debd8c4eb707667
+      - 624c4b1d5aacd898c9ce36a9f6a43f88
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2082,7 +2118,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -2096,20 +2132,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:33 GMT
+      - Tue, 05 Apr 2022 13:58:53 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 8a80a43d8273b5e3
+      - d35e9df7f577ab7c
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 8a80a43d8273b5e3
+      - d35e9df7f577ab7c
       X-B3-TraceId:
-      - 62475a9432b3999d8a80a43d8273b5e3
+      - 624c4b1dd6e618b9d35e9df7f577ab7c
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2121,7 +2157,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/reset_to_remote
   response:
@@ -2131,19 +2167,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:03:34 GMT
+      - Tue, 05 Apr 2022 13:58:54 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - be41f31f455bd638
+      - 429de9ace13b5810
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - be41f31f455bd638
+      - 429de9ace13b5810
       X-B3-TraceId:
-      - 62475a957afb6278be41f31f455bd638
+      - 624c4b1d53bd6a75429de9ace13b5810
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2153,7 +2189,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:54 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 9b2644029bfda1d5
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 9b2644029bfda1d5
+      X-B3-TraceId:
+      - 624c4b1eec0bb9c39b2644029bfda1d5
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -2167,19 +2239,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:34 GMT
+      - Tue, 05 Apr 2022 13:58:54 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 3a9a817b42dd43f9
+      - 0c7a098d8ef79b07
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 3a9a817b42dd43f9
+      - 0c7a098d8ef79b07
       X-B3-TraceId:
-      - 62475a961d9397903a9a817b42dd43f9
+      - 624c4b1e7d22c2dc0c7a098d8ef79b07
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2189,7 +2261,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -2203,20 +2275,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:34 GMT
+      - Tue, 05 Apr 2022 13:58:55 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 96543f8b578dd428
+      - f50bd8123e268fc1
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 96543f8b578dd428
+      - f50bd8123e268fc1
       X-B3-TraceId:
-      - 62475a96bbe55c1b96543f8b578dd428
+      - 624c4b1ed3223eabf50bd8123e268fc1
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:55 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 8b36e1ec6ec04fb9
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 8b36e1ec6ec04fb9
+      X-B3-TraceId:
+      - 624c4b1f95dc51888b36e1ec6ec04fb9
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2226,7 +2338,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:55 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 081753a5112b5385
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 081753a5112b5385
+      X-B3-TraceId:
+      - 624c4b1fc4a79578081753a5112b5385
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:55 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 8ea2009fa6ff1327
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 8ea2009fa6ff1327
+      X-B3-TraceId:
+      - 624c4b1f6dd055188ea2009fa6ff1327
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:55 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - e44f75ef7d831c05
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - e44f75ef7d831c05
+      X-B3-TraceId:
+      - 624c4b1fa251af96e44f75ef7d831c05
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:55 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - cdb162aba50f94a4
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - cdb162aba50f94a4
+      X-B3-TraceId:
+      - 624c4b1f1d68a3dbcdb162aba50f94a4
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:55 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - ff8fa6d62f1622e5
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - ff8fa6d62f1622e5
+      X-B3-TraceId:
+      - 624c4b1ffb453010ff8fa6d62f1622e5
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_c"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_c","remote":"origin","remote_name":"tmp_spectacles_c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:55 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 81177c4f3ad34f12
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 81177c4f3ad34f12
+      X-B3-TraceId:
+      - 624c4b1f414f3d5f81177c4f3ad34f12
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_c", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_c","remote":"origin","remote_name":"tmp_spectacles_c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:58:56 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 2e9fa206ef99324a
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 2e9fa206ef99324a
+      X-B3-TraceId:
+      - 624c4b1fa91549d92e9fa206ef99324a
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -2275,320 +2655,12 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:03:34 GMT
+      - Tue, 05 Apr 2022 13:58:56 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
-- request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:34 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - e4df02c98cc69853
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - e4df02c98cc69853
-      X-B3-TraceId:
-      - 62475a9690e8ae1de4df02c98cc69853
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:34 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 4cc481d6dfce8601
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 4cc481d6dfce8601
-      X-B3-TraceId:
-      - 62475a96539fcc3e4cc481d6dfce8601
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:34 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 04526098fc596279
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 04526098fc596279
-      X-B3-TraceId:
-      - 62475a96a986856804526098fc596279
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:34 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - c5f6f996deb03127
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - c5f6f996deb03127
-      X-B3-TraceId:
-      - 62475a96d0cd4ea8c5f6f996deb03127
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:34 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 70d792637d734f54
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 70d792637d734f54
-      X-B3-TraceId:
-      - 62475a96e6fb589170d792637d734f54
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:34 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - cee0a81e0d08ef87
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - cee0a81e0d08ef87
-      X-B3-TraceId:
-      - 62475a96e96da141cee0a81e0d08ef87
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_c"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_c","remote":"origin","remote_name":"tmp_spectacles_c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:35 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 9d85bb1fa2b01aef
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 9d85bb1fa2b01aef
-      X-B3-TraceId:
-      - 62475a9725df88309d85bb1fa2b01aef
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_c", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_c","remote":"origin","remote_name":"tmp_spectacles_c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:36 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 062f0ec16de6b2cc
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 062f0ec16de6b2cc
-      X-B3-TraceId:
-      - 62475a97a4ca60a0062f0ec16de6b2cc
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
 - request:
     body: '{"model": "eye_exam", "view": "users__fail", "fields": ["users__fail.city"],
       "limit": 0, "filter_expression": "1=2"}'
@@ -2598,7 +2670,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -2612,19 +2684,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:36 GMT
+      - Tue, 05 Apr 2022 13:58:56 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 6d8fc16fb4869dcc
+      - d33ab9478d07ecbf
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6d8fc16fb4869dcc
+      - d33ab9478d07ecbf
       X-B3-TraceId:
-      - 62475a98a4b03b616d8fc16fb4869dcc
+      - 624c4b2019ac7cfdd33ab9478d07ecbf
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2639,7 +2711,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -2653,19 +2725,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:36 GMT
+      - Tue, 05 Apr 2022 13:58:56 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f040abe9b7002f04
+      - 6eeb7f6ce20980de
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f040abe9b7002f04
+      - 6eeb7f6ce20980de
       X-B3-TraceId:
-      - 62475a980f1c9ae9f040abe9b7002f04
+      - 624c4b20ddaf130d6eeb7f6ce20980de
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2680,7 +2752,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -2694,19 +2766,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:36 GMT
+      - Tue, 05 Apr 2022 13:58:57 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 17174efad30fd646
+      - ef0a1e48f4cc643f
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 17174efad30fd646
+      - ef0a1e48f4cc643f
       X-B3-TraceId:
-      - 62475a98d614d6be17174efad30fd646
+      - 624c4b200a3234ceef0a1e48f4cc643f
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2721,7 +2793,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -2735,19 +2807,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:36 GMT
+      - Tue, 05 Apr 2022 13:58:57 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 6c7d1f09f33b88e6
+      - ce8b899c317d6ff0
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 6c7d1f09f33b88e6
+      - ce8b899c317d6ff0
       X-B3-TraceId:
-      - 62475a98b2f28d176c7d1f09f33b88e6
+      - 624c4b2149e6cb3ece8b899c317d6ff0
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2762,7 +2834,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -2776,19 +2848,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:37 GMT
+      - Tue, 05 Apr 2022 13:58:57 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - ce8037bb9cc8cb2d
+      - fd3dfdd30f853b91
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - ce8037bb9cc8cb2d
+      - fd3dfdd30f853b91
       X-B3-TraceId:
-      - 62475a9882d1cff5ce8037bb9cc8cb2d
+      - 624c4b2119e3dde9fd3dfdd30f853b91
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2802,12 +2874,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"6b07391b0ec3fe7a5034870f1ab77ca5"}'
+      string: '{"id":"5a964a093fc5ee3d753c9f984b8d55a9"}'
     headers:
       Connection:
       - keep-alive
@@ -2816,19 +2888,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:37 GMT
+      - Tue, 05 Apr 2022 13:58:57 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 331db0ca244b2826
+      - 7d1588febd99daa4
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 331db0ca244b2826
+      - 7d1588febd99daa4
       X-B3-TraceId:
-      - 62475a99bb3a142f331db0ca244b2826
+      - 624c4b214cd17da97d1588febd99daa4
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2842,12 +2914,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"7c36c8fe41eb53157791ea56ee8f10c2"}'
+      string: '{"id":"ff5d1d7947f86dc967ae22d9745dfb3a"}'
     headers:
       Connection:
       - keep-alive
@@ -2856,19 +2928,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:37 GMT
+      - Tue, 05 Apr 2022 13:58:57 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 854601ca83b2f69d
+      - f47ae2929f9b4d66
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 854601ca83b2f69d
+      - f47ae2929f9b4d66
       X-B3-TraceId:
-      - 62475a992037b97b854601ca83b2f69d
+      - 624c4b21570f062ff47ae2929f9b4d66
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2882,12 +2954,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"a6dbdcdddfed304acc832835555790c5"}'
+      string: '{"id":"e2101c4816850f1e0413ea4731187cb6"}'
     headers:
       Connection:
       - keep-alive
@@ -2896,19 +2968,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:37 GMT
+      - Tue, 05 Apr 2022 13:58:57 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 26ba87caa1300b88
+      - 5af3f9acefb552e6
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 26ba87caa1300b88
+      - 5af3f9acefb552e6
       X-B3-TraceId:
-      - 62475a991b577ad426ba87caa1300b88
+      - 624c4b21f8028e3d5af3f9acefb552e6
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2922,12 +2994,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"0e35912540d3c094171b42237d997f5e"}'
+      string: '{"id":"968e18ee4a0e77dcff132cfad252a0e5"}'
     headers:
       Connection:
       - keep-alive
@@ -2936,19 +3008,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:37 GMT
+      - Tue, 05 Apr 2022 13:58:57 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 4dc577eb567977a8
+      - 191a259c96765d47
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 4dc577eb567977a8
+      - 191a259c96765d47
       X-B3-TraceId:
-      - 62475a99d07cd6e74dc577eb567977a8
+      - 624c4b21cbb34507191a259c96765d47
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2962,12 +3034,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"99ab4094daa16c596512ff3093ef69ae"}'
+      string: '{"id":"db72baaba488c76bd49dab688d39464a"}'
     headers:
       Connection:
       - keep-alive
@@ -2976,19 +3048,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:37 GMT
+      - Tue, 05 Apr 2022 13:58:58 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 5b4539ab44b4485f
+      - 5a61f30d4c912f9e
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 5b4539ab44b4485f
+      - 5a61f30d4c912f9e
       X-B3-TraceId:
-      - 62475a996d07d9cb5b4539ab44b4485f
+      - 624c4b21bdc6a0d85a61f30d4c912f9e
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2998,18 +3070,12 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=6b07391b0ec3fe7a5034870f1ab77ca5%2C7c36c8fe41eb53157791ea56ee8f10c2%2Ca6dbdcdddfed304acc832835555790c5%2C0e35912540d3c094171b42237d997f5e%2C99ab4094daa16c596512ff3093ef69ae
+    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=5a964a093fc5ee3d753c9f984b8d55a9%2Cff5d1d7947f86dc967ae22d9745dfb3a%2Ce2101c4816850f1e0413ea4731187cb6%2C968e18ee4a0e77dcff132cfad252a0e5%2Cdb72baaba488c76bd49dab688d39464a
   response:
     body:
-      string: '{"0e35912540d3c094171b42237d997f5e":{"status":"running"},"6b07391b0ec3fe7a5034870f1ab77ca5":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"6b07391b0ec3fe7a5034870f1ab77ca5","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:03:37+00:00","aggregate_table_used_info":null,"runtime":"0.506","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.city"]},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":true,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_gkborbtUxjalpg1AkTnVE6mjoeQ8"},"sql":"SELECT\n    users__fail.city  AS
-        users__fail_city\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
-        (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
-        Fail City","label_from_parameter":null,"label_short":"City","map_layer":null,"name":"users__fail.city","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users__fail","view_label":"Users
-        Fail","dynamic":false,"week_start_day":"monday","original_view":"users__fail","dimension_group":null,"error":null,"field_group_variant":"City","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users__fail","suggest_dimension":"users__fail.city","suggest_explore":"users__fail","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers__fail.view.lkml?line=20","permanent":null,"source_file":"views/users__fail.view.lkml","source_file_path":"eye_exam/views/users__fail.view.lkml","sql":"${TABLE}.city
-        ","sql_case":null,"filters":null,"times_used":0,"sorted":{"sort_index":0,"desc":false}}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users__fail","label":"Users
-        Fail","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.036697,"has_subtotals":false}},"7c36c8fe41eb53157791ea56ee8f10c2":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"7c36c8fe41eb53157791ea56ee8f10c2","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:03:37+00:00","aggregate_table_used_info":null,"runtime":"0.330","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.email"]},"forecast_result":null,"sql":"SELECT\n    users__fail.email_address  AS
+      string: '{"5a964a093fc5ee3d753c9f984b8d55a9":{"status":"running"},"968e18ee4a0e77dcff132cfad252a0e5":{"status":"running"},"db72baaba488c76bd49dab688d39464a":{"status":"added"},"e2101c4816850f1e0413ea4731187cb6":{"status":"running"},"ff5d1d7947f86dc967ae22d9745dfb3a":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"ff5d1d7947f86dc967ae22d9745dfb3a","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:58:57+00:00","aggregate_table_used_info":null,"runtime":"0.281","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.email"]},"forecast_result":null,"sql":"SELECT\n    users__fail.email_address  AS
         users__fail_email\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
         (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
         Fail Email","label_from_parameter":null,"label_short":"Email","map_layer":null,"name":"users__fail.email","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users__fail","view_label":"Users
@@ -3020,30 +3086,29 @@ interactions:
         query.","message_details":"Query execution failed:  - Name email_address not
         found inside users__fail at [2:17]","params":"SELECT\n    users__fail.email_address  AS
         users__fail_email\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
-        (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":2,"column":17}}],"drill_menu_build_time":0.035208,"has_subtotals":false}},"99ab4094daa16c596512ff3093ef69ae":{"status":"added"},"a6dbdcdddfed304acc832835555790c5":{"status":"expired","data":{"error":"Results
-        have expired. Run the query again."}}}'
+        (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":2,"column":17}}],"drill_menu_build_time":0.035357000000000006,"has_subtotals":false}}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '5663'
+      - '3101'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:38 GMT
+      - Tue, 05 Apr 2022 13:58:58 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 0f964ce71ea83c8c
+      - 970ad147893aee00
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 0f964ce71ea83c8c
+      - 970ad147893aee00
       X-B3-TraceId:
-      - 62475a9904653bf00f964ce71ea83c8c
+      - 624c4b2258c8f6f1970ad147893aee00
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3053,18 +3118,24 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=a6dbdcdddfed304acc832835555790c5%2C0e35912540d3c094171b42237d997f5e%2C99ab4094daa16c596512ff3093ef69ae
+    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=5a964a093fc5ee3d753c9f984b8d55a9%2Ce2101c4816850f1e0413ea4731187cb6%2C968e18ee4a0e77dcff132cfad252a0e5%2Cdb72baaba488c76bd49dab688d39464a
   response:
     body:
-      string: '{"0e35912540d3c094171b42237d997f5e":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"0e35912540d3c094171b42237d997f5e","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:03:38+00:00","aggregate_table_used_info":null,"runtime":"0.492","added_params":{"query_timezone":"America/New_York"},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":true,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_nn6c4nfBGFCFSdmuWzhRcFY34qeg"},"sql":"SELECT\n    users__fail.id  AS
+      string: '{"5a964a093fc5ee3d753c9f984b8d55a9":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"5a964a093fc5ee3d753c9f984b8d55a9","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:58:58+00:00","aggregate_table_used_info":null,"runtime":"0.550","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.city"]},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":true,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_Hru4Ji8D4UUKtcZKDU_gNQfNehC0"},"sql":"SELECT\n    users__fail.city  AS
+        users__fail_city\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
+        (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
+        Fail City","label_from_parameter":null,"label_short":"City","map_layer":null,"name":"users__fail.city","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users__fail","view_label":"Users
+        Fail","dynamic":false,"week_start_day":"monday","original_view":"users__fail","dimension_group":null,"error":null,"field_group_variant":"City","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users__fail","suggest_dimension":"users__fail.city","suggest_explore":"users__fail","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers__fail.view.lkml?line=20","permanent":null,"source_file":"views/users__fail.view.lkml","source_file_path":"eye_exam/views/users__fail.view.lkml","sql":"${TABLE}.city
+        ","sql_case":null,"filters":null,"times_used":0,"sorted":{"sort_index":0,"desc":false}}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users__fail","label":"Users
+        Fail","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.035337,"has_subtotals":false}},"968e18ee4a0e77dcff132cfad252a0e5":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"968e18ee4a0e77dcff132cfad252a0e5","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:58:58+00:00","aggregate_table_used_info":null,"runtime":"0.484","added_params":{"query_timezone":"America/New_York"},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":false,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_TZsVSTviNrbXS-SNNNwv7q_lZThE"},"sql":"SELECT\n    users__fail.id  AS
         users__fail_id\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
         (1 = 2)\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"right","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":true,"label":"Users
         Fail ID","label_from_parameter":null,"label_short":"ID","map_layer":null,"name":"users__fail.id","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"number","user_attribute_filter_types":["number","advanced_filter_number"],"value_format":null,"view":"users__fail","view_label":"Users
         Fail","dynamic":false,"week_start_day":"monday","original_view":"users__fail","dimension_group":null,"error":null,"field_group_variant":"ID","measure":false,"parameter":false,"primary_key":true,"project_name":"eye_exam","scope":"users__fail","suggest_dimension":"users__fail.id","suggest_explore":"users__fail","suggestable":false,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers__fail.view.lkml?line=8","permanent":null,"source_file":"views/users__fail.view.lkml","source_file_path":"eye_exam/views/users__fail.view.lkml","sql":"${TABLE}.id
         ","sql_case":null,"filters":null,"times_used":0}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users__fail","label":"Users
-        Fail","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.03504500000000001,"has_subtotals":false}},"99ab4094daa16c596512ff3093ef69ae":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"99ab4094daa16c596512ff3093ef69ae","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:03:38+00:00","aggregate_table_used_info":null,"runtime":"0.299","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.last_name"]},"forecast_result":null,"sql":"SELECT\n    users__fail.last  AS
+        Fail","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.035382000000000004,"has_subtotals":false}},"db72baaba488c76bd49dab688d39464a":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"db72baaba488c76bd49dab688d39464a","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:58:58+00:00","aggregate_table_used_info":null,"runtime":"0.318","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.last_name"]},"forecast_result":null,"sql":"SELECT\n    users__fail.last  AS
         users__fail_last_name\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
         (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
         Fail Last Name","label_from_parameter":null,"label_short":"Last Name","map_layer":null,"name":"users__fail.last_name","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users__fail","view_label":"Users
@@ -3076,7 +3147,7 @@ interactions:
         query.","message_details":"Query execution failed:  - Name last not found
         inside users__fail at [2:17]","params":"SELECT\n    users__fail.last  AS users__fail_last_name\nFROM
         looker-private-demo.ecomm.users\n   AS users__fail\nWHERE (1 = 2)\nGROUP BY\n    1\nORDER
-        BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":2,"column":17}}],"drill_menu_build_time":0.035298,"has_subtotals":false}},"a6dbdcdddfed304acc832835555790c5":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"a6dbdcdddfed304acc832835555790c5","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:03:37+00:00","aggregate_table_used_info":null,"runtime":"0.355","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.first_name"]},"forecast_result":null,"sql":"SELECT\n    users__fail.first  AS
+        BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":2,"column":17}}],"drill_menu_build_time":0.036257,"has_subtotals":false}},"e2101c4816850f1e0413ea4731187cb6":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"e2101c4816850f1e0413ea4731187cb6","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:58:58+00:00","aggregate_table_used_info":null,"runtime":"0.342","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.first_name"]},"forecast_result":null,"sql":"SELECT\n    users__fail.first  AS
         users__fail_first_name\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
         (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
         Fail First Name","label_from_parameter":null,"label_short":"First Name","map_layer":null,"name":"users__fail.first_name","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users__fail","view_label":"Users
@@ -3088,29 +3159,29 @@ interactions:
         query.","message_details":"Query execution failed:  - Name first not found
         inside users__fail at [2:17]","params":"SELECT\n    users__fail.first  AS
         users__fail_first_name\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
-        (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":2,"column":17}}],"drill_menu_build_time":0.036266,"has_subtotals":false}}}'
+        (1 = 2)\nGROUP BY\n    1\nORDER BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":2,"column":17}}],"drill_menu_build_time":0.035368000000000004,"has_subtotals":false}}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '8197'
+      - '10779'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:38 GMT
+      - Tue, 05 Apr 2022 13:58:58 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 32adbf325bac200c
+      - 189ac1a325bdfeb7
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 32adbf325bac200c
+      - 189ac1a325bdfeb7
       X-B3-TraceId:
-      - 62475a9a9b4c59a332adbf325bac200c
+      - 624c4b2283642eed189ac1a325bdfeb7
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3124,7 +3195,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3138,20 +3209,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:39 GMT
+      - Tue, 05 Apr 2022 13:58:59 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - b11e57d366726b3b
+      - 5fbb4b2c5af2af2b
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - b11e57d366726b3b
+      - 5fbb4b2c5af2af2b
       X-B3-TraceId:
-      - 62475a9b1d90bcd3b11e57d366726b3b
+      - 624c4b23c735573d5fbb4b2c5af2af2b
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3163,7 +3234,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_c
   response:
@@ -3173,19 +3244,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:03:40 GMT
+      - Tue, 05 Apr 2022 13:59:00 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 968ac51b235933ed
+      - ccf08cd8bd87f2c7
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 968ac51b235933ed
+      - ccf08cd8bd87f2c7
       X-B3-TraceId:
-      - 62475a9b4c62184c968ac51b235933ed
+      - 624c4b23dbfb0141ccf08cd8bd87f2c7
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3199,7 +3270,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -3213,20 +3284,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:40 GMT
+      - Tue, 05 Apr 2022 13:59:00 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - d018a17e65f86617
+      - 3e6b250372a923e9
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - d018a17e65f86617
+      - 3e6b250372a923e9
       X-B3-TraceId:
-      - 62475a9c0c512e3ed018a17e65f86617
+      - 624c4b2409ebac393e6b250372a923e9
       X-Content-Type-Options:
       - nosniff
     status:
@@ -3240,7 +3311,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -3254,19 +3325,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:40 GMT
+      - Tue, 05 Apr 2022 13:59:00 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - a6126ee6e6d89543
+      - 72259c422925d776
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a6126ee6e6d89543
+      - 72259c422925d776
       X-B3-TraceId:
-      - 62475a9c08682ba6a6126ee6e6d89543
+      - 624c4b2414cf980972259c422925d776
       X-Content-Type-Options:
       - nosniff
     status:

--- a/tests/cassettes/test_runner/test_validate_sql_should_work[True].yaml
+++ b/tests/cassettes/test_runner/test_validate_sql_should_work[True].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -17,19 +17,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:06 GMT
+      - Tue, 05 Apr 2022 13:59:00 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 4e6cc05e57cff1f5
+      - b1a4815e45c437c4
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 4e6cc05e57cff1f5
+      - b1a4815e45c437c4
       X-B3-TraceId:
-      - 62475a7ac01b5bd04e6cc05e57cff1f5
+      - 624c4b249f9ba64cb1a4815e45c437c4
       X-Content-Type-Options:
       - nosniff
     status:
@@ -39,7 +39,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -53,56 +53,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:06 GMT
+      - Tue, 05 Apr 2022 13:59:01 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - cb64ebb5750f4a49
+      - 499dd6d3f79580fc
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - cb64ebb5750f4a49
+      - 499dd6d3f79580fc
       X-B3-TraceId:
-      - 62475a7aa1f6cb6acb64ebb5750f4a49
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
-  response:
-    body:
-      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '147'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:06 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - fd26f8e754548a52
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - fd26f8e754548a52
-      X-B3-TraceId:
-      - 62475a7a0d2aa4f8fd26f8e754548a52
+      - 624c4b24bceaaca9499dd6d3f79580fc
       X-Content-Type-Options:
       - nosniff
     status:
@@ -116,7 +80,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -130,19 +94,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:06 GMT
+      - Tue, 05 Apr 2022 13:59:01 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 1a814aa6a311a2c4
+      - 36fbe148c8542589
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 1a814aa6a311a2c4
+      - 36fbe148c8542589
       X-B3-TraceId:
-      - 62475a7a2b0d02031a814aa6a311a2c4
+      - 624c4b25387a820a36fbe148c8542589
       X-Content-Type-Options:
       - nosniff
     status:
@@ -156,7 +120,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -170,20 +134,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:07 GMT
+      - Tue, 05 Apr 2022 13:59:01 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 1c90df1fed0c2ccd
+      - a24aca3608f9949a
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 1c90df1fed0c2ccd
+      - a24aca3608f9949a
       X-B3-TraceId:
-      - 62475a7af145b3ea1c90df1fed0c2ccd
+      - 624c4b252f882c38a24aca3608f9949a
       X-Content-Type-Options:
       - nosniff
     status:
@@ -195,7 +159,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/reset_to_remote
   response:
@@ -205,19 +169,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:03:08 GMT
+      - Tue, 05 Apr 2022 13:59:02 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - cb8e8f276f8fc979
+      - a5e9818782517fbc
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - cb8e8f276f8fc979
+      - a5e9818782517fbc
       X-B3-TraceId:
-      - 62475a7b622feab2cb8e8f276f8fc979
+      - 624c4b25fdda6f76a5e9818782517fbc
       X-Content-Type-Options:
       - nosniff
     status:
@@ -227,7 +191,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:02 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 2d3e1e8e5cd90316
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 2d3e1e8e5cd90316
+      X-B3-TraceId:
+      - 624c4b26123357ca2d3e1e8e5cd90316
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -241,19 +241,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:08 GMT
+      - Tue, 05 Apr 2022 13:59:02 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 2a60855ca0432ff8
+      - 1a296d94d0f2151f
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 2a60855ca0432ff8
+      - 1a296d94d0f2151f
       X-B3-TraceId:
-      - 62475a7cc658e7d72a60855ca0432ff8
+      - 624c4b26f9d859e31a296d94d0f2151f
       X-Content-Type-Options:
       - nosniff
     status:
@@ -263,7 +263,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -277,20 +277,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:08 GMT
+      - Tue, 05 Apr 2022 13:59:02 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f83ff5db269f2542
+      - 3dae3a846c32771d
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f83ff5db269f2542
+      - 3dae3a846c32771d
       X-B3-TraceId:
-      - 62475a7c70a52373f83ff5db269f2542
+      - 624c4b265575685c3dae3a846c32771d
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:03 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 262987f9eb4db6f6
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 262987f9eb4db6f6
+      X-B3-TraceId:
+      - 624c4b2642532071262987f9eb4db6f6
       X-Content-Type-Options:
       - nosniff
     status:
@@ -300,7 +340,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:03 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 432cd19b85d8a279
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 432cd19b85d8a279
+      X-B3-TraceId:
+      - 624c4b27d0d0f178432cd19b85d8a279
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:03 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - f5823de5b36c51ff
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - f5823de5b36c51ff
+      X-B3-TraceId:
+      - 624c4b271403d08df5823de5b36c51ff
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:03 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 2a38d81ca49bbe36
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 2a38d81ca49bbe36
+      X-B3-TraceId:
+      - 624c4b276d5134972a38d81ca49bbe36
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:03 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 142ae0dd3e341ea6
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 142ae0dd3e341ea6
+      X-B3-TraceId:
+      - 624c4b272202ea52142ae0dd3e341ea6
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:03 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - b3ffe04fb02f0f9e
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - b3ffe04fb02f0f9e
+      X-B3-TraceId:
+      - 624c4b27fdf78f61b3ffe04fb02f0f9e
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_a"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:03 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - cb4bead5c8db916c
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - cb4bead5c8db916c
+      X-B3-TraceId:
+      - 624c4b27b074418bcb4bead5c8db916c
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_a", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:04 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 88c351fa1aee0b29
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 88c351fa1aee0b29
+      X-B3-TraceId:
+      - 624c4b276cbca5c988c351fa1aee0b29
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -349,325 +657,17 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:03:08 GMT
+      - Tue, 05 Apr 2022 13:59:04 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
 - request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:08 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - c10b1450cf5daf37
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - c10b1450cf5daf37
-      X-B3-TraceId:
-      - 62475a7c7f172974c10b1450cf5daf37
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:08 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 199d965da5b06b83
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 199d965da5b06b83
-      X-B3-TraceId:
-      - 62475a7c1baf39bd199d965da5b06b83
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:08 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 694db71eddb9f547
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 694db71eddb9f547
-      X-B3-TraceId:
-      - 62475a7c2cc9e52b694db71eddb9f547
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:09 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - d9a74d091872b399
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - d9a74d091872b399
-      X-B3-TraceId:
-      - 62475a7deef87ad4d9a74d091872b399
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:09 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - d0538a9c897bb02c
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - d0538a9c897bb02c
-      X-B3-TraceId:
-      - 62475a7d77c30aecd0538a9c897bb02c
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:09 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 59ac8922d63053d2
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 59ac8922d63053d2
-      X-B3-TraceId:
-      - 62475a7dbf73aa8659ac8922d63053d2
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_a"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:09 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 40bf36888f7c7d0c
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 40bf36888f7c7d0c
-      X-B3-TraceId:
-      - 62475a7d15d0cefe40bf36888f7c7d0c
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_a", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_a","remote":"origin","remote_name":"tmp_spectacles_a","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:10 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - f9a9f2f07475f5e8
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - f9a9f2f07475f5e8
-      X-B3-TraceId:
-      - 62475a7d5c27e8daf9a9f2f07475f5e8
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models?fields=name%2Cproject_name%2Cexplores
   response:
@@ -751,20 +751,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:11 GMT
+      - Tue, 05 Apr 2022 13:59:05 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 83deec7717f247e0
+      - 71842193940d9a3c
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 83deec7717f247e0
+      - 71842193940d9a3c
       X-B3-TraceId:
-      - 62475a7e5de2292d83deec7717f247e0
+      - 624c4b28f3d1830871842193940d9a3c
       X-Content-Type-Options:
       - nosniff
     status:
@@ -774,7 +774,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users?fields=fields
   response:
@@ -805,20 +805,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:11 GMT
+      - Tue, 05 Apr 2022 13:59:05 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 7124fa62dac31f8e
+      - 040a0c0dd4dd7a5b
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 7124fa62dac31f8e
+      - 040a0c0dd4dd7a5b
       X-B3-TraceId:
-      - 62475a7ffd3acc577124fa62dac31f8e
+      - 624c4b29ec863bf2040a0c0dd4dd7a5b
       X-Content-Type-Options:
       - nosniff
     status:
@@ -828,7 +828,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/lookml_models/eye_exam/explores/users__fail?fields=fields
   response:
@@ -864,20 +864,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:11 GMT
+      - Tue, 05 Apr 2022 13:59:05 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 764be0fabcd61a9d
+      - 753bb848562ea58b
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 764be0fabcd61a9d
+      - 753bb848562ea58b
       X-B3-TraceId:
-      - 62475a7f291432f2764be0fabcd61a9d
+      - 624c4b296be708d8753bb848562ea58b
       X-Content-Type-Options:
       - nosniff
     status:
@@ -893,7 +893,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -907,19 +907,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:11 GMT
+      - Tue, 05 Apr 2022 13:59:05 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 067f2a6a24d63eaa
+      - 6aa6e653adb66747
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 067f2a6a24d63eaa
+      - 6aa6e653adb66747
       X-B3-TraceId:
-      - 62475a7f6a5d85b9067f2a6a24d63eaa
+      - 624c4b29c662fe386aa6e653adb66747
       X-Content-Type-Options:
       - nosniff
     status:
@@ -935,7 +935,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/queries?fields=id%2Cshare_url
   response:
@@ -949,19 +949,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:11 GMT
+      - Tue, 05 Apr 2022 13:59:05 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 7e7181028e3b7f3a
+      - c407e494d19946a2
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 7e7181028e3b7f3a
+      - c407e494d19946a2
       X-B3-TraceId:
-      - 62475a7f626b3b467e7181028e3b7f3a
+      - 624c4b29482a6bd7c407e494d19946a2
       X-Content-Type-Options:
       - nosniff
     status:
@@ -975,7 +975,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -989,20 +989,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:12 GMT
+      - Tue, 05 Apr 2022 13:59:06 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 0491ca4f4302e827
+      - 721fec7df46d1188
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 0491ca4f4302e827
+      - 721fec7df46d1188
       X-B3-TraceId:
-      - 62475a7f4810001c0491ca4f4302e827
+      - 624c4b292c92fe85721fec7df46d1188
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1014,7 +1014,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_a
   response:
@@ -1024,19 +1024,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:03:12 GMT
+      - Tue, 05 Apr 2022 13:59:06 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - b6d9a5b5e7fa7940
+      - d875eef150bebab9
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - b6d9a5b5e7fa7940
+      - d875eef150bebab9
       X-B3-TraceId:
-      - 62475a801dd7ac75b6d9a5b5e7fa7940
+      - 624c4b2ab10309ffd875eef150bebab9
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1050,7 +1050,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -1064,20 +1064,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:13 GMT
+      - Tue, 05 Apr 2022 13:59:07 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 30fa374d3d86d9b8
+      - 11de7f286efd2ee5
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 30fa374d3d86d9b8
+      - 11de7f286efd2ee5
       X-B3-TraceId:
-      - 62475a8011a728f930fa374d3d86d9b8
+      - 624c4b2af8bead3511de7f286efd2ee5
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1091,7 +1091,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1105,19 +1105,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:13 GMT
+      - Tue, 05 Apr 2022 13:59:07 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 964cb69e32bf54fc
+      - 13c75678d06dea0f
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 964cb69e32bf54fc
+      - 13c75678d06dea0f
       X-B3-TraceId:
-      - 62475a81401dac61964cb69e32bf54fc
+      - 624c4b2b4172c2d213c75678d06dea0f
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1131,7 +1131,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1145,19 +1145,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:13 GMT
+      - Tue, 05 Apr 2022 13:59:07 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - a26b6dcdc306485c
+      - 9687086b399d41ec
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - a26b6dcdc306485c
+      - 9687086b399d41ec
       X-B3-TraceId:
-      - 62475a814da45205a26b6dcdc306485c
+      - 624c4b2b85f6b89f9687086b399d41ec
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1171,7 +1171,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/git_branch
   response:
@@ -1185,20 +1185,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:13 GMT
+      - Tue, 05 Apr 2022 13:59:07 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 446a1c584c1025d0
+      - f76fe2ddc2ab8843
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 446a1c584c1025d0
+      - f76fe2ddc2ab8843
       X-B3-TraceId:
-      - 62475a81bc03740d446a1c584c1025d0
+      - 624c4b2b65515ceff76fe2ddc2ab8843
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1210,7 +1210,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/reset_to_remote
   response:
@@ -1220,19 +1220,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:03:14 GMT
+      - Tue, 05 Apr 2022 13:59:08 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 939e13b8c4d5f7c0
+      - 4a0bdecffbaadd89
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 939e13b8c4d5f7c0
+      - 4a0bdecffbaadd89
       X-B3-TraceId:
-      - 62475a815f38daff939e13b8c4d5f7c0
+      - 624c4b2bdd0f3ff24a0bdecffbaadd89
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1242,7 +1242,43 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/eye_exam/manifest
+  response:
+    body:
+      string: '{"name":"eye_exam","imports":[{"name":"welcome_to_looker","url":null,"ref":null,"is_remote":false,"can":{}}],"localization_settings":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:08 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - d3adcd41076b4801
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - d3adcd41076b4801
+      X-B3-TraceId:
+      - 624c4b2c595fa9f8d3adcd41076b4801
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -1256,19 +1292,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:14 GMT
+      - Tue, 05 Apr 2022 13:59:08 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - cb594f4ed3dd0ba7
+      - a184fd18995c97bc
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - cb594f4ed3dd0ba7
+      - a184fd18995c97bc
       X-B3-TraceId:
-      - 62475a82ebb5aedfcb594f4ed3dd0ba7
+      - 624c4b2c8c2d3b40a184fd18995c97bc
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1278,7 +1314,7 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -1292,20 +1328,60 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:14 GMT
+      - Tue, 05 Apr 2022 13:59:09 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 386968e5a9067d75
+      - 1747839b7a42a12e
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 386968e5a9067d75
+      - 1747839b7a42a12e
       X-B3-TraceId:
-      - 62475a8239c0caa7386968e5a9067d75
+      - 624c4b2df6564b981747839b7a42a12e
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "production"}'
+    headers:
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:09 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 989705a4e2e1792e
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 989705a4e2e1792e
+      X-B3-TraceId:
+      - 624c4b2d5ffab065989705a4e2e1792e
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1315,7 +1391,275 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:09 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - a6cdf647d54627cc
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - a6cdf647d54627cc
+      X-B3-TraceId:
+      - 624c4b2d864beaf3a6cdf647d54627cc
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '362'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:09 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 8f0102667d2c0a59
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 8f0102667d2c0a59
+      X-B3-TraceId:
+      - 624c4b2d2b4c6b9d8f0102667d2c0a59
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"workspace_id": "dev"}'
+    headers:
+      Content-Length:
+      - '23'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PATCH
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:09 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - bac02c6ffc3c6fe4
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - bac02c6ffc3c6fe4
+      X-B3-TraceId:
+      - 624c4b2d0de1bc7cbac02c6ffc3c6fe4
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/session
+  response:
+    body:
+      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:09 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - ad4fc53d4c8fb7ff
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - ad4fc53d4c8fb7ff
+      X-B3-TraceId:
+      - 624c4b2dc8b6bc0fad4fc53d4c8fb7ff
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
+    method: GET
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:09 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - cd4cc301f27e7e5b
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - cd4cc301f27e7e5b
+      X-B3-TraceId:
+      - 624c4b2dbde1fc28cd4cc301f27e7e5b
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_b"}'
+    headers:
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: POST
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:09 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 00b1055e5b7fe554
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 00b1055e5b7fe554
+      X-B3-TraceId:
+      - 624c4b2d6bd400e400b1055e5b7fe554
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "tmp_spectacles_b", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
+    headers:
+      Content-Length:
+      - '79'
+      Content-Type:
+      - application/json
+      Cookie:
+      - looker.browser=39326198
+    method: PUT
+    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
+  response:
+    body:
+      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 05 Apr 2022 13:59:10 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Origin
+      X-B3-ParentSpanId:
+      - 2fb5fc6ca133471b
+      X-B3-Sampled:
+      - '0'
+      X-B3-SpanId:
+      - 2fb5fc6ca133471b
+      X-B3-TraceId:
+      - 624c4b2d6b6676372fb5fc6ca133471b
+      X-Content-Type-Options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Cookie:
+      - looker.browser=39326198
     method: GET
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/manifest
   response:
@@ -1364,320 +1708,12 @@ interactions:
       Content-Type:
       - text/html
       Date:
-      - Fri, 01 Apr 2022 20:03:14 GMT
+      - Tue, 05 Apr 2022 13:59:10 GMT
       Vary:
       - Accept-Encoding
     status:
       code: 404
       message: Not Found
-- request:
-    body: '{"workspace_id": "production"}'
-    headers:
-      Content-Length:
-      - '30'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:15 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - d1a07e3f2ea1741b
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - d1a07e3f2ea1741b
-      X-B3-TraceId:
-      - 62475a83e4c4cd1fd1a07e3f2ea1741b
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"production","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '83'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:15 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 733f3ddc2df1be5e
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 733f3ddc2df1be5e
-      X-B3-TraceId:
-      - 62475a838f265cac733f3ddc2df1be5e
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"master","remote":"origin","remote_name":"master","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":true,"is_production":true,"ahead_count":0,"behind_count":0,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":"71025770cf923f656ba2375436a1bd85ac00affc","can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '362'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:15 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 94076de9a1167c8b
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 94076de9a1167c8b
-      X-B3-TraceId:
-      - 62475a83a175c35294076de9a1167c8b
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"workspace_id": "dev"}'
-    headers:
-      Content-Length:
-      - '23'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PATCH
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:15 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - d1d44357114a65f9
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - d1d44357114a65f9
-      X-B3-TraceId:
-      - 62475a838f0a70cbd1d44357114a65f9
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/session
-  response:
-    body:
-      string: '{"workspace_id":"dev","sudo_user_id":null,"can":{"view":true,"update":true}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '76'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:15 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 3d2236eb71f230af
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 3d2236eb71f230af
-      X-B3-TraceId:
-      - 62475a83d823f15d3d2236eb71f230af
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Cookie:
-      - looker.browser=9881689
-    method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_5e52c0302c","remote":"origin","remote_name":"tmp_spectacles_5e52c0302c","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '370'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:15 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - bea2f2d7ebd5d210
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - bea2f2d7ebd5d210
-      X-B3-TraceId:
-      - 62475a832609c886bea2f2d7ebd5d210
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_b"}'
-    headers:
-      Content-Length:
-      - '28'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: POST
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:15 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 68e9ab2c5cd112eb
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 68e9ab2c5cd112eb
-      X-B3-TraceId:
-      - 62475a8327f9533468e9ab2c5cd112eb
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"name": "tmp_spectacles_b", "ref": "71025770cf923f656ba2375436a1bd85ac00affc"}'
-    headers:
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Cookie:
-      - looker.browser=9881689
-    method: PUT
-    uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
-  response:
-    body:
-      string: '{"name":"tmp_spectacles_b","remote":"origin","remote_name":"tmp_spectacles_b","error":null,"message":null,"owner_name":null,"readonly":false,"personal":false,"is_local":true,"is_remote":false,"is_production":false,"ahead_count":null,"behind_count":null,"commit_at":1589215827,"ref":"71025770cf923f656ba2375436a1bd85ac00affc","remote_ref":null,"can":{}}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '352'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 01 Apr 2022 20:03:16 GMT
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      - Accept-Encoding, Origin
-      X-B3-ParentSpanId:
-      - 65bdd0fe229aebaa
-      X-B3-Sampled:
-      - '0'
-      X-B3-SpanId:
-      - 65bdd0fe229aebaa
-      X-B3-TraceId:
-      - 62475a83bff946b365bdd0fe229aebaa
-      X-Content-Type-Options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
 - request:
     body: '{"query_id": 2216, "result_format": "json_detail"}'
     headers:
@@ -1686,12 +1722,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"442d810f09973ebab19a427e86914d50"}'
+      string: '{"id":"34f41b2b097824b6e958092ebe61d4b4"}'
     headers:
       Connection:
       - keep-alive
@@ -1700,19 +1736,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:16 GMT
+      - Tue, 05 Apr 2022 13:59:10 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - b367b1e1815979ca
+      - 5b2d19f8492ca324
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - b367b1e1815979ca
+      - 5b2d19f8492ca324
       X-B3-TraceId:
-      - 62475a8465ff8537b367b1e1815979ca
+      - 624c4b2e3790e15f5b2d19f8492ca324
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1726,12 +1762,12 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: POST
     uri: https://spectacles.looker.com:19999/api/3.1/query_tasks?fields=id&cache=false
   response:
     body:
-      string: '{"id":"c5909e67ead0a5580fc83e490f59be00"}'
+      string: '{"id":"099445fc499e80b7d69d41c982e227da"}'
     headers:
       Connection:
       - keep-alive
@@ -1740,19 +1776,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:17 GMT
+      - Tue, 05 Apr 2022 13:59:11 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - fd5f82342840b2c4
+      - 73b1c01d88054cec
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - fd5f82342840b2c4
+      - 73b1c01d88054cec
       X-B3-TraceId:
-      - 62475a843e71036afd5f82342840b2c4
+      - 624c4b2ee54cbeaf73b1c01d88054cec
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1762,33 +1798,33 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=442d810f09973ebab19a427e86914d50%2Cc5909e67ead0a5580fc83e490f59be00
+    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=34f41b2b097824b6e958092ebe61d4b4%2C099445fc499e80b7d69d41c982e227da
   response:
     body:
-      string: '{"442d810f09973ebab19a427e86914d50":{"status":"running"},"c5909e67ead0a5580fc83e490f59be00":{"status":"added"}}'
+      string: '{"099445fc499e80b7d69d41c982e227da":{"status":"running"},"34f41b2b097824b6e958092ebe61d4b4":{"status":"running"}}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '111'
+      - '113'
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:17 GMT
+      - Tue, 05 Apr 2022 13:59:11 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 5ac642bb43dcd2e5
+      - 8649c3563e8b90d2
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 5ac642bb43dcd2e5
+      - 8649c3563e8b90d2
       X-B3-TraceId:
-      - 62475a85da83f9b05ac642bb43dcd2e5
+      - 624c4b2f265af2d48649c3563e8b90d2
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1798,30 +1834,12 @@ interactions:
     body: null
     headers:
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: GET
-    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=442d810f09973ebab19a427e86914d50%2Cc5909e67ead0a5580fc83e490f59be00
+    uri: https://spectacles.looker.com:19999/api/3.1/query_tasks/multi_results?query_task_ids=34f41b2b097824b6e958092ebe61d4b4%2C099445fc499e80b7d69d41c982e227da
   response:
     body:
-      string: '{"442d810f09973ebab19a427e86914d50":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"442d810f09973ebab19a427e86914d50","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:03:17+00:00","aggregate_table_used_info":null,"runtime":"0.515","added_params":{"query_timezone":"America/New_York","sorts":["users.city"]},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":true,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_K-wHTS9cTaf78BTXqu8Kp2CZOjAp"},"sql":"SELECT\n    users.city  AS
-        users_city,\n    users.email  AS users_email,\n    users.first_name  AS users_first_name,\n    users.id  AS
-        users_id,\n    users.last_name  AS users_last_name,\n    users.state  AS users_state\nFROM
-        looker-private-demo.ecomm.users\n     AS users\nWHERE (1 = 2)\nORDER BY\n    1\nLIMIT
-        0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
-        City","label_from_parameter":null,"label_short":"City","map_layer":null,"name":"users.city","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users","view_label":"Users","dynamic":false,"week_start_day":"monday","original_view":"users","dimension_group":null,"error":null,"field_group_variant":"City","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.city","suggest_explore":"users","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=23","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.city
-        ","sql_case":null,"filters":null,"times_used":0,"sorted":{"sort_index":0,"desc":false}},{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
-        Email","label_from_parameter":null,"label_short":"Email","map_layer":null,"name":"users.email","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users","view_label":"Users","dynamic":false,"week_start_day":"monday","original_view":"users","dimension_group":null,"error":null,"field_group_variant":"Email","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.email","suggest_explore":"users","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=28","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.email
-        ","sql_case":null,"filters":null,"times_used":0},{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
-        First Name","label_from_parameter":null,"label_short":"First Name","map_layer":null,"name":"users.first_name","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users","view_label":"Users","dynamic":false,"week_start_day":"monday","original_view":"users","dimension_group":null,"error":null,"field_group_variant":"First
-        Name","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.first_name","suggest_explore":"users","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=33","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.first_name
-        ","sql_case":null,"filters":null,"times_used":0},{"align":"right","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":true,"label":"Users
-        ID","label_from_parameter":null,"label_short":"ID","map_layer":null,"name":"users.id","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"number","user_attribute_filter_types":["number","advanced_filter_number"],"value_format":null,"view":"users","view_label":"Users","dynamic":false,"week_start_day":"monday","original_view":"users","dimension_group":null,"error":null,"field_group_variant":"ID","measure":false,"parameter":false,"primary_key":true,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.id","suggest_explore":"users","suggestable":false,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=6","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.id
-        ","sql_case":null,"filters":null,"times_used":0},{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
-        Last Name","label_from_parameter":null,"label_short":"Last Name","map_layer":null,"name":"users.last_name","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users","view_label":"Users","dynamic":false,"week_start_day":"monday","original_view":"users","dimension_group":null,"error":null,"field_group_variant":"Last
-        Name","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.last_name","suggest_explore":"users","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=38","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.last_name
-        ","sql_case":null,"filters":null,"times_used":0},{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
-        State","label_from_parameter":null,"label_short":"State","map_layer":{"url":"/data/us_states.topo-402e425f99.json","name":"us_states","feature_key":"usa","property_key":null,"property_label_key":null,"projection":"albersUsa","format":"","extents_json_url":null,"max_zoom_level":null,"min_zoom_level":null},"name":"users.state","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users","view_label":"Users","dynamic":false,"week_start_day":"monday","original_view":"users","dimension_group":null,"error":null,"field_group_variant":"State","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.state","suggest_explore":"users","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=18","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.state
-        ","sql_case":null,"filters":null,"times_used":0}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users","label":"Users","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.06625700000000001,"has_subtotals":false}},"c5909e67ead0a5580fc83e490f59be00":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"c5909e67ead0a5580fc83e490f59be00","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-01T20:03:17+00:00","aggregate_table_used_info":null,"runtime":"0.333","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.city"]},"forecast_result":null,"sql":"SELECT\n    users__fail.city  AS
+      string: '{"099445fc499e80b7d69d41c982e227da":{"status":"error","result_source":"query","data":{"from_cache":true,"id":"099445fc499e80b7d69d41c982e227da","supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:59:11+00:00","aggregate_table_used_info":null,"runtime":"0.300","added_params":{"query_timezone":"America/New_York","sorts":["users__fail.city"]},"forecast_result":null,"sql":"SELECT\n    users__fail.city  AS
         users__fail_city,\n    users__fail.email_address  AS users__fail_email,\n    users__fail.first  AS
         users__fail_first_name,\n    users__fail.id  AS users__fail_id,\n    users__fail.last  AS
         users__fail_last_name\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
@@ -1850,7 +1868,25 @@ interactions:
         users__fail_city,\n    users__fail.email_address  AS users__fail_email,\n    users__fail.first  AS
         users__fail_first_name,\n    users__fail.id  AS users__fail_id,\n    users__fail.last  AS
         users__fail_last_name\nFROM looker-private-demo.ecomm.users\n   AS users__fail\nWHERE
-        (1 = 2)\nORDER BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":3,"column":17}}],"drill_menu_build_time":0.038035,"has_subtotals":false}}}'
+        (1 = 2)\nORDER BY\n    1\nLIMIT 0","edit_url":null,"error_pos":null,"level":"error","sql_error_loc":{"line":3,"column":17}}],"drill_menu_build_time":0.038342,"has_subtotals":false}},"34f41b2b097824b6e958092ebe61d4b4":{"status":"complete","result_source":"query","data":{"from_cache":true,"id":"34f41b2b097824b6e958092ebe61d4b4","truncated":true,"supports_pivot_in_db":true,"null_sort_treatment":"low","expired":false,"ran_at":"2022-04-05T13:59:11+00:00","aggregate_table_used_info":null,"runtime":"0.552","added_params":{"query_timezone":"America/New_York","sorts":["users.city"]},"forecast_result":null,"dialect_specific_metadata":{"total_bytes_processed":0,"backend_cache_hit":true,"bi_engine_mode":null,"bi_engine_reasons":null,"bigquery_job_id":"looker-partners:US.job_p-LiAjkp7XJkk0LWCYtDL0mHu2GZ"},"sql":"SELECT\n    users.city  AS
+        users_city,\n    users.email  AS users_email,\n    users.first_name  AS users_first_name,\n    users.id  AS
+        users_id,\n    users.last_name  AS users_last_name,\n    users.state  AS users_state\nFROM
+        looker-private-demo.ecomm.users\n     AS users\nWHERE (1 = 2)\nORDER BY\n    1\nLIMIT
+        0","sql_explain":null,"fields":{"measures":[],"dimensions":[{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
+        City","label_from_parameter":null,"label_short":"City","map_layer":null,"name":"users.city","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users","view_label":"Users","dynamic":false,"week_start_day":"monday","original_view":"users","dimension_group":null,"error":null,"field_group_variant":"City","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.city","suggest_explore":"users","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=23","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.city
+        ","sql_case":null,"filters":null,"times_used":0,"sorted":{"sort_index":0,"desc":false}},{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
+        Email","label_from_parameter":null,"label_short":"Email","map_layer":null,"name":"users.email","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users","view_label":"Users","dynamic":false,"week_start_day":"monday","original_view":"users","dimension_group":null,"error":null,"field_group_variant":"Email","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.email","suggest_explore":"users","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=28","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.email
+        ","sql_case":null,"filters":null,"times_used":0},{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
+        First Name","label_from_parameter":null,"label_short":"First Name","map_layer":null,"name":"users.first_name","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users","view_label":"Users","dynamic":false,"week_start_day":"monday","original_view":"users","dimension_group":null,"error":null,"field_group_variant":"First
+        Name","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.first_name","suggest_explore":"users","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=33","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.first_name
+        ","sql_case":null,"filters":null,"times_used":0},{"align":"right","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":true,"label":"Users
+        ID","label_from_parameter":null,"label_short":"ID","map_layer":null,"name":"users.id","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"number","user_attribute_filter_types":["number","advanced_filter_number"],"value_format":null,"view":"users","view_label":"Users","dynamic":false,"week_start_day":"monday","original_view":"users","dimension_group":null,"error":null,"field_group_variant":"ID","measure":false,"parameter":false,"primary_key":true,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.id","suggest_explore":"users","suggestable":false,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=6","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.id
+        ","sql_case":null,"filters":null,"times_used":0},{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
+        Last Name","label_from_parameter":null,"label_short":"Last Name","map_layer":null,"name":"users.last_name","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users","view_label":"Users","dynamic":false,"week_start_day":"monday","original_view":"users","dimension_group":null,"error":null,"field_group_variant":"Last
+        Name","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.last_name","suggest_explore":"users","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=38","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.last_name
+        ","sql_case":null,"filters":null,"times_used":0},{"align":"left","can_filter":true,"category":"dimension","default_filter_value":null,"description":"","enumerations":null,"field_group_label":null,"fill_style":null,"fiscal_month_offset":0,"has_allowed_values":false,"hidden":false,"is_filter":false,"is_numeric":false,"label":"Users
+        State","label_from_parameter":null,"label_short":"State","map_layer":{"url":"/data/us_states.topo-402e425f99.json","name":"us_states","feature_key":"usa","property_key":null,"property_label_key":null,"projection":"albersUsa","format":"","extents_json_url":null,"max_zoom_level":null,"min_zoom_level":null},"name":"users.state","strict_value_format":false,"requires_refresh_on_sort":false,"sortable":true,"suggestions":null,"tags":[],"type":"string","user_attribute_filter_types":["string","advanced_filter_string"],"value_format":null,"view":"users","view_label":"Users","dynamic":false,"week_start_day":"monday","original_view":"users","dimension_group":null,"error":null,"field_group_variant":"State","measure":false,"parameter":false,"primary_key":false,"project_name":"eye_exam","scope":"users","suggest_dimension":"users.state","suggest_explore":"users","suggestable":true,"is_fiscal":false,"is_timeframe":false,"can_time_filter":false,"time_interval":null,"lookml_link":"/projects/eye_exam/files/views%2Fusers.view.lkml?line=18","permanent":null,"source_file":"views/users.view.lkml","source_file_path":"eye_exam/views/users.view.lkml","sql":"${TABLE}.state
+        ","sql_case":null,"filters":null,"times_used":0}],"table_calculations":[],"pivots":[]},"fill_fields":[],"has_totals":false,"has_row_totals":false,"applied_filters":{},"applied_filter_expression":"1=2","number_format":"1,234.56","explore":{"name":"users","label":"Users","description":null},"timezone":"America/New_York","data":[],"drill_menu_build_time":0.06919800000000001,"has_subtotals":false}}}'
     headers:
       Connection:
       - keep-alive
@@ -1859,20 +1895,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:17 GMT
+      - Tue, 05 Apr 2022 13:59:11 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f8bd5ea2d23b3115
+      - a83cfc6cfa463f93
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f8bd5ea2d23b3115
+      - a83cfc6cfa463f93
       X-B3-TraceId:
-      - 62475a85b7e272dbf8bd5ea2d23b3115
+      - 624c4b2f659e9deda83cfc6cfa463f93
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1886,7 +1922,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -1900,20 +1936,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:18 GMT
+      - Tue, 05 Apr 2022 13:59:12 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 18e08be19a1de08e
+      - 5a58ed511475267d
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 18e08be19a1de08e
+      - 5a58ed511475267d
       X-B3-TraceId:
-      - 62475a86f262931d18e08be19a1de08e
+      - 624c4b30343e5b7f5a58ed511475267d
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1925,7 +1961,7 @@ interactions:
       Content-Length:
       - '0'
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: DELETE
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch/tmp_spectacles_b
   response:
@@ -1935,19 +1971,19 @@ interactions:
       Connection:
       - keep-alive
       Date:
-      - Fri, 01 Apr 2022 20:03:19 GMT
+      - Tue, 05 Apr 2022 13:59:13 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Origin
       X-B3-ParentSpanId:
-      - 3d843a15d8aafcf6
+      - 94f58fac33cba8ba
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 3d843a15d8aafcf6
+      - 94f58fac33cba8ba
       X-B3-TraceId:
-      - 62475a8698432f573d843a15d8aafcf6
+      - 624c4b305ffa6e2a94f58fac33cba8ba
       X-Content-Type-Options:
       - nosniff
     status:
@@ -1961,7 +1997,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PUT
     uri: https://spectacles.looker.com:19999/api/3.1/projects/welcome_to_looker/git_branch
   response:
@@ -1975,20 +2011,20 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:19 GMT
+      - Tue, 05 Apr 2022 13:59:13 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - f3096f4566092a4e
+      - 0e5f38645ac7fe31
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - f3096f4566092a4e
+      - 0e5f38645ac7fe31
       X-B3-TraceId:
-      - 62475a87fc023e0ef3096f4566092a4e
+      - 624c4b311fe87f130e5f38645ac7fe31
       X-Content-Type-Options:
       - nosniff
     status:
@@ -2002,7 +2038,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - looker.browser=9881689
+      - looker.browser=39326198
     method: PATCH
     uri: https://spectacles.looker.com:19999/api/3.1/session
   response:
@@ -2016,19 +2052,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 01 Apr 2022 20:03:19 GMT
+      - Tue, 05 Apr 2022 13:59:13 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding, Origin
       X-B3-ParentSpanId:
-      - 0d49d486abedd18c
+      - 5d084169fa33f727
       X-B3-Sampled:
       - '0'
       X-B3-SpanId:
-      - 0d49d486abedd18c
+      - 5d084169fa33f727
       X-B3-TraceId:
-      - 62475a879fe3d3cb0d49d486abedd18c
+      - 624c4b31e3f7a40c5d084169fa33f727
       X-Content-Type-Options:
       - nosniff
     status:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,13 @@ import pytest
 import requests
 from constants import ENV_VARS
 from utils import build_validation
-from spectacles.cli import main, create_parser, handle_exceptions, preprocess_dash
+from spectacles.cli import (
+    main,
+    create_parser,
+    handle_exceptions,
+    preprocess_dash,
+    process_pin_imports,
+)
 from spectacles.exceptions import (
     LookerApiError,
     SpectaclesException,
@@ -424,6 +430,23 @@ def test_main_with_do_not_track(mock_tracking, mock_run_connect, env):
         port=8080,
         api_version=3.1,
     )
+
+
+def test_process_pin_imports_with_no_refs():
+    output = process_pin_imports([])
+    assert output == {}
+
+
+def test_process_pin_imports_with_one_ref():
+    output = process_pin_imports(["welcome_to_looker:testing-imports"])
+    assert output == {"welcome_to_looker": "testing-imports"}
+
+
+def test_process_pin_imports_with_multiple_refs():
+    output = process_pin_imports(
+        ["welcome_to_looker:testing-imports", "eye_exam:123abc"]
+    )
+    assert output == {"welcome_to_looker": "testing-imports", "eye_exam": "123abc"}
 
 
 def test_preprocess_dashes_with_folder_ids_should_work():


### PR DESCRIPTION
## Change description

This PR updates the Runner, LookerBranchManager and CLI to allow users to run Spectacles with locally imported Looker projects pinned to specific git refs.

i.e. if the project `eye_exam` currently locally imports `welcome_to_looker`, the prior behaviour would have always tested `welcome_to_looker` @ production. Now, by passing the following CLI arg, we can test it at any git ref:

```bash
--pin-imports welcome_to_looker:some-branch-name
```

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

Closes #454 

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
