### PR TITLE
Improve how 502s from the Looker API are handled

### DIFF
--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -651,7 +651,7 @@ class LookerClient:
 
         return response.json()["fields"]["dimensions"]
 
-    @backoff.on_exception(backoff.expo, BACKOFF_EXCEPTIONS, max_tries=5)
+    @backoff.on_exception(backoff.expo, BACKOFF_EXCEPTIONS, max_tries=8)
     async def create_query(
         self,
         model: str,
@@ -717,6 +717,7 @@ class LookerClient:
         )
         return result
 
+    @backoff.on_exception(backoff.expo, BACKOFF_EXCEPTIONS, max_tries=8)
     async def create_query_task(self, query_id: str) -> str:
         """Runs a previously created query asynchronously and returns the query task ID.
 

--- a/spectacles/logger.py
+++ b/spectacles/logger.py
@@ -61,6 +61,15 @@ class IndentedLogger(logging.Logger):
                 handler.formatter.indent(amount)
 
 
+class BackoffFilter(logging.Filter):
+    """Force all logs from the backoff package to be emitted at DEBUG level."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno >= logging.DEBUG:
+            record.levelno = logging.DEBUG
+        return True
+
+
 logging.setLoggerClass(IndentedLogger)
 logger = cast(IndentedLogger, logging.getLogger("spectacles"))
 logger.setLevel(logging.DEBUG)
@@ -72,6 +81,8 @@ ch.setLevel(logging.INFO)
 logger.addHandler(ch)
 
 GLOBAL_LOGGER = logger
+
+logging.getLogger("backoff").addFilter(BackoffFilter())
 
 
 def set_file_handler(log_dir: str) -> None:

--- a/spectacles/validators/sql.py
+++ b/spectacles/validators/sql.py
@@ -265,6 +265,9 @@ class SqlValidator:
             logger.error(
                 "Encountered an exception while running a query:", exc_info=True
             )
+            while not running_queries.empty():
+                logger.debug("Waiting for the running_queries queue to clear")
+                await asyncio.sleep(1)
             raise
         finally:
             # This only gets called if a sentinel is received or exception is raised.


### PR DESCRIPTION
## Change description

This change ensures that if the Looker API suddenly returns a bad response from the Create Async Query endpoint, Spectacles can handle the bad response without getting stuck in an infinite loop.

It increases the number of retries for HTTP status errors on Create Async Query from 3 -> 8.

It also forces the backoff library to log at the DEBUG level.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Closes #654 

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
