### PR TITLE
Skip Explores without dimensions

### DIFF
--- a/spectacles/cli.py
+++ b/spectacles/cli.py
@@ -952,7 +952,9 @@ async def run_sql(
 
     for test in sorted(results["tested"], key=lambda x: (x["model"], x["explore"])):
         message = f"{test['model']}.{test['explore']}"
-        printer.print_validation_result(status=test["status"], source=message)
+        printer.print_validation_result(
+            status=test["status"], skip_reason=test.get("skip_reason"), source=message
+        )
 
     errors = sorted(
         results["errors"],

--- a/spectacles/exceptions.py
+++ b/spectacles/exceptions.py
@@ -23,12 +23,6 @@ class SpectaclesException(Exception):
         return {k: v for k, v in self.__dict__.items() if not k.startswith("_")}
 
 
-class SpectaclesWarning(SpectaclesException):
-    def __init__(self, name: str, title: str, detail: str):
-        super().__init__(name, title, detail)
-        self.type = "/warnings/" + name
-
-
 class LookMlNotFound(SpectaclesException):
     ...
 

--- a/spectacles/exceptions.py
+++ b/spectacles/exceptions.py
@@ -18,6 +18,16 @@ class SpectaclesException(Exception):
     def __str__(self) -> str:
         return self.title + " " + self.detail
 
+    def to_dict(self) -> dict:
+        """Returns a dictionary representation, scrubbed of private attributes"""
+        return {k: v for k, v in self.__dict__.items() if not k.startswith("_")}
+
+
+class SpectaclesWarning(SpectaclesException):
+    def __init__(self, name: str, title: str, detail: str):
+        super().__init__(name, title, detail)
+        self.type = "/warnings/" + name
+
 
 class LookMlNotFound(SpectaclesException):
     ...
@@ -99,10 +109,6 @@ class ValidationError(GenericValidationError):
     @ignore.setter
     def ignore(self, value: bool) -> None:
         self._ignore = value
-
-    def to_dict(self) -> dict:
-        """Returns a dictionary representation, scrubbed of private attributes"""
-        return {k: v for k, v in self.__dict__.items() if not k.startswith("_")}
 
 
 class LookMLError(ValidationError):

--- a/spectacles/lookml.py
+++ b/spectacles/lookml.py
@@ -410,7 +410,7 @@ class Project(LookMlObject):
 
                 if explore.skipped:
                     test["status"] = "skipped"
-                    test["skip_reason"] = str(explore.skipped)
+                    test["skip_reason"] = explore.skipped.value
                 elif explore.errored and validator != "sql":
                     test["status"] = "failed"
                     errors.extend([e.to_dict() for e in explore.errors])

--- a/spectacles/lookml.py
+++ b/spectacles/lookml.py
@@ -4,6 +4,7 @@ import re
 from typing import Dict, List, Sequence, Optional, Any, Iterable
 from spectacles.client import LookerClient
 from spectacles.exceptions import ValidationError, LookMlNotFound
+from spectacles.logger import GLOBAL_LOGGER as logger
 from spectacles.types import JsonDict
 from spectacles.select import is_selected
 
@@ -469,6 +470,12 @@ async def build_explore_dimensions(
             dimensions.append(dimension)
 
     explore.dimensions = dimensions
+    if len(explore.dimensions) == 0:
+        logger.warning(
+            f"Warning: Explore '{explore.name}' does not have any non-ignored "
+            "dimensions and will not be validated."
+        )
+        explore.skipped = True
 
 
 async def build_project(

--- a/spectacles/printer.py
+++ b/spectacles/printer.py
@@ -142,13 +142,19 @@ def print_sql_error(
     logger.info("\n" + f"Test SQL: {file_path}")
 
 
-def print_validation_result(status: str, source: str):
+def print_validation_result(
+    status: str, source: str, skip_reason: Optional[str] = None
+):
     bullet = "✗" if status == "failed" else "✓"
     if status == "passed":
         message = green(source)
     elif status == "failed":
         message = red(source)
     elif status == "skipped":
+        if skip_reason is None:
+            raise TypeError("Skipped Explores must state a reason for skipping")
+        skip_reason = skip_reason.replace("_", " ")
+        status = f"skipped ({skip_reason})"
         message = dim(source)
     else:
         raise ValueError(f"Unexpected value for status '{status}'")

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -357,14 +357,14 @@ class Runner:
                     ignore_hidden_fields=ignore_hidden_fields,
                 )
                 target_explores: Set[CompiledSql] = set()
-                if incremental:
-                    compiled_explores = await asyncio.gather(
-                        *(
-                            validator.compile_explore(explore)
-                            for explore in target_project.iter_explores()
-                        )
+
+                compiled_explores = await asyncio.gather(
+                    *(
+                        validator.compile_explore(explore)
+                        for explore in target_project.iter_explores()
                     )
-                    target_explores = set(compiled_explores)
+                )
+                target_explores = set(compiled_explores)
 
             # Determine which explore tests are identical between target and base
             # Iterate instead of set operations so we have control of which test, and

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -390,10 +390,10 @@ class Runner:
         else:
             explores = tuple(project.iter_explores())
 
-        explore_count = len(explores)
+        n_tested_explores = len([e for e in explores if not e.skipped])
+        n_total_explores = len(base_explores)
         print_header(
-            f"Testing {explore_count} "
-            f"{'explore' if explore_count == 1 else 'explores'} "
+            f"Testing {n_tested_explores}/{n_total_explores} explores "
             + ("[fail fast] " if fail_fast else "")
             + f"[concurrency = {concurrency}]"
         )

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -11,7 +11,7 @@ from spectacles.validators import (
     ContentValidator,
     LookMLValidator,
 )
-from spectacles.types import JsonDict
+from spectacles.types import JsonDict, SkipReason
 from spectacles.validators.sql import (
     DEFAULT_CHUNK_SIZE,
     DEFAULT_QUERY_CONCURRENCY,
@@ -381,7 +381,7 @@ class Runner:
                     )
                 if compiled in target_explores:
                     # Mark explores with the same compiled SQL (test) as skipped
-                    explore.skipped = True
+                    explore.skipped = SkipReason.UNMODIFIED
                 else:
                     # Test explores with unique SQL for base ref
                     explores += (explore,)

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -391,7 +391,7 @@ class Runner:
             explores = tuple(project.iter_explores())
 
         n_tested_explores = len([e for e in explores if not e.skipped])
-        n_total_explores = len(base_explores)
+        n_total_explores = len(base_explores or explores)
         print_header(
             f"Testing {n_tested_explores}/{n_total_explores} explores "
             + ("[fail fast] " if fail_fast else "")

--- a/spectacles/types.py
+++ b/spectacles/types.py
@@ -1,8 +1,14 @@
+from enum import Enum
 from typing import Dict, Any, TypeVar, Optional, Tuple, Union, Literal
 from pydantic import BaseModel, Field
 
 JsonDict = Dict[str, Any]
 T = TypeVar("T")
+
+
+class SkipReason(str, Enum):
+    NO_DIMENSIONS = "no_dimensions"
+    UNMODIFIED = "unmodified"
 
 
 class ErrorSqlLocation(BaseModel):

--- a/spectacles/validators/sql.py
+++ b/spectacles/validators/sql.py
@@ -188,6 +188,7 @@ class SqlValidator:
                         f"Warning: Explore '{explore.name}' does not have any non-ignored "
                         "dimensions and will not be validated."
                     )
+                    explore.skipped = True
                 elif len(dimensions) <= chunk_size:
                     queries_to_run.put_nowait(Query(explore, dimensions))
                 else:

--- a/tests/resources/validation_schema.json
+++ b/tests/resources/validation_schema.json
@@ -196,6 +196,25 @@
             },
             "uniqueItems": true
         },
+        "warnings": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "detail": {
+                        "type": "string"
+                    }
+                }
+            },
+            "uniqueItems": true
+        },
         "successes": {
             "type": "array",
             "items": {

--- a/tests/resources/validation_schema.json
+++ b/tests/resources/validation_schema.json
@@ -196,25 +196,6 @@
             },
             "uniqueItems": true
         },
