### PR TITLE
Extend timeout for LookML validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,18 +2,18 @@ repos:
   - repo: https://github.com/ambv/black
     rev: 22.3.0
     hooks:
-    - id: black
-  - repo: https://gitlab.com/pycqa/flake8
+      - id: black
+  - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
-    - id: flake8
+      - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.961
     hooks:
-    - id: mypy
-      args: [--ignore-missing-imports]
-      additional_dependencies:
-        - 'types-requests==2.25.11'
-        - 'types-tabulate==0.8.3'
-        - 'types-PyYAML==6.0.0'
-        - 'pydantic==1.9.0'
+      - id: mypy
+        args: [--ignore-missing-imports]
+        additional_dependencies:
+          - "types-requests==2.25.11"
+          - "types-tabulate==0.8.3"
+          - "types-PyYAML==6.0.0"
+          - "pydantic==1.9.0"

--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -863,7 +863,7 @@ class LookerClient:
     async def lookml_validation(self, project) -> JsonDict:
         logger.debug(f"Validating LookML for project '{project}'")
         url = utils.compose_url(self.api_url, path=["projects", project, "validate"])
-        response = await self.post(url=url, timeout=TIMEOUT_SEC)
+        response = await self.post(url=url, timeout=1800)
 
         try:
             response.raise_for_status()
@@ -883,7 +883,7 @@ class LookerClient:
     async def cached_lookml_validation(self, project) -> Optional[JsonDict]:
         logger.debug(f"Getting cached LookML validation results for '{project}'")
         url = utils.compose_url(self.api_url, path=["projects", project, "validate"])
-        response = await self.get(url=url, timeout=TIMEOUT_SEC)
+        response = await self.get(url=url, timeout=1800)
 
         try:
             response.raise_for_status()


### PR DESCRIPTION
## Change description

When we make requests to the LookML validation endpoint, we use the default Spectacles timeout of 300 seconds (5 minutes). This is too short for some instances with long validation times, so this change extends the timeout for that request to 30 minutes.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
