### PR TITLE
Handle content errors without a folder

### DIFF
--- a/spectacles/validators/content.py
+++ b/spectacles/validators/content.py
@@ -60,7 +60,8 @@ class ContentValidator:
                 continue
 
             # Sometimes the content no longer exists, in which case the folder is None
-            folder_id: Optional[str] = content[content_type]["folder"].get("id")
+            folder = content[content_type].get("folder")
+            folder_id: Optional[str] = folder.get("id") if folder else None
             # If exclude_personal isn't specified, personal_folders list is empty
             if not is_folder_selected(folder_id):
                 continue


### PR DESCRIPTION
## Change description

Using spectacles on my company's Looker instance, I ran into error caused by (I think) the same issue as reported here: https://github.com/spectacles-ci/spectacles/issues/327

```
Encountered unexpected AttributeError: "'NoneType' object has no attribute 'get'"
```

The [PR to fix this issue](https://github.com/spectacles-ci/spectacles/pull/352) didn't seem to work in my case though, since the call to `content[content_type]["folder"]` returns a `None`, it's the `folder` that's not set, not the `id` attribute.

This change fixed the error for me locally.

## Type of change
- [x] Bug fix (fixes an issue)

## Related issues

Closes [#327](https://github.com/spectacles-ci/spectacles/issues/327) 

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
