### PR TITLE
reset skip_imports when exiting branch manager

### DIFF
--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -196,6 +196,8 @@ class LookerBranchManager:
         for manager in self.import_managers:
             await manager.__aexit__()
 
+        self.skip_imports = []
+
         if self.init_state.workspace == "production":
             await self.update_workspace("production")
         else:

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -93,6 +93,7 @@ class LookerBranchManager:
 
         self.is_temp_branch = False
         self.import_managers = []
+        self.skip_imports = []
         return self
 
     async def __aenter__(self):
@@ -195,8 +196,6 @@ class LookerBranchManager:
 
         for manager in self.import_managers:
             await manager.__aexit__()
-
-        self.skip_imports = []
 
         if self.init_state.workspace == "production":
             await self.update_workspace("production")

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -93,7 +93,6 @@ class LookerBranchManager:
 
         self.is_temp_branch = False
         self.import_managers = []
-        self.skip_imports = []
         return self
 
     async def __aenter__(self):
@@ -196,6 +195,8 @@ class LookerBranchManager:
 
         for manager in self.import_managers:
             await manager.__aexit__()
+
+        self.skip_imports = []
 
         if self.init_state.workspace == "production":
             await self.update_workspace("production")


### PR DESCRIPTION
## Change description

This change resets `skip_imports` on the branch manager to an empty list, in the `__aexit__` function. This means that imports will be resolved for each use of the branch manager, which is the intended behaviour.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Closes #674 

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
