### PR TITLE
Ensure pin imports run go in dev mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "spectacles"
-version = "2.4.6"
+version = "2.4.7"
 description = "A command-line, continuous integration tool for Looker and LookML."
 authors = ["Spectacles <hello@spectacles.dev>"]
 license = "MIT"

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -79,7 +79,7 @@ class LookerBranchManager:
             self.branch = ref
 
         if ephemeral is None:
-            if self.commit:
+            if self.commit or self.pin_imports:
                 self.ephemeral = True
             else:
                 self.ephemeral = False


### PR DESCRIPTION
## Change description

Previously, we were not properly entering dev mode and respecting the `pin-imports` option when the run was set to run against Looker production. This change remedies that.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues 

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer
