### PR TITLE
Stop re-importing imported projects

### DIFF
--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -137,13 +137,19 @@ class LookerBranchManager:
             )
         else:
             logger.debug("Creating temporary branches in imported projects")
+            previously_imported = tuple(mgr.project for mgr in self.import_managers)
             for project in self.imports:
-                import_ref = self.pin_imports.get(project, None)
-                manager = LookerBranchManager(
-                    self.client, project, pin_imports=self.pin_imports
-                )
-                manager(ref=import_ref, ephemeral=True).__enter__()
-                self.import_managers.append(manager)
+                if project not in previously_imported:
+                    import_ref = self.pin_imports.get(project, None)
+                    manager = LookerBranchManager(
+                        self.client, project, pin_imports=self.pin_imports
+                    )
+                    manager(ref=import_ref, ephemeral=True).__enter__()
+                    self.import_managers.append(manager)
+                else:
+                    logger.debug(
+                        f"Skipping project '{project}', which is already imported"
+                    )
 
         logger.indent(-1)
         logger.debug("")


### PR DESCRIPTION
## Change description

If the tree of imported projects is quite extensive, Spectacles can encounter situations where it's importing a far upstream project twice.

For example, consider the following imports:

project_a -> project_b
project_a -> current_project
project_b -> current_project

In this case, project_a is imported twice, once by project_b and again by the current project. When this happens, we end up in a bad state at cleanup because we attempt to return to a temporary branch created by another branch manager that no longer exists.

This change keeps track of projects that have already been imported and doesn't import them.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
