### PR TITLE
Add headers to Looker version API call

### DIFF
--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -172,7 +172,9 @@ class LookerClient:
 
         url = utils.compose_url(self.api_url, path=["versions"])
 
-        response = httpx.get(url=url, timeout=TIMEOUT_SEC)
+        response = httpx.get(
+            url=url, timeout=TIMEOUT_SEC, headers=self.async_client.headers
+        )
         try:
             response.raise_for_status()
         except httpx.HTTPStatusError as error:


### PR DESCRIPTION
## Change description

We were making an API call without authentication, which seems to work in almost all cases except for on some old versions of Looker. This PR updates the API call to fix the regression and make an authenticated request.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Closes #656 

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
