### PR TITLE
Fix fail fast cancellations of chunked queries

### DIFF
--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -349,7 +349,9 @@ class Runner:
         )
 
         with self.branch_manager(ref=ref):
-            validator.run_tests(tests, profile=profile if fail_fast else False)
+            validator.run_tests(
+                tests, fail_fast, profile=profile if fail_fast else False
+            )
 
         # Create dimension tests for the desired ref when explores errored
         if not fail_fast:
@@ -357,7 +359,7 @@ class Runner:
                 base_ref = self.branch_manager.ref
                 logger.debug("Building dimension tests for the desired ref")
                 base_tests = validator.create_tests(project, at_dimension_level=True)
-                validator.run_tests(base_tests, profile)
+                validator.run_tests(base_tests, fail_fast, profile)
 
             # For errored dimensions, create dimension tests for the target ref
             if incremental:

--- a/tests/cassettes/test_runner/test_incremental_sql_with_diff_explores_and_valid_sql_should_not_error.yaml
+++ b/tests/cassettes/test_runner/test_incremental_sql_with_diff_explores_and_valid_sql_should_not_error.yaml
@@ -5363,4 +5363,60 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: '{"batch": [{"integrations": {}, "anonymousId": null, "properties": {"label":
+      "start", "command": "sql", "project": "861d2b5ca10a0dd590753e48001f93ab", "invocation_id":
+      "b4a7295b-673a-4903-b795-d180b8c03ea6"}, "timestamp": "2022-05-12T23:46:20.454355+00:00",
+      "context": {"library": {"name": "analytics-python", "version": "1.4.0"}}, "userId":
+      "0bc6479c09a037b58960e5c4902c5d4c", "type": "track", "event": "invocation",
+      "messageId": "96d12b60-dca1-4587-8877-db066c1674e0"}, {"integrations": {}, "anonymousId":
+      null, "properties": {"label": "end", "command": "sql", "project": "861d2b5ca10a0dd590753e48001f93ab",
+      "invocation_id": "b4a7295b-673a-4903-b795-d180b8c03ea6"}, "timestamp": "2022-05-12T23:46:20.454725+00:00",
+      "context": {"library": {"name": "analytics-python", "version": "1.4.0"}}, "userId":
+      "0bc6479c09a037b58960e5c4902c5d4c", "type": "track", "event": "invocation",
+      "messageId": "a9103bef-c4b7-4a4c-a7a7-a57fd38fbd3b"}, {"integrations": {}, "anonymousId":
+      null, "properties": {"label": "start", "command": "sql", "project": "861d2b5ca10a0dd590753e48001f93ab",
+      "invocation_id": "b4a7295b-673a-4903-b795-d180b8c03ea6"}, "timestamp": "2022-05-12T23:46:20.575034+00:00",
+      "context": {"library": {"name": "analytics-python", "version": "1.4.0"}}, "userId":
+      "43f97e90e92b29990be0c4e68bc7ec77", "type": "track", "event": "invocation",
+      "messageId": "08516b6c-9b91-40d9-9011-1d3a878db858"}, {"integrations": {}, "anonymousId":
+      null, "properties": {"label": "end", "command": "sql", "project": "861d2b5ca10a0dd590753e48001f93ab",
+      "invocation_id": "b4a7295b-673a-4903-b795-d180b8c03ea6"}, "timestamp": "2022-05-12T23:46:20.575246+00:00",
+      "context": {"library": {"name": "analytics-python", "version": "1.4.0"}}, "userId":
+      "43f97e90e92b29990be0c4e68bc7ec77", "type": "track", "event": "invocation",
+      "messageId": "0b279b1f-a3cc-4241-9a22-29f0222d1fcf"}], "sentAt": "2022-05-12T23:46:20.957883+00:00"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1897'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - analytics-python/1.4.0
+    method: POST
+    uri: https://api.segment.io/v1/batch
+  response:
+    body:
+      string: "{\n  \"success\": true\n}"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '21'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 12 May 2022 23:46:21 GMT
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -131,7 +131,7 @@ def test_validate_sql_returns_valid_schema(
 ):
     error_message = "An error ocurred"
 
-    def add_error_to_project(tests, profile):
+    def add_error_to_project(tests, fail_fast, profile):
         project.models[0].explores[0].queried = True
         project.models[0].explores[0].errors = [SqlError("", "", "", "", error_message)]
 

--- a/tests/test_sql_validator.py
+++ b/tests/test_sql_validator.py
@@ -40,7 +40,7 @@ class TestValidatePass:
     @pytest.mark.vcr(match_on=["uri", "method", "raw_body"])
     @pytest.fixture(scope="class")
     def validator_after_run(self, validator, explore_tests) -> Iterable[SqlValidator]:
-        validator.run_tests(list(explore_tests))
+        validator.run_tests(list(explore_tests), fail_fast=True)
         yield validator
 
     @pytest.mark.default_cassette("fixture_dimension_tests_pass.yaml")
@@ -104,7 +104,7 @@ class TestValidateFail:
     @pytest.mark.vcr(match_on=["uri", "method", "raw_body"])
     @pytest.fixture(scope="class")
     def validator_after_run(self, validator, explore_tests) -> Iterable[SqlValidator]:
-        validator.run_tests(list(explore_tests))
+        validator.run_tests(list(explore_tests), fail_fast=True)
         yield validator
 
     @pytest.mark.default_cassette("fixture_dimension_tests_fail.yaml")
@@ -167,7 +167,8 @@ def test_create_and_run_keyboard_interrupt_cancels_queries(validator):
                     query_task_id="def",
                     explore_url="https://example.looker.com/x/56789",
                 )
-            ]
+            ],
+            fail_fast=True,
         )
     except SpectaclesException:
         mock_cancel_queries.assert_called_once_with(["abc"])


### PR DESCRIPTION
## Change description

Some of the lower-level functions in the SQL validator accept an argument `fail_fast`, but it has a default value of `True`. This argument was never actually passed in dynamically further up in the runner, so it always ran with `fail_fast=True`.

It affects one small part of the code where we "preemptively cancel" any other chunk queries for a SQL test as soon as the first one fails. The truthy default argument meant we always preemptively cancelled, even when we weren't in fail fast.

The impact is pretty minimal, since this would only matter for SQL tests with more than one chunk query (i.e. an explore with # of dimensions > `DEFAULT_CHUNK_SIZE`: 500). In those cases, for non-fail-fast runs, we would have only returned the first error instead of all errors, and this would have only happened if the other chunk queries for the test were queued up and not already running.
 
This wasn't caught by our tests because our `eye_exam` project simply isn't big enough to trigger chunking.

That said, this change makes the fix.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
