### PR TITLE
Retry httpcore remote prococol error in client

### DIFF
--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -2,6 +2,7 @@ from typing import List, Dict, Optional, Tuple
 import time
 from dataclasses import dataclass
 import backoff  # type: ignore
+from httpcore._exceptions import RemoteProtocolError
 import httpx
 from httpx import HTTPStatusError, ConnectError, TimeoutException
 import spectacles.utils as utils
@@ -18,6 +19,7 @@ BACKOFF_EXCEPTIONS = (
     HTTPStatusError,
     ConnectError,
     LookerApiError,
+    RemoteProtocolError,
 )
 
 


### PR DESCRIPTION
## Change description

As outlined in [this ticket](https://linear.app/spectacles/issue/ENG-88/not-retrying-on-httpcore-errors), we are seeing the following error on some runs:

```
httpcore.RemoteProtocolError: Server disconnected without sending a response.
```

This code change retries those errors.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Closes [this ticket](https://linear.app/spectacles/issue/ENG-88/not-retrying-on-httpcore-errors)

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
