### PR TITLE
Validate only changed LookML

### DIFF
--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -907,6 +907,32 @@ class LookerClient:
         return result
 
     @backoff.on_exception(backoff.expo, BACKOFF_EXCEPTIONS, max_tries=DEFAULT_MAX_TRIES)
+    async def new_lookml_validation(self, project) -> Optional[JsonDict]:
+        logger.debug(
+            f"Getting LookML validation results for altered files for '{project}'"
+        )
+        url = utils.compose_url(
+            self.api_url, path=["projects", project, "validate_new_lookml_only"]
+        )
+        response = await self.post(url=url, timeout=1800)
+
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as error:
+            raise LookerApiError(
+                name="unable-to-get-new-lookml-validation",
+                title=f"Couldn't get new LookML validation results in project '{project}'.",
+                status=response.status_code,
+                detail=(
+                    "Failed to get new LookML valiation results. Please try again."
+                ),
+                response=response,
+            ) from error
+
+        result = response.json()
+        return result
+
+    @backoff.on_exception(backoff.expo, BACKOFF_EXCEPTIONS, max_tries=DEFAULT_MAX_TRIES)
     async def all_folders(self) -> List[JsonDict]:
         logger.debug("Getting information about all folders")
         url = utils.compose_url(self.api_url, path=["folders"])

--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -907,7 +907,7 @@ class LookerClient:
         return result
 
     @backoff.on_exception(backoff.expo, BACKOFF_EXCEPTIONS, max_tries=DEFAULT_MAX_TRIES)
-    async def new_lookml_validation(self, project) -> Optional[JsonDict]:
+    async def partial_lookml_validation(self, project) -> JsonDict:
         logger.debug(
             f"Getting LookML validation results for altered files for '{project}'"
         )

--- a/spectacles/validators/lookml.py
+++ b/spectacles/validators/lookml.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any, Optional
 from spectacles.client import LookerClient
 from spectacles.exceptions import LookMLError
+from spectacles.logger import GLOBAL_LOGGER as logger
 import httpx
 
 # Define constants for severity levels
@@ -43,6 +44,10 @@ class LookMLValidator:
             # fallback to full validation
             except httpx.HTTPStatusError as http_error:
                 if http_error.response.status_code == 404:
+                    logger.debug(
+                        "Partial LookML validation not found. "
+                        "Falling back to full validation."
+                    )
                     validation_results = await self.client.lookml_validation(project)
                 else:
                     raise http_error

--- a/spectacles/validators/lookml.py
+++ b/spectacles/validators/lookml.py
@@ -1,8 +1,7 @@
 from typing import Dict, Any, Optional
 from spectacles.client import LookerClient
-from spectacles.exceptions import LookMLError
+from spectacles.exceptions import LookMLError, LookerApiError
 from spectacles.logger import GLOBAL_LOGGER as logger
-import httpx
 
 # Define constants for severity levels
 SUCCESS = 0
@@ -42,8 +41,11 @@ class LookMLValidator:
                 )
             # If Looker ever removes this undocumented endpoint,
             # fallback to full validation
-            except httpx.HTTPStatusError as http_error:
-                if http_error.response.status_code == 404:
+            except LookerApiError as http_error:
+                if (
+                    http_error.looker_api_response
+                    and http_error.looker_api_response["status_code"] == 404
+                ):
                     logger.debug(
                         "Partial LookML validation not found. "
                         "Falling back to full validation."

--- a/spectacles/validators/lookml.py
+++ b/spectacles/validators/lookml.py
@@ -34,7 +34,10 @@ class LookMLValidator:
         severity_level: int = NAME_TO_LEVEL[severity]
         validation_results = await self.client.cached_lookml_validation(project)
         if not validation_results or validation_results.get("stale"):
-            validation_results = await self.client.lookml_validation(project)
+            try:
+                validation_results = await self.client.new_lookml_validation(project)
+            except:  # noqa
+                validation_results = await self.client.lookml_validation(project)
         errors = []
         lookml_url: Optional[str] = None
         for error in validation_results["errors"]:

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -81,6 +81,7 @@ def client_kwargs():
         content_validation={},
         lookml_validation={"project": "project_name"},
         cached_lookml_validation={"project": "project_name"},
+        partial_lookml_validation={"project": "project_name"},
         all_folders={},
         run_query={"query_id": 13041},
     )


### PR DESCRIPTION
## Change description

This change leverages an undocumented Looker endpoint to perform partial LookML validation, which is much faster than validating the entire project every time. This is the same endpoint used internally by the Looker browser IDE.

We've included a fallback to the full validation 

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
