### PR TITLE
Swap retries from httpcore exception to httpx exception for RemoteProtocolError

### DIFF
--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -2,9 +2,8 @@ from typing import List, Dict, Optional, Tuple
 import time
 from dataclasses import dataclass
 import backoff  # type: ignore
-from httpcore._exceptions import RemoteProtocolError
 import httpx
-from httpx import HTTPStatusError, ConnectError, TimeoutException
+from httpx import HTTPStatusError, ConnectError, TimeoutException, RemoteProtocolError
 import spectacles.utils as utils
 from spectacles.types import JsonDict
 from spectacles.logger import GLOBAL_LOGGER as logger


### PR DESCRIPTION
## Change description

When we set up retries for `RemoteProtocolError` in the client, we set it to retry on the exception from `httpcore` not `httpx`. In reality, it is the latter that is being raised. This change swaps this.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
