### PR TITLE
Update run_lookml_test to use proper request method 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Project specifics
 logs/
+branch_comparison/results/*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -133,7 +133,7 @@ class LookerClient:
     @backoff.on_exception(
         backoff.expo,
         BACKOFF_EXCEPTIONS,
-        max_tries=2,
+        max_tries=3,
     )
     def request(self, method: str, url: str, *args, **kwargs) -> requests.Response:
         if self.access_token and self.access_token.expired:
@@ -558,7 +558,7 @@ class LookerClient:
             params["model"] = model
         if test is not None:
             params["test"] = test
-        response = self.session.get(url=url, params=params, timeout=TIMEOUT_SEC)
+        response = self.get(url=url, params=params, timeout=TIMEOUT_SEC)
 
         try:
             response.raise_for_status()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -171,3 +171,14 @@ def test_authenticate_should_set_session_headers(mock_post, monkeypatch):
     mock_post.return_value = mock_post_response
     client = LookerClient("base_url", "client_id", "client_secret")
     assert client.session.headers == {"Authorization": "token test_access_token"}
+
+
+@patch(
+    "spectacles.client.requests.Session.request",
+    side_effect=requests.exceptions.ReadTimeout,
+)
+def test_timeout_gets_handled_with_retries(mock_request, looker_client):
+    with pytest.raises(requests.exceptions.ReadTimeout):
+        looker_client.run_lookml_test(project="project_name")
+
+    assert mock_request.call_count == 3


### PR DESCRIPTION
## Change description

There was a call in the `run_lookml_test` function that was using `Session.get` instead of `self.get`. This PR fixes that and adds a test.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Closes #595 

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
