### PR TITLE
Join instead of just waiting for empty queue

### DIFF
--- a/spectacles/validators/sql.py
+++ b/spectacles/validators/sql.py
@@ -265,9 +265,8 @@ class SqlValidator:
             logger.error(
                 "Encountered an exception while running a query:", exc_info=True
             )
-            while not running_queries.empty():
-                logger.debug("Waiting for the running_queries queue to clear")
-                await asyncio.sleep(1)
+            logger.debug("Waiting for the running_queries queue to clear")
+            await running_queries.join()
             raise
         finally:
             # This only gets called if a sentinel is received or exception is raised.

--- a/tests/unit/test_sql_validator.py
+++ b/tests/unit/test_sql_validator.py
@@ -187,6 +187,7 @@ async def test_run_query_handles_exceptions_raised_within(
     queries_to_run.put_nowait(query)  # This will succeed
     queries_to_run.put_nowait(query)  # This will fail with 404
     await running_queries.get()  # Retrieve the successfully query
+    running_queries.task_done()
 
     # Normally these steps are handled by _get_query_results
     queries_to_run.task_done()


### PR DESCRIPTION
## Change description

Previously, when encountering an error in `SqlValidator._run_query`, we would wait for the running_queries queue to _clear_ but not for all tasks to be marked done. This didn't actually fix the error in #654, because any query still in an incomplete status (like running) would have left the running_queries queue but would not yet be marked done.

Now we call `.join()` which waits for all tasks from the queue to also be marked done.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Closes #654

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
