### PR TITLE
[Work in progress] Refactor to only run `get_all_models` if necessary

### DIFF
--- a/spectacles/lookml.py
+++ b/spectacles/lookml.py
@@ -564,7 +564,7 @@ async def build_project(
                 models[model] = Model(name=model, project_name=name, explores=[])
             if explore not in models[model].explores:
                 models[model].explores.append(Explore(name=explore, model_name=model))
-        project = Project(name=name, models=models.values())
+        project = Project(name=name, models=list(models.values()))
         models = project.models
 
     # Prune to selected explores for non-content validators

--- a/spectacles/lookml.py
+++ b/spectacles/lookml.py
@@ -521,6 +521,7 @@ async def build_project(
     """Creates an object (tree) representation of a LookML project."""
     if filters is None:
         filters = ["*/*"]
+    is_complete_project = False
 
     if get_full_project:
         models = []
@@ -540,8 +541,7 @@ async def build_project(
                     "b) it has an active configuration."
                 ),
             )
-        else:
-            project.is_complete_project = True
+        is_complete_project = True
 
     else:
         # Create a project with only the models specified in the filters
@@ -581,4 +581,6 @@ async def build_project(
     else:
         project = Project(name, [m for m in models if len(m.explores) > 0])
 
+    # Indicates whether the project has all of the models/explores or just the selected ones
+    project.is_complete_project = is_complete_project
     return project

--- a/spectacles/lookml.py
+++ b/spectacles/lookml.py
@@ -307,6 +307,7 @@ class Project(LookMlObject):
     def __init__(self, name: str, models: Sequence[Model]) -> None:
         self.name = name
         self.models = models
+        self._is_complete = False
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Project):
@@ -343,6 +344,14 @@ class Project(LookMlObject):
                         yield dimension
                 else:
                     yield dimension
+
+    @property
+    def is_complete_project(self) -> bool:
+        return self._is_complete
+
+    @is_complete_project.setter
+    def is_complete_project(self, value: bool) -> None:
+        self._is_complete = value
 
     @property
     def errored(self) -> Optional[bool]:
@@ -531,6 +540,9 @@ async def build_project(
                     "b) it has an active configuration."
                 ),
             )
+        else:
+            project.is_complete_project = True
+
     else:
         # Create a project with only the models specified in the filters
         logger.debug("Building project with only the filtered models")

--- a/spectacles/lookml.py
+++ b/spectacles/lookml.py
@@ -534,7 +534,7 @@ async def build_project(
     else:
         # Create a project with only the models specified in the filters
         logger.debug("Building project with only the filtered models")
-        models = Dict[str, Model]
+        models: Dict[str, Model] = {}
         for filter in filters:
             model, explore = filter.split("/")
             if model not in models:

--- a/spectacles/lookml.py
+++ b/spectacles/lookml.py
@@ -532,6 +532,8 @@ async def build_project(
                 ),
             )
     else:
+        # Create a project with only the models specified in the filters
+        logger.debug("Building project with only the filtered models")
         models = Dict[str, Model]
         for filter in filters:
             model, explore = filter.split("/")

--- a/spectacles/lookml.py
+++ b/spectacles/lookml.py
@@ -541,7 +541,8 @@ async def build_project(
                 models[model] = Model(name=model, project_name=name, explores=[])
             if explore not in models[model].explores:
                 models[model].explores.append(Explore(name=explore, model_name=model))
-        return Project(name=name, models=models.values())
+        project = Project(name=name, models=models.values())
+        models = project.models
 
     # Prune to selected explores for non-content validators
     if not include_all_explores:

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -540,7 +540,7 @@ class Runner:
         logger.debug(
             f"Validating content. ref={ref}, filters={filters}, incremental={incremental}",
         )
-        if filters is not None or filters != ["*/*"]:
+        if filters is not None or filters == ["*/*"]:
             # Only build the full project from the API if we're using a wildcard filter and not in incremental mode
             get_full_project = any("*" in f for f in filters) or (not incremental)
             logger.debug(f"get_full_project = {get_full_project}")

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -355,6 +355,7 @@ class Runner:
     ) -> JsonDict:
         if filters is None:
             filters = ["*/*"]
