### PR TITLE
Fix indent in build_project explore loop

### DIFF
--- a/spectacles/lookml.py
+++ b/spectacles/lookml.py
@@ -494,13 +494,13 @@ async def build_project(
                 if is_selected(model.name, explore.name, filters)
             ]
 
-        tasks: List[asyncio.Task] = []
-        if include_dimensions:
-            for explore in model.explores:
-                task = asyncio.create_task(
-                    build_explore_dimensions(client, explore, ignore_hidden_fields)
-                )
-                tasks.append(task)
+            tasks: List[asyncio.Task] = []
+            if include_dimensions:
+                for explore in model.explores:
+                    task = asyncio.create_task(
+                        build_explore_dimensions(client, explore, ignore_hidden_fields)
+                    )
+                    tasks.append(task)
 
         await asyncio.gather(*tasks)
 


### PR DESCRIPTION
There was a bug in the `build_project` function that meant Spectacles would only work with single model projects (or with projects where the model that was needed was the last one returned by the API, which was unlikely). 

This fix indents the loop that iterates over explores in the `build_project` function, ensuring that we include all relevant explores.