### PR TITLE
Allow Looker API errors with a single, string-typed error

### DIFF
--- a/tests/unit/test_sql_validator.py
+++ b/tests/unit/test_sql_validator.py
@@ -439,7 +439,7 @@ async def test_get_query_results_handles_bogus_expired_queries(
             json={
                 query_task_id: ErrorQueryResult(
                     status="error",
-                    data=ErrorQueryResult.QueryResultData(
+                    data=ErrorQueryResult.MultiErrorData(
                         id="",
                         runtime=1.0,
                         sql="",

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -129,3 +129,21 @@ def test_get_valid_errors_should_ignore_warnings():
     query_result = cast(ErrorQueryResult, QueryResult.parse_obj(response_json).__root__)
     valid_errors = query_result.get_valid_errors()
     assert not valid_errors
+
+
+def test_can_parse_string_errors():
+    response = {
+        "status": "error",
+        "result_source": None,
+        "data": {
+            "from_cache": True,
+            "id": "67120bd3c7d23eb81f72692be9581c4a",
+            "error": "View Not Found",
+        },
+    }
+
+    result = QueryResult.parse_obj(response).__root__
+    assert isinstance(result, ErrorQueryResult)
+    assert result.errors[0].message == "View Not Found"
+    assert result.runtime == 0.0
+    assert result.sql == ""


### PR DESCRIPTION
## Change description

This change allows a type of SQL validation error that we've been seeing following the release of the "new" LookML runtime. This type of error has an `error` key instead of `errors` and is string typed.

Now, instead of logging it and failing as unexpected, we can let this error flow through as a regular SQL validation error.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