+        get_full_project = any("*" in f for f in filters)
         validator = SqlValidator(self.client, concurrency, runtime_threshold)
         ephemeral = True if incremental else None
         # Create explore-level tests for the desired ref
@@ -367,6 +368,7 @@ class Runner:
                 filters=filters,
                 include_dimensions=True,
                 ignore_hidden_fields=ignore_hidden_fields,
+                get_full_project=get_full_project,
             )
             base_explores: Set[CompiledSql] = set()
             if incremental:
@@ -564,6 +566,8 @@ class Runner:
                 logger.debug(
                     "Incremental mode is enabled, initializing and empty project"
                 )
+                # Incremental content validation doesn't require knowing anything about the project hierarchy
+                # we can initialize and empty project and pass it to the validator
                 project = Project(name=self.project, models=[])
 
             await validator.validate(project)

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -540,7 +540,7 @@ class Runner:
         logger.debug(
             f"Validating content. ref={ref}, filters={filters}, incremental={incremental}",
         )
-        if filters is not None:
+        if filters is not None or filters != ["*/*"]:
             # Only build the full project from the API if we're using a wildcard filter and not in incremental mode
             get_full_project = any("*" in f for f in filters) or (not incremental)
             logger.debug(f"get_full_project = {get_full_project}")

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -538,7 +538,7 @@ class Runner:
         folders: Optional[List[str]] = None,
     ) -> JsonDict:
         logger.debug(
-            "Validating content", ref=ref, filters=filters, incremental=incremental
+            f"Validating content. ref={ref}, filters={filters}, incremental={incremental}",
         )
         if filters is not None:
             # Only build the full project from the API if we're using a wildcard filter and not in incremental mode

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -564,7 +564,7 @@ class Runner:
                 logger.debug(
                     "Incremental mode is enabled, initializing and empty project"
                 )
-                project = Project(name=self.project)
+                project = Project(name=self.project, models=[])
 
             await validator.validate(project)
             results = project.get_results(validator="content", filters=filters)

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -542,7 +542,9 @@ class Runner:
         )
         if filters is not None or filters == ["*/*"]:
             # Only build the full project from the API if we're using a wildcard filter and not in incremental mode
-            get_full_project = any("*" in f for f in filters) or (not incremental)
+            get_full_project = any("*" in f for f in filters if f != "*/*") or (
+                not incremental
+            )
             logger.debug(f"get_full_project = {get_full_project}")
 
         if folders is None:

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -568,11 +568,17 @@ class Runner:
                 get_full_project=get_full_project,
             )
             explore_count = project.count_explores()
-            print_header(
-                f"Validating content based on {explore_count} "
-                f"{'explore' if explore_count == 1 else 'explores'}"
-                + (" [incremental mode] " if incremental else "")
-            )
+            if not project.is_complete_project:
+                print_header(
+                    f"Validating content based on all explores "
+                    + (" [incremental mode] " if incremental else "")
+                )
+            else:
+                print_header(
+                    f"Validating content based on {explore_count} "
+                    f"{'explore' if explore_count == 1 else 'explores'}"
+                    + (" [incremental mode] " if incremental else "")
+                )
 
             await validator.validate(project)
             results = project.get_results(validator="content", filters=filters)

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -543,6 +543,7 @@ class Runner:
         if filters is not None:
             # Only build the full project from the API if we're using a wildcard filter and not in incremental mode
             get_full_project = any("*" in f for f in filters) or (not incremental)
