### PR TITLE
Handle 404 when compiling SQL

### DIFF
--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -903,17 +903,22 @@ class LookerClient:
         response = self.get(url=url, timeout=TIMEOUT_SEC)
         try:
             response.raise_for_status()
-        except requests.exceptions.HTTPError:
-            raise LookerApiError(
-                name="unable-to-retrieve-compiled-sql",
-                title="Couldn't retrieve compiled SQL.",
-                status=response.status_code,
-                detail=(
-                    f"Failed to retrieve compiled SQL for query '{query_id}'. "
-                    "Please try again."
-                ),
-                response=response,
-            )
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 404:
+                return (
+                    "-- SQL could not be generated because of errors with this query."
+                )
+            else:
+                raise LookerApiError(
+                    name="unable-to-retrieve-compiled-sql",
+                    title="Couldn't retrieve compiled SQL.",
+                    status=response.status_code,
+                    detail=(
+                        f"Failed to retrieve compiled SQL for query '{query_id}'. "
+                        "Please try again."
+                    ),
+                    response=response,
+                )
 
         result = response.text
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -42,14 +42,14 @@ def get_client_method_names() -> List[str]:
 
 
 @pytest.fixture
-def mock_404_response():
+def mock_401_response():
     mock_request = Mock(spec=requests.PreparedRequest)
     mock_request.method = "POST"
     mock_request.url = "https://spectacles.looker.com"
     mock_response = Mock(spec=requests.Response)
-    mock_response.status_code = 404
+    mock_response.status_code = 401
     mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
-        "An HTTP error occurred."
+        "An HTTP error occurred.", response=mock_response
     )
     mock_response.request = mock_request
     return mock_response
@@ -149,10 +149,10 @@ def test_create_query_without_dimensions_should_return_certain_fields(looker_cli
 @patch("spectacles.client.requests.Session.request")
 @pytest.mark.parametrize("method_name", get_client_method_names())
 def test_bad_requests_should_raise_looker_api_errors(
-    mock_request, method_name, looker_client, client_kwargs, mock_404_response
+    mock_request, method_name, looker_client, client_kwargs, mock_401_response
 ):
-    """Tests each method of LookerClient for how it handles a 404 response"""
-    mock_request.return_value = mock_404_response
+    """Tests each method of LookerClient for how it handles a 401 response"""
+    mock_request.return_value = mock_401_response
     client_method = getattr(looker_client, method_name)
     with pytest.raises(LookerApiError):
         client_method(**client_kwargs[method_name])


### PR DESCRIPTION
## Change description

This changes allows handling for the `run_query` client function for when a 404 is returned. This can be because an explore or model doesn't exist on the branch and we need to return a string for incremental diff comparison.

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Closes #554 

## Checklists

### Security

- [X] Security impact of change has been considered
- [X] Code follows security best practices and guidelines

### Code review 

- [X] Pull request has a descriptive title and context useful to a reviewer
