### PR TITLE
Extend LookML Validation timeout to 2 hours

### DIFF
--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -865,7 +865,7 @@ class LookerClient:
     async def lookml_validation(self, project) -> JsonDict:
         logger.debug(f"Validating LookML for project '{project}'")
         url = utils.compose_url(self.api_url, path=["projects", project, "validate"])
-        response = await self.post(url=url, timeout=1800)
+        response = await self.post(url=url, timeout=7200)
 
         try:
             response.raise_for_status()


### PR DESCRIPTION
## Change description

Some customers are hitting LookML validation timeouts. The long running nature of this endpoint is due to issues with the Looker API that we have documented elsewhere. This change extends the Spectacles implemented timeout.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
