### PR TITLE
Add read timeout handling with backoff and retry in Looker client

### DIFF
--- a/spectacles/client.py
+++ b/spectacles/client.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 import backoff
 import httpx
 from aiocache import Cache, cached, serializers
-from httpx import HTTPStatusError, NetworkError, RemoteProtocolError, TimeoutException
+from httpx import HTTPStatusError, NetworkError, RemoteProtocolError, TimeoutException, ReadTimeout
 
 import spectacles.utils as utils
 from spectacles.exceptions import LookerApiError, SpectaclesException
@@ -919,6 +919,7 @@ class LookerClient:
         + (
             NetworkError,
             RemoteProtocolError,
+            ReadTimeout,
         ),
         giveup=giveup_unless_bad_gateway,
         max_tries=DEFAULT_RETRIES,


### PR DESCRIPTION
## Change description

Added `ReadTimeout` exception to the backoff retry mechanism in the Looker API client. This ensures that when HTTP read timeouts occur during API calls, the client will automatically retry the request using the existing exponential backoff strategy, improving reliability when dealing with slow or intermittent network connections.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

[853](https://github.com/spectacles-ci/spectacles/issues/853) 

## Checklists

### Security

- [x] Security impact of change has been considered
- [x] Code follows security best practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer