### PR TITLE
Fix profiling and open it back up to all queries

### DIFF
--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -399,9 +399,7 @@ class Runner:
         )
 
         async with self.branch_manager(ref=ref):
-            await validator.search(
-                explores, fail_fast, chunk_size, profile=profile if fail_fast else False
-            )
+            await validator.search(explores, fail_fast, chunk_size, profile=profile)
 
         # Create dimension tests for the desired ref when explores errored
         if not fail_fast and incremental:

--- a/spectacles/validators/sql.py
+++ b/spectacles/validators/sql.py
@@ -16,7 +16,7 @@ QUERY_TASK_LIMIT = 250
 DEFAULT_CHUNK_SIZE = 500
 DEFAULT_QUERY_CONCURRENCY = 10
 DEFAULT_RUNTIME_THRESHOLD = 5
-ProfilerTableRow = Tuple[str, float, str, str]
+ProfilerTableRow = Tuple[str, str, float, str, str]
 
 
 @dataclass
@@ -62,7 +62,13 @@ class Query:
                 "Query.explore_url cannot be None, "
                 "run Query.create to get an explore URL"
             )
-        return (self.explore.name, self.runtime, self.query_id, self.explore_url)
+        return (
+            self.explore.name,
+            self.dimensions[0].name if len(self.dimensions) == 1 else "*",
+            self.runtime,
+            self.query_id,
+            self.explore_url,
+        )
 
 
 def print_profile_results(queries: List[Query], runtime_threshold: int) -> None:
@@ -79,6 +85,7 @@ def print_profile_results(queries: List[Query], runtime_threshold: int) -> None:
             [query.to_profiler_format() for query in queries_by_runtime],
             headers=[
                 "Explore",
+                "Dimension(s)",
                 "Runtime (s)",
                 "Query ID",
                 "Explore From Here",

--- a/spectacles/validators/sql.py
+++ b/spectacles/validators/sql.py
@@ -315,6 +315,7 @@ class SqlValidator:
                             Union[CompletedQueryResult, ErrorQueryResult], query_result
                         )
                         query = self._task_to_query[task_id]
+                        query.runtime = query_result.runtime
                         if query_result.runtime > self.runtime_threshold:
                             self._long_running_queries.append(query)
                         if query_result.status == "complete":

--- a/tests/integration/test_runner.py
+++ b/tests/integration/test_runner.py
@@ -191,3 +191,11 @@ async def test_incremental_sql_with_diff_explores_and_invalid_existing_sql_shoul
     assert result["tested"][1]["explore"] == "users__fail"
     assert result["tested"][1]["status"] == "passed"
     assert len(result["errors"]) == 0
+
+
+async def test_validate_sql_with_query_profiler_should_work(
+    looker_client: LookerClient, caplog: pytest.LogCaptureFixture
+):
+    runner = Runner(looker_client, "eye_exam")
+    await runner.validate_sql(fail_fast=True, profile=True, runtime_threshold=0)
+    assert "Query profiler results" in caplog.text

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -70,4 +70,25 @@ def test_query_should_convert_to_profiler_format(
         query_id=query_id,
         explore_url=explore_url,
     )
-    assert query.to_profiler_format() == (explore.name, runtime, query_id, explore_url)
+    assert query.to_profiler_format() == (
+        explore.name,
+        "*",
+        runtime,
+        query_id,
+        explore_url,
+    )
+
+    query = Query(
+        explore=explore,
+        dimensions=(dimension,),
+        runtime=runtime,
+        query_id=query_id,
+        explore_url=explore_url,
+    )
+    assert query.to_profiler_format() == (
+        explore.name,
+        dimension.name,
+        runtime,
+        query_id,
+        explore_url,
+    )


### PR DESCRIPTION
## Change description

Fixes a bug where profiling did not work at all and expands profiling to be allowed for all queries again, not just fail fast queries.

It's important to note that the profiler results are a bit harder to interpret now that we use binary search. Previously, we had N + 1 queries for each Explore (one that selected all dimensions and one for each dimension). So a query either had exactly N dimensions or 1 dimension.

Now, a query can have any number of dimensions between 1 and N. I've basically handwaved this by returning "*" for the `Dimension(s)` column in the profiler output whenever a query has more than 1 dimension. It's worth documenting that this means "more than one" and not necessarily "all". I thought this was better than trying to print an arbitrarily long list of dimensions, but open to feedback.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Closes #653.

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
