### PR TITLE
Bugfix: allow None type for dashboard title

### DIFF
--- a/spectacles/validators/content.py
+++ b/spectacles/validators/content.py
@@ -163,7 +163,7 @@ class ContentValidator:
                     message=error["message"],
                     field_name=error["field_name"],
                     content_type=content_type,
-                    title=result[content_type]["title"],
+                    title=result[content_type].get("title"),
                     folder=folder_name,
                     url=f"{self.client.base_url}/{content_type}s/{content_id}",
                     tile_type=(


### PR DESCRIPTION
## Change description

Closes #626 content validation bug where a dashboard have `title=None`. I suspect this is from `lookml` dashboards.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Closes [#626](https://github.com/spectacles-ci/spectacles/issues/626) 

## Checklists

I was unable to run full test suite locally. I can run if you can share API credentials for your test Looker instance.

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