-        "warnings": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "type": {
-                        "type": "string"
-                    },
-                    "title": {
-                        "type": "string"
-                    },
-                    "detail": {
-                        "type": "string"
-                    }
-                }
-            },
-            "uniqueItems": true
-        },
         "successes": {
             "type": "array",
             "items": {

--- a/tests/unit/test_printer.py
+++ b/tests/unit/test_printer.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 from spectacles import printer
 from spectacles.logger import delete_color_codes
+from spectacles.types import SkipReason
 
 
 def test_extract_sql_context():
@@ -126,4 +127,6 @@ def test_data_test_error_prints_with_relevant_info(sql_error, caplog):
 def test_print_validation_result_should_work():
     printer.print_validation_result(status="passed", source="model.explore")
     printer.print_validation_result(status="failed", source="model.explore")
-    printer.print_validation_result(status="skipped", source="model.explore")
+    printer.print_validation_result(
+        status="skipped", source="model.explore", skip_reason=SkipReason.UNMODIFIED
+    )

--- a/tests/unit/test_sql_validator.py
+++ b/tests/unit/test_sql_validator.py
@@ -2,7 +2,6 @@ import asyncio
 from typing import Optional
 from unittest.mock import Mock, patch
 import json
-import logging
 import pytest
 import httpx
 import respx
@@ -42,13 +41,6 @@ def query_slot() -> asyncio.Semaphore:
 @pytest.fixture
 def query(explore: Explore, dimension: Dimension) -> Query:
     return Query(explore, (dimension,), query_id="12345")
-
-
-async def test_compile_explore_without_dimensions_should_not_work(
-    explore: Explore, validator: SqlValidator
-):
-    with pytest.raises(AttributeError):
-        await validator.compile_explore(explore)
 
 
 async def test_compile_explore_compiles_sql(
@@ -646,15 +638,6 @@ async def test_search_with_chunk_size_should_limit_queries(
     for request, _ in mocked_api["create_query"].calls:
         body = json.loads(request.content)
         assert len(body["fields"]) == 10
-
-
-async def test_search_with_explore_without_dimensions_warns(
-    explore: Explore, validator: SqlValidator, caplog: pytest.LogCaptureFixture
-):
-    caplog.set_level(logging.WARNING)
-    explore.dimensions = []
-    await validator.search(explores=(explore,), fail_fast=False)
-    assert explore.name in caplog.text
 
 
 async def test_looker_api_error_with_queries_in_flight_shuts_down_gracefully(


### PR DESCRIPTION
## Change description

This change modifies Spectacles SQL validation behavior from raising an exception on Explores with zero dimensions to instead logging a warning and marking the Explore as skipped.

Here's an example of the output. Note the warning log and the improvement in the "Testing" header, as well as `eye_exam.users__no_dims` being marked as `skipped` with a reason for skipping.

```bash
(spectacles) ➜ spectacles sql --project eye_exam --branch dev-josh-temple-8m75 --incremental
Connected to Looker version 23.6.53 using Looker API 4.0
Warning: Explore 'users__no_dims' does not have any non-ignored dimensions and will not be validated.

=================== Testing 2/5 explores [concurrency = 10] ====================

✓ eye_exam.users passed
✓ eye_exam.users__fail skipped (unmodified)
✓ eye_exam.users__fail_and_warn skipped (unmodified)
✓ eye_exam.users__no_dims skipped (no dimensions)
✓ eye_exam.users__warn passed
```

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Improvement

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
