### PR TITLE
Fixing logging for outstanding query count in SQL validator

### DIFF
--- a/spectacles/validators/sql.py
+++ b/spectacles/validators/sql.py
@@ -323,7 +323,7 @@ class SqlValidator:
         )
         while queries or self._test_by_task_id:
             if queries:
-                logger.debug(f"Starting a new loop, {len(tests)} tests queued")
+                logger.debug(f"Starting a new loop, {len(queries)} tests queued")
                 fill_query_slots(queries)
             query_tasks = list(self._test_by_task_id.keys())[:QUERY_TASK_LIMIT]
             logger.debug(f"Checking for results of {len(query_tasks)} query tasks")


### PR DESCRIPTION
## Change description

We are currently incorrectly logging the number of outstanding SQL tests to run. Currently, it logs the total number of tests, not the outstanding number of queries. This PR fixes this issue.

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Hotfix, no issue

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
