### PR TITLE
Report "dangling" content validator errors

### DIFF
--- a/spectacles/lookml.py
+++ b/spectacles/lookml.py
@@ -339,23 +339,20 @@ class Project(LookMlObject):
             # We create an explore "tested" record for those that
             # aren't in the LookML tree.
             distinct_explores = set()
-            if filters is None and model.errors:
-                # Raise name error if there are errors on the model and filters
-                # isn't being passed. We need filters when running the content
-                # validator, which is the only time a model will have errors.
-                raise TypeError(
-                    "The argument 'filters' is required in Content Validator."
-                )
-            elif filters is not None and model.errors:  # appease mypy
-                for error in model.errors:
-                    if is_selected(model.name, error.explore, filters):
-                        distinct_explores.add(error.explore)
-                        errors.append(error.to_dict())
-                model_tested = [
-                    {"model": model.name, "explore": e, "status": "failed"}
-                    for e in distinct_explores
-                ]
-                tested.extend(model_tested)
+
+            for error in model.errors:
+                if filters is not None and not is_selected(
+                    model.name, error.explore, filters
+                ):
+                    continue
+                distinct_explores.add(error.explore)
+                errors.append(error.to_dict())
+
+            model_tested = [
+                {"model": model.name, "explore": e, "status": "failed"}
+                for e in distinct_explores
+            ]
+            tested.extend(model_tested)
 
             for explore in model.explores:
                 if filters is not None and not is_selected(

--- a/spectacles/lookml.py
+++ b/spectacles/lookml.py
@@ -474,6 +474,8 @@ def build_project(
                     explore.dimensions = build_dimensions(
                         client, model.name, explore.name, ignore_hidden_fields
                     )
-
-    project = Project(name, models)
-    return project
+        project = Project(name, [m for m in models if len(m.explores) > 0])
+        return project
+    else:
+        project = Project(name, models)
+        return project

--- a/spectacles/lookml.py
+++ b/spectacles/lookml.py
@@ -172,6 +172,7 @@ class Model(LookMlObject):
         self.name = name
         self.project_name = project_name
         self.explores = explores
+        self.errors: List[ValidationError] = []
 
     def __repr__(self):
         return f"{self.__class__.__name__}(name={self.name}, explores={self.explores})"
@@ -189,7 +190,9 @@ class Model(LookMlObject):
     @property
     def errored(self):
         if self.queried:
-            return any(explore.errored for explore in self.explores)
+            return bool(self.errors) or any(
+                explore.errored for explore in self.explores
+            )
         else:
             return None
 
@@ -322,14 +325,46 @@ class Project(LookMlObject):
             return model_object.get_explore(name)
 
     def get_results(
-        self, validator: str, fail_fast: Optional[bool] = None
+        self,
+        validator: str,
+        fail_fast: Optional[bool] = None,
+        filters: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         errors: List[Dict[str, Any]] = []
         successes: List[Dict[str, Any]] = []
         tested = []
 
         for model in self.models:
+            # Add model level content validation errors.
+            # We create an explore "tested" record for those that
+            # aren't in the LookML tree.
+            distinct_explores = set()
+            if filters is None and model.errors:
+                # Raise name error if there are errors on the model and filters
+                # isn't being passed. We need filters when running the content
+                # validator, which is the only time a model will have errors.
+                raise NameError(
+                    "The argument 'filters' is required in Content Validator."
+                )
+            elif filters is not None and model.errors:  # appease mypy
+                for error in [
+                    e
+                    for e in model.errors
+                    if is_selected(model.name, e.explore, filters)
+                ]:
+                    distinct_explores.add(error.explore)
+                    errors.append(error.to_dict())
+                model_tested = [
+                    {"model": model.name, "explore": e, "status": "failed"}
+                    for e in distinct_explores
+                ]
+                tested.extend(model_tested)
+
             for explore in model.explores:
+                if filters is not None and not is_selected(
+                    model.name, explore.name, filters
+                ):
+                    continue
                 status = "passed"
                 if explore.skipped:
                     status = "skipped"
@@ -401,6 +436,7 @@ def build_project(
     filters: Optional[List[str]] = None,
     include_dimensions: bool = False,
     ignore_hidden_fields: bool = False,
+    include_all_explores: bool = False,
 ) -> Project:
     """Creates an object (tree) representation of a LookML project."""
     if filters is None:
@@ -410,7 +446,7 @@ def build_project(
     fields = ["name", "project_name", "explores"]
     for lookmlmodel in client.get_lookml_models(fields=fields):
         model = Model.from_json(lookmlmodel)
-        if model.project_name == name and model.explores:
+        if model.project_name == name:
             models.append(model)
 
     if not models:
@@ -424,18 +460,20 @@ def build_project(
             ),
         )
 
-    for model in models:
-        model.explores = [
-            explore
-            for explore in model.explores
-            if is_selected(model.name, explore.name, filters)
-        ]
+    # For the content validator, we need all explores.
+    if not include_all_explores:
+        for model in models:
+            model.explores = [
+                explore
+                for explore in model.explores
+                if is_selected(model.name, explore.name, filters)
+            ]
 
-        if include_dimensions:
-            for explore in model.explores:
-                explore.dimensions = build_dimensions(
-                    client, model.name, explore.name, ignore_hidden_fields
-                )
+            if include_dimensions:
+                for explore in model.explores:
+                    explore.dimensions = build_dimensions(
+                        client, model.name, explore.name, ignore_hidden_fields
+                    )
 
-    project = Project(name, [model for model in models if len(model.explores) > 0])
+    project = Project(name, models)
     return project

--- a/spectacles/lookml.py
+++ b/spectacles/lookml.py
@@ -239,7 +239,7 @@ class Model(LookMlObject):
 
     @property
     def number_of_errors(self):
-        return sum(
+        return len(self.errors) + sum(
             [explore.number_of_errors for explore in self.explores if explore.errored]
         )
 

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -446,7 +446,12 @@ class Runner:
                 "Building LookML project hierarchy for project "
                 f"'{self.project}' @ {self.branch_manager.ref}"
             )
-            project = build_project(self.client, name=self.project, filters=filters)
+            project = build_project(
+                self.client,
+                name=self.project,
+                filters=filters,
+                include_all_explores=True,
+            )
             explore_count = project.count_explores()
             print_header(
                 f"Validating content based on {explore_count} "
@@ -454,7 +459,7 @@ class Runner:
                 + (" [incremental mode] " if incremental else "")
             )
             validator.validate(project)
-            results = project.get_results(validator="content")
+            results = project.get_results(validator="content", filters=filters)
 
         if incremental and (self.branch_manager.branch or self.branch_manager.commit):
             logger.debug("Starting another content validation against the target ref")
@@ -464,10 +469,15 @@ class Runner:
                     f"'{self.project}' @ {self.branch_manager.ref}"
                 )
                 target_project = build_project(
-                    self.client, name=self.project, filters=filters
+                    self.client,
+                    name=self.project,
+                    filters=filters,
+                    include_all_explores=True,
                 )
                 validator.validate(target_project)
-                target_results = target_project.get_results(validator="content")
+                target_results = target_project.get_results(
+                    validator="content", filters=filters
+                )
 
             return self._incremental_results(base=results, target=target_results)
         else:

--- a/spectacles/validators/content.py
+++ b/spectacles/validators/content.py
@@ -158,7 +158,7 @@ class ContentValidator:
                 if explore and content_error not in explore.errors:
                     explore.errors.append(content_error)
                     content_errors.append(content_error)
-                if model and content_error not in model.errors:
+                elif model and content_error not in model.errors:
                     model.errors.append(content_error)
                     content_errors.append(content_error)
 

--- a/spectacles/validators/content.py
+++ b/spectacles/validators/content.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Any, Dict
 from spectacles.client import LookerClient
 from spectacles.exceptions import ContentError, SpectaclesException
-from spectacles.lookml import Explore, Project
+from spectacles.lookml import Explore, Project, Model
 from spectacles.logger import GLOBAL_LOGGER as logger
 from spectacles.types import JsonDict
 
@@ -131,8 +131,9 @@ class ContentValidator:
             explore: Optional[Explore] = project.get_explore(
                 model=model_name, name=explore_name
             )
+            model: Optional[Model] = project.get_model(model_name)
             # Skip errors that are not associated with selected explores
-            if explore:
+            if explore or model:
                 content_id = result[content_type]["id"]
                 content_error = ContentError(
                     model=model_name,
@@ -154,8 +155,11 @@ class ContentValidator:
                         else None
                     ),
                 )
-                if content_error not in explore.errors:
+                if explore and content_error not in explore.errors:
                     explore.errors.append(content_error)
+                    content_errors.append(content_error)
+                if model and content_error not in model.errors:
+                    model.errors.append(content_error)
                     content_errors.append(content_error)
 
         return content_errors

--- a/spectacles/validators/content.py
+++ b/spectacles/validators/content.py
@@ -128,10 +128,11 @@ class ContentValidator:
         for error in result["errors"]:
             model_name = error["model_name"]
             explore_name = error["explore_name"]
-            explore: Optional[Explore] = project.get_explore(
-                model=model_name, name=explore_name
-            )
             model: Optional[Model] = project.get_model(model_name)
+            if model:
+                explore: Optional[Explore] = model.get_explore(name=explore_name)
+            else:
+                explore = None
             # Skip errors that are not associated with selected explores
             if explore or model:
                 content_id = result[content_type]["id"]

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -32,10 +32,15 @@ class TestValidatePass:
     @pytest.mark.vcr(match_on=["uri", "method", "raw_body"])
     @pytest.fixture(scope="class")
     def validator_errors(self, validator) -> Iterable[List[ContentError]]:
+        filters = ["eye_exam/users"]
         project = build_project(
-            validator.client, name="eye_exam", filters=["eye_exam/users"]
+            validator.client,
+            name="eye_exam",
+            filters=filters,
+            include_all_explores=True,
         )
-        errors: List[ContentError] = validator.validate(project)
+        validator.validate(project)
+        errors = project.get_results(validator="content", filters=filters)["errors"]
         yield errors
 
     def test_should_not_return_errors(self, validator_errors):
@@ -49,17 +54,22 @@ class TestValidateFail:
     @pytest.mark.vcr(match_on=["uri", "method", "raw_body"])
     @pytest.fixture(scope="class")
     def validator_errors(self, validator) -> Iterable[List[ContentError]]:
+        filters = ["eye_exam/users__fail"]
         project = build_project(
-            validator.client, name="eye_exam", filters=["eye_exam/users__fail"]
+            validator.client,
+            name="eye_exam",
+            filters=filters,
+            include_all_explores=True,
         )
-        errors: List[ContentError] = validator.validate(project)
+        validator.validate(project)
+        errors = project.get_results(validator="content", filters=filters)["errors"]
         yield errors
 
     def test_should_return_errors(self, validator_errors):
         assert len(validator_errors) == 1
 
     def test_personal_folder_content_should_not_be_present(self, validator_errors):
-        titles = [error.metadata["title"] for error in validator_errors]
+        titles = [error["metadata"]["title"] for error in validator_errors]
         # All failing content in personal spaces has been tagged with "[personal]"
         assert "personal" not in titles
 
@@ -71,11 +81,16 @@ class TestValidateFailExcludeFolder:
     @pytest.mark.vcr(match_on=["uri", "method", "raw_body"])
     @pytest.fixture(scope="class")
     def validator_errors(self, validator) -> Iterable[List[ContentError]]:
+        filters = ["eye_exam/users__fail"]
         project = build_project(
-            validator.client, name="eye_exam", filters=["eye_exam/users__fail"]
+            validator.client,
+            name="eye_exam",
+            filters=filters,
+            include_all_explores=True,
         )
         validator.excluded_folders.append(26)
-        errors: List[ContentError] = validator.validate(project)
+        validator.validate(project)
+        errors = project.get_results(validator="content", filters=filters)["errors"]
         yield errors
 
     def test_error_from_excluded_folder_should_be_ignored(self, validator_errors):
@@ -89,11 +104,16 @@ class TestValidateFailIncludeFolder:
     @pytest.mark.vcr(match_on=["uri", "method", "raw_body"])
     @pytest.fixture(scope="class")
     def validator_errors(self, validator) -> Iterable[List[ContentError]]:
+        filters = ["eye_exam/users__fail"]
         project = build_project(
-            validator.client, name="eye_exam", filters=["eye_exam/users__fail"]
+            validator.client,
+            name="eye_exam",
+            filters=filters,
+            include_all_explores=True,
         )
         validator.included_folders.append(26)
-        errors: List[ContentError] = validator.validate(project)
+        validator.validate(project)
+        errors = project.get_results(validator="content", filters=filters)["errors"]
         yield errors
 
     def test_error_from_included_folder_should_be_returned(self, validator_errors):
@@ -107,12 +127,17 @@ class TestValidateFailIncludeExcludeFolder:
     @pytest.mark.vcr(match_on=["uri", "method", "raw_body"])
     @pytest.fixture(scope="class")
     def validator_errors(self, validator) -> Iterable[List[ContentError]]:
+        filters = ["eye_exam/users__fail"]
         project = build_project(
-            validator.client, name="eye_exam", filters=["eye_exam/users__fail"]
+            validator.client,
+            name="eye_exam",
+            filters=filters,
+            include_all_explores=True,
         )
         validator.included_folders.append(26)
         validator.excluded_folders.append(26)
-        errors: List[ContentError] = validator.validate(project)
+        validator.validate(project)
+        errors = project.get_results(validator="content", filters=filters)["errors"]
         yield errors
 
     def test_excluded_folder_should_take_priority_over_included_folder(


### PR DESCRIPTION
## Change description

We currently prune the LookML tree when building the project. This means that content validator errors relating to explores that don't exist anymore don't get reported by Spectacles. This PR changes this functionality so that these errors now appear.

The changes work in the following way:

* When we build the project for content validation runs, we now return the entire LookML tree. This allows us to attach all errors to their relevant place on the tree, even if the explore has been excluded from the run. This is what allows us to distinguish between explores that have been deleted and explores that have been excluded by the filters.
* When we attach the errors to the LookML tree, we first check if the relevant explore exists. If it does, we attach the error there. We then check if the relevant model exists. If it does, we attach the error there. This second part is new. Previously, we were only attaching to existing explores.
* When we return the errors for the project, we now allow for filters to be passed to the `get_results` function. This will only happen during the content validator. When this occurs, we prune the errors to just the relevant LookML tree.

This changes mean that we will now return all content validation errors relevant to a project, except for those that are linked to models that don't exist anymore. There is no way for us to know where to attach those, so they will remain dangling. 

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Closes #240 

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
