### PR TITLE
Handle killed status for queries

### DIFF
--- a/spectacles/lookml.py
+++ b/spectacles/lookml.py
@@ -423,7 +423,7 @@ class Project(LookMlObject):
                     # errors, return those instead. Skip anything marked as ignored.
                     relevant_errors = [
                         e.to_dict()
-                        for e in (dimension_errors or explore.errors)
+                        for e in dimension_errors + explore.errors
                         if not e.ignore
                     ]
                     if relevant_errors:

--- a/spectacles/types.py
+++ b/spectacles/types.py
@@ -34,11 +34,11 @@ class PendingQueryResult(BaseModel):
     status: Literal["added", "running"]
 
 
-class ExpiredQueryResult(BaseModel):
+class InterruptedQueryResult(BaseModel):
     class QueryResultData(BaseModel):
         error: str
 
-    status: Literal["expired"]
+    status: Literal["expired", "killed"]
     data: QueryResultData
 
 
@@ -97,5 +97,8 @@ class QueryResult(BaseModel):
     """Container model to allow discriminated union on status."""
 
     __root__: Union[
-        PendingQueryResult, ExpiredQueryResult, CompletedQueryResult, ErrorQueryResult
+        PendingQueryResult,
+        InterruptedQueryResult,
+        CompletedQueryResult,
+        ErrorQueryResult,
     ] = Field(..., discriminator="status")

--- a/spectacles/types.py
+++ b/spectacles/types.py
@@ -35,11 +35,7 @@ class PendingQueryResult(BaseModel):
 
 
 class InterruptedQueryResult(BaseModel):
-    class QueryResultData(BaseModel):
-        error: str
-
     status: Literal["expired", "killed"]
-    data: QueryResultData
 
 
 class CompletedQueryResult(BaseModel):

--- a/spectacles/validators/sql.py
+++ b/spectacles/validators/sql.py
@@ -390,7 +390,9 @@ class SqlValidator:
 
                     elif query_result.status == "killed":
                         query = self._task_to_query[task_id]
+                        query.errored = True
                         explore = query.explore
+                        explore.queried = True
                         explore.errors.append(
                             SqlError(
                                 model=explore.model_name,

--- a/spectacles/validators/sql.py
+++ b/spectacles/validators/sql.py
@@ -387,6 +387,27 @@ class SqlValidator:
 
                             # Indicate there are no more queries or subqueries to run
                             queries_to_run.task_done()
+
+                    elif query_result.status == "killed":
+                        query = self._task_to_query[task_id]
+                        explore = query.explore
+                        explore.errors.append(
+                            SqlError(
+                                model=explore.model_name,
+                                explore=explore.name,
+                                dimension=None,
+                                sql="",
+                                message=(
+                                    "Couldn't finish testing "
+                                    f"{explore.model_name}.{explore.name} "
+                                    "because the test query was killed in Looker. "
+                                ),
+                                explore_url=query.explore_url,
+                            )
+                        )
+                        query_slot.release()
+                        queries_to_run.task_done()
+
                     else:
                         # Query still running, put the task back on the queue
                         await running_queries.put(task_id)

--- a/spectacles/validators/sql.py
+++ b/spectacles/validators/sql.py
@@ -402,7 +402,8 @@ class SqlValidator:
                                 message=(
                                     "Couldn't finish testing "
                                     f"{explore.model_name}.{explore.name} "
-                                    "because the test query was killed in Looker. "
+                                    "because the test query was killed "
+                                    "in the database. "
                                 ),
                                 explore_url=query.explore_url,
                             )


### PR DESCRIPTION
## Change description

We've been encountering a new query status from Looker, `killed`. This was previously unhandled, so this change handles it by placing an error on the Explore indicating that testing for that Explore was interrupted.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
