### PR TITLE
Fix issue with "space" deprecation

### DIFF
--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -842,7 +842,7 @@ async def run_content(
                 error["metadata"]["content_type"],
                 error["metadata"].get("tile_type"),
                 error["metadata"].get("tile_title"),
-                error["metadata"]["space"],
+                error["metadata"]["folder"],
                 error["metadata"]["title"],
                 error["metadata"]["url"],
             )

--- a/spectacles/exceptions.py
+++ b/spectacles/exceptions.py
@@ -182,6 +182,7 @@ class ContentError(ValidationError):
         field_name: str,
         content_type: str,
         title: str,
+        folder: str,
         url: str,
         tile_type: Optional[str] = None,
         tile_title: Optional[str] = None,
@@ -190,6 +191,7 @@ class ContentError(ValidationError):
             "field_name": field_name,
             "content_type": content_type,
             "title": title,
+            "folder": folder,
             "url": url,
         }
         if tile_type and tile_title:

--- a/spectacles/exceptions.py
+++ b/spectacles/exceptions.py
@@ -182,7 +182,7 @@ class ContentError(ValidationError):
         field_name: str,
         content_type: str,
         title: str,
-        folder: str,
+        folder: Optional[str],
         url: str,
         tile_type: Optional[str] = None,
         tile_title: Optional[str] = None,

--- a/spectacles/validators/content.py
+++ b/spectacles/validators/content.py
@@ -110,12 +110,24 @@ class ContentValidator:
 
     @staticmethod
     def _get_content_type(content: Dict[str, Any]) -> str:
-        if content["dashboard"]:
-            return "dashboard"
-        elif content["look"]:
-            return "look"
-        else:
-            raise KeyError("Content type not found. Valid keys are 'look', 'dashboard'")
+        CONTENT_TYPES = (
+            "look",
+            "dashboard",
+            "dashboard_element",
+            "dashboard_filter",
+            "scheduled_plan",
+            "alert",
+            "lookml_dashboard",
+            "lookml_dashboard_element",
+        )
+        for content_type in CONTENT_TYPES:
+            if content.get(content_type):
+                return content_type
+
+        # If none of the content types are found
+        raise KeyError(
+            f"Content type not found. Valid keys are: {', '.join(CONTENT_TYPES)}"
+        )
 
     @staticmethod
     def _get_tile_type(content: Dict[str, Any]) -> str:
@@ -150,6 +162,7 @@ class ContentValidator:
                     field_name=error["field_name"],
                     content_type=content_type,
                     title=result[content_type]["title"],
+                    folder=result[content_type]["folder"]["name"],
                     url=f"{self.client.base_url}/{content_type}s/{content_id}",
                     tile_type=(
                         self._get_tile_type(result)

--- a/spectacles/validators/content.py
+++ b/spectacles/validators/content.py
@@ -155,6 +155,8 @@ class ContentValidator:
             # Skip errors that are not associated with selected explores or existing models
             if explore or model:
                 content_id = result[content_type]["id"]
+                folder = result[content_type].get("folder")
+                folder_name: Optional[str] = folder.get("name") if folder else None
                 content_error = ContentError(
                     model=model_name,
                     explore=explore_name,
@@ -162,7 +164,7 @@ class ContentValidator:
                     field_name=error["field_name"],
                     content_type=content_type,
                     title=result[content_type]["title"],
-                    folder=result[content_type]["folder"]["name"],
+                    folder=folder_name,
                     url=f"{self.client.base_url}/{content_type}s/{content_id}",
                     tile_type=(
                         self._get_tile_type(result)

--- a/tests/resources/validation_schema.json
+++ b/tests/resources/validation_schema.json
@@ -78,7 +78,7 @@
                 "title": {
                     "type": "string"
                 },
-                "space": {
+                "folder": {
                     "type": "string"
                 },
                 "url": {

--- a/tests/unit/test_content_validator.py
+++ b/tests/unit/test_content_validator.py
@@ -11,7 +11,7 @@ def validator(looker_client: LookerClient) -> ContentValidator:
 def test_get_content_type_with_bad_keys_should_raise_key_error(
     validator: ContentValidator,
 ):
-    content = {"lookml_dashboard": "Something goes here."}
+    content = {"tableau_dashboard": "Something goes here."}
     with pytest.raises(KeyError):
         validator._get_content_type(content)
 


### PR DESCRIPTION
## Change description

This change accounts for some deprecation that happened in the Looker API when going from v3.1 to 4.0. In the latest version, the key `space` has been replaced by `folder`.

**Important:** This change also expands allowed Content Validation errors from other types of content besides Looks and Dashboards (e.g. alerts or LookML dashboards). Previously we skipped content validation errors for non-Look or non-Dashboard content.

Description here

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Closes #610, closes #600.

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