+            logger.debug(f"get_full_project = {get_full_project}")
 
         if folders is None:
             folders = []

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -537,6 +537,9 @@ class Runner:
         exclude_personal: bool = False,
         folders: Optional[List[str]] = None,
     ) -> JsonDict:
+        logger.debug(
+            "Validating content", ref=ref, filters=filters, incremental=incremental
+        )
         if filters is not None:
             # Only build the full project from the API if we're using a wildcard filter and not in incremental mode
             get_full_project = any("*" in f for f in filters) or (not incremental)

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -595,6 +595,7 @@ class Runner:
                     name=self.project,
                     filters=filters,
                     include_all_explores=True,
+                    get_full_project=get_full_project,
                 )
                 await validator.validate(target_project)
                 target_results = target_project.get_results(

--- a/spectacles/runner.py
+++ b/spectacles/runner.py
@@ -608,7 +608,7 @@ class Runner:
 
     @staticmethod
     def _incremental_results(base: JsonDict, target: JsonDict) -> JsonDict:
-        """Returns a new result with only the additional errors in `additional`."""
+        """Returns a new result with only the additional errors in `target`."""
         diff: JsonDict = {
             "validator": "content",
             # Start with models and explores we know passed for the base ref

--- a/spectacles/validators/content.py
+++ b/spectacles/validators/content.py
@@ -139,6 +139,7 @@ class ContentValidator:
         content_type: str,
     ) -> List[ContentError]:
         content_errors: List[ContentError] = []
+        create_if_missing = False
         if not project.is_complete_project:
             logger.debug(
                 f"Project is not complete -- showing errors for all models/explores"

--- a/spectacles/validators/content.py
+++ b/spectacles/validators/content.py
@@ -133,7 +133,10 @@ class ContentValidator:
             )
 
     def _get_errors_from_result(
-        self, project: Project, result: Dict[str, Any], content_type: str
+        self,
+        project: Project,
+        result: Dict[str, Any],
+        content_type: str,
     ) -> List[ContentError]:
         content_errors: List[ContentError] = []
         for error in result["errors"]:
@@ -145,7 +148,11 @@ class ContentValidator:
             else:
                 explore = None
             # Skip errors that are not associated with selected explores or existing models
-            if explore or model:
+            if not project.is_complete_project:
+                logger.debug(
+                    f"Project is not complete -- showing errors for all models/explores"
+                )
+            if explore or model or not project.is_complete_project:
                 content_id = result[content_type]["id"]
                 folder = result[content_type].get("folder")
                 folder_name: Optional[str] = folder.get("name") if folder else None

--- a/spectacles/validators/content.py
+++ b/spectacles/validators/content.py
@@ -141,9 +141,6 @@ class ContentValidator:
         content_errors: List[ContentError] = []
         create_if_missing = False
         if not project.is_complete_project:
-            logger.debug(
-                f"Project is not complete -- showing errors for all models/explores"
-            )
             create_if_missing = True
 
         for error in result["errors"]:

--- a/spectacles/validators/content.py
+++ b/spectacles/validators/content.py
@@ -178,9 +178,9 @@ class ContentValidator:
                 )
                 if explore and content_error not in explore.errors:
                     explore.errors.append(content_error)
-                    content_errors.append(content_error)
                 elif model and content_error not in model.errors:
                     model.errors.append(content_error)
-                    content_errors.append(content_error)
+
+                content_errors.append(content_error)
 
         return content_errors


### PR DESCRIPTION
## Change description
The api request to build the whole project isn't necessary for the sql and content validations depending on the provided arguments. For the SQL validation you only need to know the list of models/explores if you provide an explore filter with a wildcard. If you provide the exact explore you can just do the SQL validation on the provided explore. For the content validation -- the models/explores are strictly used to filter the errors **after** the content validation has been run. If you don't provide any explores to the filters there is no need to get that full list in the first place. You can merely build the project hierarchy as you receive errors from the content validator.

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Closes [#1]() 

## Checklists

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows security best practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer
